### PR TITLE
dm vdo: add MAINTAINERS file entry

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -6001,6 +6001,15 @@ F:	include/linux/device-mapper.h
 F:	include/linux/dm-*.h
 F:	include/uapi/linux/dm-*.h
 
+DEVICE-MAPPER VDO TARGET
+M:	Matthew Sakai <msakai@redhat.com>
+M:	dm-devel@lists.linux.dev
+L:	dm-devel@lists.linux.dev
+S:	Maintained
+F:	Documentation/admin-guide/device-mapper/vdo*.rst
+F:	drivers/md/dm-vdo-target.c
+F:	drivers/md/dm-vdo/
+
 DEVLINK
 M:	Jiri Pirko <jiri@resnulli.us>
 L:	netdev@vger.kernel.org


### PR DESCRIPTION
Add a MAINTAINERS file entry. This should actually go in after I've added the new v4 VDO baseline commits.