### PR TITLE
[VDO-5602] [VDO-5614] General reformatting changes

### DIFF
--- a/drivers/md/dm-vdo-target.c
+++ b/drivers/md/dm-vdo-target.c
@@ -1139,7 +1139,7 @@ static void configure_target_capabilities(struct dm_target *ti)
 }
 
 /*
- * Implements vdo_filter_t.
+ * Implements vdo_filter_fn.
  */
 static bool vdo_uses_device(struct vdo *vdo, const void *context)
 {
@@ -1176,8 +1176,8 @@ static thread_id_t __must_check get_thread_id_for_phase(struct vdo *vdo)
 }
 
 static struct vdo_completion *prepare_admin_completion(struct vdo *vdo,
-						       vdo_action *callback,
-						       vdo_action *error_handler)
+						       vdo_action_fn callback,
+						       vdo_action_fn error_handler)
 {
 	struct vdo_completion *completion = &vdo->admin.completion;
 
@@ -1213,7 +1213,7 @@ static u32 advance_phase(struct vdo *vdo)
  * should not be called from vdo threads.
  */
 static int perform_admin_operation(struct vdo *vdo, u32 starting_phase,
-				   vdo_action *callback, vdo_action *error_handler,
+				   vdo_action_fn callback, vdo_action_fn error_handler,
 				   const char *type)
 {
 	int result;
@@ -1502,7 +1502,7 @@ static int vdo_initialize(struct dm_target *ti, unsigned int instance,
 	return VDO_SUCCESS;
 }
 
-/* Implements vdo_filter_t. */
+/* Implements vdo_filter_fn. */
 static bool __must_check vdo_is_named(struct vdo *vdo, const void *context)
 {
 	struct dm_target *ti = vdo->device_config->owning_target;

--- a/drivers/md/dm-vdo-target.c
+++ b/drivers/md/dm-vdo-target.c
@@ -276,9 +276,10 @@ static int split_string(const char *string, char separator, char ***substring_ar
 	int result;
 	ptrdiff_t length;
 
-	for (s = string; *s != 0; s++)
+	for (s = string; *s != 0; s++) {
 		if (*s == separator)
 			substring_count++;
+	}
 
 	result = uds_allocate(substring_count + 1, char *, "string-splitting array", &substrings);
 	if (result != UDS_SUCCESS)
@@ -1227,10 +1228,11 @@ static int perform_admin_operation(struct vdo *vdo,
 	int result;
 	struct vdo_administrator *admin = &vdo->admin;
 
-	if (atomic_cmpxchg(&admin->busy, 0, 1) != 0)
+	if (atomic_cmpxchg(&admin->busy, 0, 1) != 0) {
 		return uds_log_error_strerror(VDO_COMPONENT_BUSY,
 					      "Can't start %s operation, another operation is already in progress",
 					      type);
+	}
 
 	admin->phase = starting_phase;
 	reinit_completion(&admin->callback_sync);
@@ -1345,15 +1347,17 @@ static int __must_check decode_vdo(struct vdo *vdo)
 	maximum_age = vdo_convert_maximum_age(vdo->device_config->block_map_maximum_age);
 	journal_length =
 		vdo_get_recovery_journal_length(vdo->states.vdo.config.recovery_journal_size);
-	if (maximum_age > (journal_length / 2))
+	if (maximum_age > (journal_length / 2)) {
 		return uds_log_error_strerror(VDO_BAD_CONFIGURATION,
 					      "maximum age: %llu exceeds limit %llu",
 					      (unsigned long long) maximum_age,
 					      (unsigned long long) (journal_length / 2));
+	}
 
-	if (maximum_age == 0)
+	if (maximum_age == 0) {
 		return uds_log_error_strerror(VDO_BAD_CONFIGURATION,
 					      "maximum age must be greater than 0");
+	}
 
 	result = vdo_enable_read_only_entry(vdo);
 	if (result != VDO_SUCCESS)
@@ -1696,9 +1700,10 @@ static int grow_layout(struct vdo *vdo, block_count_t old_size, block_count_t ne
 	int result;
 	block_count_t min_new_size;
 
-	if (vdo->next_layout.size == new_size)
+	if (vdo->next_layout.size == new_size) {
 		/* We are already prepared to grow to the new size, so we're done. */
 		return VDO_SUCCESS;
+	}
 
 	/* Make a copy completion if there isn't one */
 	if (vdo->partition_copier == NULL) {
@@ -1864,12 +1869,13 @@ static int prepare_to_modify(struct dm_target *ti, struct device_config *config,
 	if (config->physical_blocks > vdo->device_config->physical_blocks) {
 		result = prepare_to_grow_physical(vdo, config->physical_blocks);
 		if (result != VDO_SUCCESS) {
-			if (result == VDO_PARAMETER_MISMATCH)
+			if (result == VDO_PARAMETER_MISMATCH) {
 				/*
 				 * If we don't trap this case, vdo_map_to_system_error() will remap
 				 * it to -EIO, which is misleading and ahistorical.
 				 */
 				result = -EINVAL;
+			}
 
 			if (result == VDO_TOO_MANY_SLABS)
 				ti->error = "Device vdo_prepare_to_grow_physical failed (specified physical size too big based on formatted slab size)";
@@ -2028,9 +2034,10 @@ static void suspend_callback(struct vdo_completion *completion)
 
 	switch (advance_phase(vdo)) {
 	case SUSPEND_PHASE_START:
-		if (vdo_get_admin_state_code(state)->quiescent)
+		if (vdo_get_admin_state_code(state)->quiescent) {
 			/* Already suspended */
 			break;
+		}
 
 		vdo_continue_completion(completion, vdo_start_operation(state, vdo->suspend_type));
 		return;
@@ -2098,9 +2105,10 @@ static void suspend_callback(struct vdo_completion *completion)
 		return;
 
 	case SUSPEND_PHASE_WRITE_SUPER_BLOCK:
-		if (vdo_is_state_suspending(state) || (completion->result != VDO_SUCCESS))
+		if (vdo_is_state_suspending(state) || (completion->result != VDO_SUCCESS)) {
 			/* If we didn't save the VDO or there was an error, we're done. */
 			break;
+		}
 
 		write_super_block_for_suspend(completion);
 		return;
@@ -2295,12 +2303,13 @@ static void load_callback(struct vdo_completion *completion)
 
 	case LOAD_PHASE_DATA_REDUCTION:
 		WRITE_ONCE(vdo->compressing, vdo->device_config->compression);
-		if (vdo->device_config->deduplication)
+		if (vdo->device_config->deduplication) {
 			/*
 			 * Don't try to load or rebuild the index first (and log scary error
 			 * messages) if this is known to be a newly-formatted volume.
 			 */
 			vdo_start_dedupe_index(vdo->hash_zones, was_new(vdo));
+		}
 
 		vdo->allocations_allowed = false;
 		fallthrough;
@@ -2846,9 +2855,10 @@ static int vdo_preresume_registered(struct dm_target *ti, struct vdo *vdo)
 		return result;
 	}
 
-	if (vdo_get_admin_state(vdo)->normal)
+	if (vdo_get_admin_state(vdo)->normal) {
 		/* The VDO was just started, so we don't need to resume it. */
 		return VDO_SUCCESS;
+	}
 
 	result = perform_admin_operation(vdo,
 					 RESUME_PHASE_START,
@@ -2856,9 +2866,10 @@ static int vdo_preresume_registered(struct dm_target *ti, struct vdo *vdo)
 					 resume_callback,
 					 "resume");
 	BUG_ON(result == VDO_INVALID_ADMIN_STATE);
-	if (result == VDO_READ_ONLY)
+	if (result == VDO_READ_ONLY) {
 		/* Even if the vdo is read-only, it has still resumed. */
 		result = VDO_SUCCESS;
+	}
 
 	if (result != VDO_SUCCESS)
 		uds_log_error("resume of device '%s' failed with error: %d", device_name, result);

--- a/drivers/md/dm-vdo-target.c
+++ b/drivers/md/dm-vdo-target.c
@@ -210,7 +210,8 @@ static void free_device_config(struct device_config *config)
  *
  * Return: VDO_SUCCESS or an error code.
  */
-static int get_version_number(int argc, char **argv, char **error_ptr, unsigned int *version_ptr)
+static int get_version_number(int argc, char **argv, char **error_ptr,
+			      unsigned int *version_ptr)
 {
 	/* version, if it exists, is in a form of V<n> */
 	if (sscanf(argv[0], "V%u", version_ptr) == 1) {
@@ -239,8 +240,7 @@ static int get_version_number(int argc, char **argv, char **error_ptr, unsigned 
 
 	if (*version_ptr != TABLE_VERSION) {
 		uds_log_warning("Detected version mismatch between kernel module and tools kernel: %d, tool: %d",
-				TABLE_VERSION,
-				*version_ptr);
+				TABLE_VERSION, *version_ptr);
 		uds_log_warning("Please consider upgrading management tools to match kernel.");
 	}
 	return VDO_SUCCESS;
@@ -281,7 +281,8 @@ static int split_string(const char *string, char separator, char ***substring_ar
 			substring_count++;
 	}
 
-	result = uds_allocate(substring_count + 1, char *, "string-splitting array", &substrings);
+	result = uds_allocate(substring_count + 1, char *, "string-splitting array",
+			      &substrings);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -289,9 +290,7 @@ static int split_string(const char *string, char separator, char ***substring_ar
 		if (*s == separator) {
 			ptrdiff_t length = s - string;
 
-			result = uds_allocate(length + 1,
-					      char,
-					      "split string",
+			result = uds_allocate(length + 1, char, "split string",
 					      &substrings[current_substring]);
 			if (result != UDS_SUCCESS) {
 				free_string_array(substrings);
@@ -312,7 +311,8 @@ static int split_string(const char *string, char separator, char ***substring_ar
 	BUG_ON(current_substring != (substring_count - 1));
 	length = strlen(string);
 
-	result = uds_allocate(length + 1, char, "split string", &substrings[current_substring]);
+	result = uds_allocate(length + 1, char, "split string",
+			      &substrings[current_substring]);
 	if (result != UDS_SUCCESS) {
 		free_string_array(substrings);
 		return result;
@@ -329,8 +329,8 @@ static int split_string(const char *string, char separator, char ***substring_ar
  * string. array_length is a bound on the number of valid elements in substring_array, in case it
  * is not NULL-terminated.
  */
-static int
-join_strings(char **substring_array, size_t array_length, char separator, char **string_ptr)
+static int join_strings(char **substring_array, size_t array_length, char separator,
+			char **string_ptr)
 {
 	size_t string_length = 0;
 	size_t i;
@@ -348,8 +348,7 @@ join_strings(char **substring_array, size_t array_length, char separator, char *
 
 	for (i = 0; (i < array_length) && (substring_array[i] != NULL); i++) {
 		current_position = uds_append_to_buffer(current_position,
-							output + string_length,
-							"%s",
+							output + string_length, "%s",
 							substring_array[i]);
 		*current_position = separator;
 		current_position++;
@@ -372,8 +371,8 @@ join_strings(char **substring_array, size_t array_length, char separator, char *
  *
  * Return: VDO_SUCCESS or an error if bool_str is neither true_str nor false_str.
  */
-static inline int __must_check
-parse_bool(const char *bool_str, const char *true_str, const char *false_str, bool *bool_ptr)
+static inline int __must_check parse_bool(const char *bool_str, const char *true_str,
+					  const char *false_str, bool *bool_ptr)
 {
 	bool value = false;
 
@@ -438,8 +437,7 @@ static int process_one_thread_config_spec(const char *thread_param_type,
 	/* Handle other thread count parameters */
 	if (count > MAXIMUM_VDO_THREADS) {
 		uds_log_error("thread config string error: at most %d '%s' threads are allowed",
-			      MAXIMUM_VDO_THREADS,
-			      thread_param_type);
+			      MAXIMUM_VDO_THREADS, thread_param_type);
 		return -EINVAL;
 	}
 	if (strcmp(thread_param_type, "hash") == 0) {
@@ -481,7 +479,8 @@ static int process_one_thread_config_spec(const char *thread_param_type,
  * @spec: The thread parameter specification string.
  * @config: The configuration data to be updated.
  */
-static int parse_one_thread_config_spec(const char *spec, struct thread_count_config *config)
+static int parse_one_thread_config_spec(const char *spec,
+					struct thread_count_config *config)
 {
 	unsigned int count;
 	char **fields;
@@ -531,7 +530,8 @@ static int parse_one_thread_config_spec(const char *spec, struct thread_count_co
  *
  * Return: VDO_SUCCESS or -EINVAL or -ENOMEM
  */
-static int parse_thread_config_string(const char *string, struct thread_count_config *config)
+static int parse_thread_config_string(const char *string,
+				      struct thread_count_config *config)
 {
 	int result = VDO_SUCCESS;
 	char **specs;
@@ -565,8 +565,8 @@ static int parse_thread_config_string(const char *string, struct thread_count_co
  *
  * Return: VDO_SUCCESS or -EINVAL
  */
-static int
-process_one_key_value_pair(const char *key, unsigned int value, struct device_config *config)
+static int process_one_key_value_pair(const char *key, unsigned int value,
+				      struct device_config *config)
 {
 	/* Non thread optional parameters */
 	if (strcmp(key, "maxDiscard") == 0) {
@@ -596,8 +596,8 @@ process_one_key_value_pair(const char *key, unsigned int value, struct device_co
  *
  * Return: VDO_SUCCESS or error.
  */
-static int
-parse_one_key_value_pair(const char *key, const char *value, struct device_config *config)
+static int parse_one_key_value_pair(const char *key, const char *value,
+				    struct device_config *config)
 {
 	unsigned int count;
 	int result;
@@ -665,14 +665,14 @@ static int parse_key_value_pairs(int argc, char **argv, struct device_config *co
  *
  * Return: VDO_SUCCESS or error
  */
-static int parse_optional_arguments(struct dm_arg_set *arg_set,
-				    char **error_ptr,
+static int parse_optional_arguments(struct dm_arg_set *arg_set, char **error_ptr,
 				    struct device_config *config)
 {
 	int result = VDO_SUCCESS;
 
 	if (config->version == 0 || config->version == 1) {
-		result = parse_thread_config_string(arg_set->argv[0], &config->thread_counts);
+		result = parse_thread_config_string(arg_set->argv[0],
+						    &config->thread_counts);
 		if (result != VDO_SUCCESS) {
 			*error_ptr = "Invalid thread-count configuration";
 			return VDO_BAD_CONFIGURATION;
@@ -697,7 +697,8 @@ static int parse_optional_arguments(struct dm_arg_set *arg_set,
  * @error_ptr: A place to store a constant string about the error.
  * @error_str: A constant string to store in error_ptr.
  */
-static void handle_parse_error(struct device_config *config, char **error_ptr, char *error_str)
+static void handle_parse_error(struct device_config *config, char **error_ptr,
+			       char *error_str)
 {
 	free_device_config(config);
 	*error_ptr = error_str;
@@ -712,9 +713,7 @@ static void handle_parse_error(struct device_config *config, char **error_ptr, c
  *
  * Return: VDO_SUCCESS or an error code.
  */
-static int parse_device_config(int argc,
-			       char **argv,
-			       struct dm_target *ti,
+static int parse_device_config(int argc, char **argv, struct dm_target *ti,
 			       struct device_config **config_ptr)
 {
 	bool enable_512e;
@@ -725,7 +724,8 @@ static int parse_device_config(int argc,
 	int result;
 
 	if ((logical_bytes % VDO_BLOCK_SIZE) != 0) {
-		handle_parse_error(config, error_ptr, "Logical size must be a multiple of 4096");
+		handle_parse_error(config, error_ptr,
+				   "Logical size must be a multiple of 4096");
 		return VDO_BAD_CONFIGURATION;
 	}
 
@@ -736,7 +736,8 @@ static int parse_device_config(int argc,
 
 	result = uds_allocate(1, struct device_config, "device_config", &config);
 	if (result != VDO_SUCCESS) {
-		handle_parse_error(config, error_ptr, "Could not allocate config structure");
+		handle_parse_error(config, error_ptr,
+				   "Could not allocate config structure");
 		return VDO_BAD_CONFIGURATION;
 	}
 
@@ -779,11 +780,11 @@ static int parse_device_config(int argc,
 	if (config->version >= 1)
 		dm_shift_arg(&arg_set);
 
-	result = uds_duplicate_string(dm_shift_arg(&arg_set),
-				      "parent device name",
+	result = uds_duplicate_string(dm_shift_arg(&arg_set), "parent device name",
 				      &config->parent_device_name);
 	if (result != VDO_SUCCESS) {
-		handle_parse_error(config, error_ptr, "Could not copy parent device name");
+		handle_parse_error(config, error_ptr,
+				   "Could not copy parent device name");
 		return VDO_BAD_CONFIGURATION;
 	}
 
@@ -791,7 +792,8 @@ static int parse_device_config(int argc,
 	if (config->version >= 1) {
 		result = kstrtoull(dm_shift_arg(&arg_set), 10, &config->physical_blocks);
 		if (result != VDO_SUCCESS) {
-			handle_parse_error(config, error_ptr, "Invalid physical block count");
+			handle_parse_error(config, error_ptr,
+					   "Invalid physical block count");
 			return VDO_BAD_CONFIGURATION;
 		}
 	}
@@ -811,7 +813,8 @@ static int parse_device_config(int argc,
 	/* Get the page cache size. */
 	result = kstrtouint(dm_shift_arg(&arg_set), 10, &config->cache_size);
 	if (result != VDO_SUCCESS) {
-		handle_parse_error(config, error_ptr, "Invalid block map page cache size");
+		handle_parse_error(config, error_ptr,
+				   "Invalid block map page cache size");
 		return VDO_BAD_CONFIGURATION;
 	}
 
@@ -837,7 +840,8 @@ static int parse_device_config(int argc,
 		 * the parsing of the table line.
 		 */
 		if (&arg_set.argv[0] != &argv[POOL_NAME_ARG_INDEX[config->version]]) {
-			handle_parse_error(config, error_ptr, "Pool name not in expected location");
+			handle_parse_error(config, error_ptr,
+					   "Pool name not in expected location");
 			return VDO_BAD_CONFIGURATION;
 		}
 		dm_shift_arg(&arg_set);
@@ -860,28 +864,23 @@ static int parse_device_config(int argc,
 	     (config->thread_counts.physical_zones == 0)) ||
 	    ((config->thread_counts.physical_zones == 0) !=
 	     (config->thread_counts.hash_zones == 0))) {
-		handle_parse_error(config,
-				   error_ptr,
+		handle_parse_error(config, error_ptr,
 				   "Logical, physical, and hash zones counts must all be zero or all non-zero");
 		return VDO_BAD_CONFIGURATION;
 	}
 
 	if (config->cache_size <
 	    (2 * MAXIMUM_VDO_USER_VIOS * config->thread_counts.logical_zones)) {
-		handle_parse_error(config,
-				   error_ptr,
+		handle_parse_error(config, error_ptr,
 				   "Insufficient block map cache for logical zones");
 		return VDO_BAD_CONFIGURATION;
 	}
 
-	result = dm_get_device(ti,
-			       config->parent_device_name,
-			       dm_table_get_mode(ti->table),
-			       &config->owned_device);
+	result = dm_get_device(ti, config->parent_device_name,
+			       dm_table_get_mode(ti->table), &config->owned_device);
 	if (result != 0) {
 		uds_log_error("couldn't open device \"%s\": error %d",
-			      config->parent_device_name,
-			      result);
+			      config->parent_device_name, result);
 		handle_parse_error(config, error_ptr, "Unable to open storage device");
 		return VDO_BAD_CONFIGURATION;
 	}
@@ -908,7 +907,8 @@ static int vdo_map_bio(struct dm_target *ti, struct bio *bio)
 	struct vdo_work_queue *current_work_queue;
 	const struct admin_state_code *code = vdo_get_admin_state_code(&vdo->admin.state);
 
-	ASSERT_LOG_ONLY(code->normal, "vdo should not receive bios while in state %s", code->name);
+	ASSERT_LOG_ONLY(code->normal, "vdo should not receive bios while in state %s",
+			code->name);
 
 	/* Count all incoming bios. */
 	vdo_count_bios(&vdo->stats.bios_in, bio);
@@ -965,15 +965,13 @@ static void vdo_io_hints(struct dm_target *ti, struct queue_limits *limits)
 	limits->discard_granularity = VDO_BLOCK_SIZE;
 }
 
-static int vdo_iterate_devices(struct dm_target *ti, iterate_devices_callout_fn fn, void *data)
+static int vdo_iterate_devices(struct dm_target *ti, iterate_devices_callout_fn fn,
+			       void *data)
 {
 	struct device_config *config = get_vdo_for_target(ti)->device_config;
 
-	return fn(ti,
-		  config->owned_device,
-		  0,
-		  config->physical_blocks * VDO_SECTORS_PER_BLOCK,
-		  data);
+	return fn(ti, config->owned_device, 0,
+		  config->physical_blocks * VDO_SECTORS_PER_BLOCK, data);
 }
 
 /*
@@ -982,11 +980,8 @@ static int vdo_iterate_devices(struct dm_target *ti, iterate_devices_callout_fn 
  *    <used physical blocks> <total physical blocks>
  */
 
-static void vdo_status(struct dm_target *ti,
-		       status_type_t status_type,
-		       unsigned int status_flags,
-		       char *result,
-		       unsigned int maxlen)
+static void vdo_status(struct dm_target *ti, status_type_t status_type,
+		       unsigned int status_flags, char *result, unsigned int maxlen)
 {
 	struct vdo *vdo = get_vdo_for_target(ti);
 	struct vdo_statistics *stats;
@@ -1002,8 +997,7 @@ static void vdo_status(struct dm_target *ti,
 		stats = &vdo->stats_buffer;
 
 		DMEMIT("/dev/%pg %s %s %s %s %llu %llu",
-		       vdo_get_backing_device(vdo),
-		       stats->mode,
+		       vdo_get_backing_device(vdo), stats->mode,
 		       stats->in_recovery_mode ? "recovering" : "-",
 		       vdo_get_dedupe_index_state_name(vdo->hash_zones),
 		       vdo_get_compressing(vdo) ? "online" : "offline",
@@ -1030,7 +1024,8 @@ static block_count_t __must_check get_underlying_device_block_count(const struct
 	return i_size_read(vdo_get_backing_device(vdo)->bd_inode) / VDO_BLOCK_SIZE;
 }
 
-static int __must_check process_vdo_message_locked(struct vdo *vdo, unsigned int argc, char **argv)
+static int __must_check process_vdo_message_locked(struct vdo *vdo, unsigned int argc,
+						   char **argv)
 {
 	if ((argc == 2) && (strcasecmp(argv[0], "compression") == 0)) {
 		if (strcasecmp(argv[1], "on") == 0) {
@@ -1043,7 +1038,8 @@ static int __must_check process_vdo_message_locked(struct vdo *vdo, unsigned int
 			return 0;
 		}
 
-		uds_log_warning("invalid argument '%s' to dmsetup compression message", argv[1]);
+		uds_log_warning("invalid argument '%s' to dmsetup compression message",
+				argv[1]);
 		return -EINVAL;
 	}
 
@@ -1056,7 +1052,8 @@ static int __must_check process_vdo_message_locked(struct vdo *vdo, unsigned int
  * and only proceed if so.
  * Returns -EBUSY if another message is being processed
  */
-static int __must_check process_vdo_message(struct vdo *vdo, unsigned int argc, char **argv)
+static int __must_check process_vdo_message(struct vdo *vdo, unsigned int argc,
+					    char **argv)
 {
 	int result;
 
@@ -1095,11 +1092,8 @@ static int __must_check process_vdo_message(struct vdo *vdo, unsigned int argc, 
 	return result;
 }
 
-static int vdo_message(struct dm_target *ti,
-		       unsigned int argc,
-		       char **argv,
-		       char *result_buffer,
-		       unsigned int maxlen)
+static int vdo_message(struct dm_target *ti, unsigned int argc, char **argv,
+		       char *result_buffer, unsigned int maxlen)
 {
 	struct registered_thread allocating_thread, instance_thread;
 	struct vdo *vdo;
@@ -1158,8 +1152,7 @@ static bool vdo_uses_device(struct vdo *vdo, const void *context)
  * get_thread_id_for_phase() - Get the thread id for the current phase of the admin operation in
  *                             progress.
  */
-static thread_id_t __must_check
-get_thread_id_for_phase(struct vdo *vdo)
+static thread_id_t __must_check get_thread_id_for_phase(struct vdo *vdo)
 {
 	switch (vdo->admin.phase) {
 	case RESUME_PHASE_PACKER:
@@ -1219,10 +1212,8 @@ static u32 advance_phase(struct vdo *vdo)
  * Perform an administrative operation (load, suspend, grow logical, or grow physical). This method
  * should not be called from vdo threads.
  */
-static int perform_admin_operation(struct vdo *vdo,
-				   u32 starting_phase,
-				   vdo_action *callback,
-				   vdo_action *error_handler,
+static int perform_admin_operation(struct vdo *vdo, u32 starting_phase,
+				   vdo_action *callback, vdo_action *error_handler,
 				   const char *type)
 {
 	int result;
@@ -1258,8 +1249,7 @@ static int perform_admin_operation(struct vdo *vdo,
 static void assert_admin_phase_thread(struct vdo *vdo, const char *what)
 {
 	ASSERT_LOG_ONLY(vdo_get_callback_thread_id() == get_thread_id_for_phase(vdo),
-			"%s on correct thread for %s",
-			what,
+			"%s on correct thread for %s", what,
 			ADMIN_PHASE_NAMES[vdo->admin.phase]);
 }
 
@@ -1290,8 +1280,7 @@ static int __must_check decode_from_super_block(struct vdo *vdo)
 	const struct device_config *config = vdo->device_config;
 	int result;
 
-	result = vdo_decode_component_states(vdo->super_block.buffer,
-					     &vdo->geometry,
+	result = vdo_decode_component_states(vdo->super_block.buffer, &vdo->geometry,
 					     &vdo->states);
 	if (result != VDO_SUCCESS)
 		return result;
@@ -1310,8 +1299,7 @@ static int __must_check decode_from_super_block(struct vdo *vdo)
 		vdo->states.vdo.config.logical_blocks = config->logical_blocks;
 	}
 
-	result = vdo_validate_component_states(&vdo->states,
-					       vdo->geometry.nonce,
+	result = vdo_validate_component_states(&vdo->states, vdo->geometry.nonce,
 					       config->physical_blocks,
 					       config->logical_blocks);
 	if (result != VDO_SUCCESS)
@@ -1363,11 +1351,10 @@ static int __must_check decode_vdo(struct vdo *vdo)
 	if (result != VDO_SUCCESS)
 		return result;
 
-	partition = vdo_get_known_partition(&vdo->layout, VDO_RECOVERY_JOURNAL_PARTITION);
+	partition = vdo_get_known_partition(&vdo->layout,
+					    VDO_RECOVERY_JOURNAL_PARTITION);
 	result = vdo_decode_recovery_journal(vdo->states.recovery_journal,
-					     vdo->states.vdo.nonce,
-					     vdo,
-					     partition,
+					     vdo->states.vdo.nonce, vdo, partition,
 					     vdo->states.vdo.complete_recoveries,
 					     vdo->states.vdo.config.recovery_journal_size,
 					     &vdo->recovery_journal);
@@ -1375,20 +1362,15 @@ static int __must_check decode_vdo(struct vdo *vdo)
 		return result;
 
 	partition = vdo_get_known_partition(&vdo->layout, VDO_SLAB_SUMMARY_PARTITION);
-	result = vdo_decode_slab_depot(vdo->states.slab_depot,
-				       vdo,
-				       partition,
+	result = vdo_decode_slab_depot(vdo->states.slab_depot, vdo, partition,
 				       &vdo->depot);
 	if (result != VDO_SUCCESS)
 		return result;
 
 	result = vdo_decode_block_map(vdo->states.block_map,
-				      vdo->states.vdo.config.logical_blocks,
-				      vdo,
-				      vdo->recovery_journal,
-				      vdo->states.vdo.nonce,
-				      vdo->device_config->cache_size,
-				      maximum_age,
+				      vdo->states.vdo.config.logical_blocks, vdo,
+				      vdo->recovery_journal, vdo->states.vdo.nonce,
+				      vdo->device_config->cache_size, maximum_age,
 				      &vdo->block_map);
 	if (result != VDO_SUCCESS)
 		return result;
@@ -1418,7 +1400,8 @@ static void pre_load_callback(struct vdo_completion *completion)
 
 	switch (advance_phase(vdo)) {
 	case PRE_LOAD_PHASE_START:
-		result = vdo_start_operation(&vdo->admin.state, VDO_ADMIN_STATE_PRE_LOADING);
+		result = vdo_start_operation(&vdo->admin.state,
+					     VDO_ADMIN_STATE_PRE_LOADING);
 		if (result != VDO_SUCCESS) {
 			vdo_continue_completion(completion, result);
 			return;
@@ -1447,8 +1430,7 @@ static void release_instance(unsigned int instance)
 	if (instance >= instances.bit_count) {
 		ASSERT_LOG_ONLY(false,
 				"instance number %u must be less than bit count %u",
-				instance,
-				instances.bit_count);
+				instance, instances.bit_count);
 	} else if (test_bit(instance, instances.words) == 0) {
 		ASSERT_LOG_ONLY(false, "instance number %u must be allocated", instance);
 	} else {
@@ -1458,7 +1440,8 @@ static void release_instance(unsigned int instance)
 	mutex_unlock(&instances_lock);
 }
 
-static void set_device_config(struct dm_target *ti, struct vdo *vdo, struct device_config *config)
+static void set_device_config(struct dm_target *ti, struct vdo *vdo,
+			      struct device_config *config)
 {
 	list_del_init(&config->config_list);
 	list_add_tail(&config->config_list, &vdo->device_config_list);
@@ -1467,8 +1450,8 @@ static void set_device_config(struct dm_target *ti, struct vdo *vdo, struct devi
 	configure_target_capabilities(ti);
 }
 
-static int
-vdo_initialize(struct dm_target *ti, unsigned int instance, struct device_config *config)
+static int vdo_initialize(struct dm_target *ti, unsigned int instance,
+			  struct device_config *config)
 {
 	struct vdo *vdo;
 	int result;
@@ -1497,24 +1480,19 @@ vdo_initialize(struct dm_target *ti, unsigned int instance, struct device_config
 	result = vdo_make(instance, config, &ti->error, &vdo);
 	if (result != VDO_SUCCESS) {
 		uds_log_error("Could not create VDO device. (VDO error %d, message %s)",
-			      result,
-			      ti->error);
+			      result, ti->error);
 		vdo_destroy(vdo);
 		return result;
 	}
 
-	result = perform_admin_operation(vdo,
-					 PRE_LOAD_PHASE_START,
-					 pre_load_callback,
-					 finish_operation_callback,
-					 "pre-load");
+	result = perform_admin_operation(vdo, PRE_LOAD_PHASE_START, pre_load_callback,
+					 finish_operation_callback, "pre-load");
 	if (result != VDO_SUCCESS) {
 		ti->error = ((result == VDO_INVALID_ADMIN_STATE) ?
 			     "Pre-load is only valid immediately after initialization" :
 			     "Cannot load metadata from device");
 		uds_log_error("Could not start VDO device. (VDO error %d, message %s)",
-			      result,
-			      ti->error);
+			      result, ti->error);
 		vdo_destroy(vdo);
 		return result;
 	}
@@ -1557,16 +1535,15 @@ static size_t get_bit_array_size(unsigned int bit_count)
  */
 static int grow_bit_array(void)
 {
-	unsigned int new_count =
-		max(instances.bit_count + BIT_COUNT_INCREMENT, (unsigned int) BIT_COUNT_MINIMUM);
+	unsigned int new_count = max(instances.bit_count + BIT_COUNT_INCREMENT,
+				     (unsigned int) BIT_COUNT_MINIMUM);
 	unsigned long *new_words;
 	int result;
 
 	result = uds_reallocate_memory(instances.words,
 				       get_bit_array_size(instances.bit_count),
 				       get_bit_array_size(new_count),
-				       "instance number bit array",
-				       &new_words);
+				       "instance number bit array", &new_words);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -1599,13 +1576,13 @@ static int allocate_instance(unsigned int *instance_ptr)
 	 * There must be a zero bit somewhere now. Find it, starting just after the last instance
 	 * allocated.
 	 */
-	instance = find_next_zero_bit(instances.words,
-				      instances.bit_count,
+	instance = find_next_zero_bit(instances.words, instances.bit_count,
 				      instances.next);
 	if (instance >= instances.bit_count) {
 		/* Nothing free after next, so wrap around to instance zero. */
 		instance = find_first_zero_bit(instances.words, instances.bit_count);
-		result = ASSERT(instance < instances.bit_count, "impossibly, no zero bit found");
+		result = ASSERT(instance < instances.bit_count,
+				"impossibly, no zero bit found");
 		if (result != UDS_SUCCESS)
 			return result;
 	}
@@ -1617,10 +1594,8 @@ static int allocate_instance(unsigned int *instance_ptr)
 	return UDS_SUCCESS;
 }
 
-static int construct_new_vdo_registered(struct dm_target *ti,
-					unsigned int argc,
-					char **argv,
-					unsigned int instance)
+static int construct_new_vdo_registered(struct dm_target *ti, unsigned int argc,
+					char **argv, unsigned int instance)
 {
 	int result;
 	struct device_config *config;
@@ -1719,9 +1694,9 @@ static int grow_layout(struct vdo *vdo, block_count_t old_size, block_count_t ne
 	 * Make a new layout with the existing partition sizes for everything but the slab depot
 	 * partition.
 	 */
-	result = vdo_initialize_layout(new_size,
-				       vdo->layout.start,
-				       get_partition_size(&vdo->layout, VDO_BLOCK_MAP_PARTITION),
+	result = vdo_initialize_layout(new_size, vdo->layout.start,
+				       get_partition_size(&vdo->layout,
+							  VDO_BLOCK_MAP_PARTITION),
 				       get_partition_size(&vdo->layout,
 							  VDO_RECOVERY_JOURNAL_PARTITION),
 				       get_partition_size(&vdo->layout,
@@ -1734,8 +1709,10 @@ static int grow_layout(struct vdo *vdo, block_count_t old_size, block_count_t ne
 
 	/* Ensure the new journal and summary are entirely within the added blocks. */
 	min_new_size = (old_size +
-			get_partition_size(&vdo->next_layout, VDO_SLAB_SUMMARY_PARTITION) +
-			get_partition_size(&vdo->next_layout, VDO_RECOVERY_JOURNAL_PARTITION));
+			get_partition_size(&vdo->next_layout,
+					   VDO_SLAB_SUMMARY_PARTITION) +
+			get_partition_size(&vdo->next_layout,
+					   VDO_RECOVERY_JOURNAL_PARTITION));
 	if (min_new_size > new_size) {
 		/* Copying the journal and summary would destroy some old metadata. */
 		vdo_uninitialize_layout(&vdo->next_layout);
@@ -1755,8 +1732,7 @@ static int prepare_to_grow_physical(struct vdo *vdo, block_count_t new_physical_
 		     (unsigned long long) new_physical_blocks);
 	ASSERT_LOG_ONLY((new_physical_blocks > current_physical_blocks),
 			"New physical size is larger than current physical size");
-	result = perform_admin_operation(vdo,
-					 PREPARE_GROW_PHYSICAL_PHASE_START,
+	result = perform_admin_operation(vdo, PREPARE_GROW_PHYSICAL_PHASE_START,
 					 check_may_grow_physical,
 					 finish_operation_callback,
 					 "prepare grow-physical");
@@ -1791,8 +1767,7 @@ static int prepare_to_grow_physical(struct vdo *vdo, block_count_t new_physical_
  * Return: VDO_SUCCESS or an error.
  */
 static int validate_new_device_config(struct device_config *to_validate,
-				      struct device_config *config,
-				      bool may_grow,
+				      struct device_config *config, bool may_grow,
 				      char **error_ptr)
 {
 	if (to_validate->owning_target->begin != config->owning_target->begin) {
@@ -1820,8 +1795,7 @@ static int validate_new_device_config(struct device_config *to_validate,
 		return VDO_PARAMETER_MISMATCH;
 	}
 
-	if (memcmp(&to_validate->thread_counts,
-		   &config->thread_counts,
+	if (memcmp(&to_validate->thread_counts, &config->thread_counts,
 		   sizeof(struct thread_count_config)) != 0) {
 		*error_ptr = "Thread configuration cannot change";
 		return VDO_PARAMETER_MISMATCH;
@@ -1840,12 +1814,14 @@ static int validate_new_device_config(struct device_config *to_validate,
 	return VDO_SUCCESS;
 }
 
-static int prepare_to_modify(struct dm_target *ti, struct device_config *config, struct vdo *vdo)
+static int prepare_to_modify(struct dm_target *ti, struct device_config *config,
+			     struct vdo *vdo)
 {
 	int result;
 	bool may_grow = (vdo_get_admin_state(vdo) != VDO_ADMIN_STATE_PRE_LOADED);
 
-	result = validate_new_device_config(config, vdo->device_config, may_grow, &ti->error);
+	result = validate_new_device_config(config, vdo->device_config, may_grow,
+					    &ti->error);
 	if (result != VDO_SUCCESS)
 		return -EINVAL;
 
@@ -1857,7 +1833,8 @@ static int prepare_to_modify(struct dm_target *ti, struct device_config *config,
 		ASSERT_LOG_ONLY((config->logical_blocks > logical_blocks),
 				"New logical size is larger than current size");
 
-		result = vdo_prepare_to_grow_block_map(vdo->block_map, config->logical_blocks);
+		result = vdo_prepare_to_grow_block_map(vdo->block_map,
+						       config->logical_blocks);
 		if (result != VDO_SUCCESS) {
 			ti->error = "Device vdo_prepare_to_grow_logical failed";
 			return result;
@@ -1889,8 +1866,7 @@ static int prepare_to_modify(struct dm_target *ti, struct device_config *config,
 	if (strcmp(config->parent_device_name, vdo->device_config->parent_device_name) != 0) {
 		const char *device_name = vdo_get_device_name(config->owning_target);
 
-		uds_log_info("Updating backing device of %s from %s to %s",
-			     device_name,
+		uds_log_info("Updating backing device of %s from %s to %s", device_name,
 			     vdo->device_config->parent_device_name,
 			     config->parent_device_name);
 	}
@@ -1898,11 +1874,8 @@ static int prepare_to_modify(struct dm_target *ti, struct device_config *config,
 	return VDO_SUCCESS;
 }
 
-static int update_existing_vdo(const char *device_name,
-			       struct dm_target *ti,
-			       unsigned int argc,
-			       char **argv,
-			       struct vdo *vdo)
+static int update_existing_vdo(const char *device_name, struct dm_target *ti,
+			       unsigned int argc, char **argv, struct vdo *vdo)
 {
 	int result;
 	struct device_config *config;
@@ -1976,8 +1949,7 @@ static void vdo_dtr(struct dm_target *ti)
 		 * being destroyed.
 		 */
 		vdo->device_config = list_first_entry(&vdo->device_config_list,
-						      struct device_config,
-						      config_list);
+						      struct device_config, config_list);
 	}
 
 	free_device_config(config);
@@ -2039,7 +2011,8 @@ static void suspend_callback(struct vdo_completion *completion)
 			break;
 		}
 
-		vdo_continue_completion(completion, vdo_start_operation(state, vdo->suspend_type));
+		vdo_continue_completion(completion,
+					vdo_start_operation(state, vdo->suspend_type));
 		return;
 
 	case SUSPEND_PHASE_PACKER:
@@ -2078,25 +2051,21 @@ static void suspend_callback(struct vdo_completion *completion)
 			vdo_enter_read_only_mode(vdo, result);
 
 		vdo_drain_logical_zones(vdo->logical_zones,
-					vdo_get_admin_state_code(state),
-					completion);
+					vdo_get_admin_state_code(state), completion);
 		return;
 
 	case SUSPEND_PHASE_BLOCK_MAP:
-		vdo_drain_block_map(vdo->block_map,
-				    vdo_get_admin_state_code(state),
+		vdo_drain_block_map(vdo->block_map, vdo_get_admin_state_code(state),
 				    completion);
 		return;
 
 	case SUSPEND_PHASE_JOURNAL:
 		vdo_drain_recovery_journal(vdo->recovery_journal,
-					   vdo_get_admin_state_code(state),
-					   completion);
+					   vdo_get_admin_state_code(state), completion);
 		return;
 
 	case SUSPEND_PHASE_DEPOT:
-		vdo_drain_slab_depot(vdo->depot,
-				     vdo_get_admin_state_code(state),
+		vdo_drain_slab_depot(vdo->depot, vdo_get_admin_state_code(state),
 				     completion);
 		return;
 
@@ -2138,11 +2107,8 @@ static void vdo_postsuspend(struct dm_target *ti)
 	 * It's important to note any error here does not actually stop device-mapper from
 	 * suspending the device. All this work is done post suspend.
 	 */
-	result = perform_admin_operation(vdo,
-					 SUSPEND_PHASE_START,
-					 suspend_callback,
-					 suspend_callback,
-					 "suspend");
+	result = perform_admin_operation(vdo, SUSPEND_PHASE_START, suspend_callback,
+					 suspend_callback, "suspend");
 
 	if ((result == VDO_SUCCESS) || (result == VDO_READ_ONLY)) {
 		/*
@@ -2154,7 +2120,8 @@ static void vdo_postsuspend(struct dm_target *ti)
 		uds_log_error("Suspend invoked while in unexpected state: %s",
 			      vdo_get_admin_state(vdo)->name);
 	} else {
-		uds_log_error_strerror(result, "Suspend of device '%s' failed", device_name);
+		uds_log_error_strerror(result, "Suspend of device '%s' failed",
+				       device_name);
 	}
 
 	uds_unregister_thread_device_id();
@@ -2222,7 +2189,8 @@ static int vdo_initialize_kobjects(struct vdo *vdo)
 
 	kobject_init(&vdo->vdo_directory, &vdo_directory_type);
 	vdo->sysfs_added = true;
-	result = kobject_add(&vdo->vdo_directory, &disk_to_dev(dm_disk(md))->kobj, "vdo");
+	result = kobject_add(&vdo->vdo_directory, &disk_to_dev(dm_disk(md))->kobj,
+			     "vdo");
 	if (result != 0)
 		return VDO_CANT_ADD_SYSFS_NODE;
 
@@ -2253,7 +2221,8 @@ static void load_callback(struct vdo_completion *completion)
 		}
 
 		/* Prepare the recovery journal for new entries. */
-		vdo_open_recovery_journal(vdo->recovery_journal, vdo->depot, vdo->block_map);
+		vdo_open_recovery_journal(vdo->recovery_journal, vdo->depot,
+					  vdo->block_map);
 		vdo_allow_read_only_mode_entry(completion);
 		return;
 
@@ -2277,11 +2246,9 @@ static void load_callback(struct vdo_completion *completion)
 		}
 
 		vdo_load_slab_depot(vdo->depot,
-				    (was_new(vdo) ?
-				     VDO_ADMIN_STATE_FORMATTING :
+				    (was_new(vdo) ? VDO_ADMIN_STATE_FORMATTING :
 				     VDO_ADMIN_STATE_LOADING),
-				    completion,
-				    NULL);
+				    completion, NULL);
 		return;
 
 	case LOAD_PHASE_MAKE_DIRTY:
@@ -2290,8 +2257,10 @@ static void load_callback(struct vdo_completion *completion)
 		return;
 
 	case LOAD_PHASE_PREPARE_TO_ALLOCATE:
-		vdo_initialize_block_map_from_journal(vdo->block_map, vdo->recovery_journal);
-		vdo_prepare_slab_depot_to_allocate(vdo->depot, get_load_type(vdo), completion);
+		vdo_initialize_block_map_from_journal(vdo->block_map,
+						      vdo->recovery_journal);
+		vdo_prepare_slab_depot_to_allocate(vdo->depot, get_load_type(vdo),
+						   completion);
 		return;
 
 	case LOAD_PHASE_SCRUB_SLABS:
@@ -2318,8 +2287,7 @@ static void load_callback(struct vdo_completion *completion)
 		break;
 
 	case LOAD_PHASE_DRAIN_JOURNAL:
-		vdo_drain_recovery_journal(vdo->recovery_journal,
-					   VDO_ADMIN_STATE_SAVING,
+		vdo_drain_recovery_journal(vdo->recovery_journal, VDO_ADMIN_STATE_SAVING,
 					   completion);
 		return;
 
@@ -2348,7 +2316,8 @@ static void handle_load_error(struct vdo_completion *completion)
 {
 	struct vdo *vdo = completion->vdo;
 
-	if (vdo_requeue_completion_if_needed(completion, vdo->thread_config.admin_thread))
+	if (vdo_requeue_completion_if_needed(completion,
+					     vdo->thread_config.admin_thread))
 		return;
 
 	if (vdo_state_requires_read_only_rebuild(vdo->load_state) &&
@@ -2359,7 +2328,8 @@ static void handle_load_error(struct vdo_completion *completion)
 		return;
 	}
 
-	uds_log_error_strerror(completion->result, "Entering read-only mode due to load error");
+	uds_log_error_strerror(completion->result,
+			       "Entering read-only mode due to load error");
 	vdo->admin.phase = LOAD_PHASE_WAIT_FOR_READ_ONLY;
 	vdo_enter_read_only_mode(vdo, completion->result);
 	completion->result = VDO_READ_ONLY;
@@ -2409,7 +2379,8 @@ static void resume_callback(struct vdo_completion *completion)
 
 	switch (advance_phase(vdo)) {
 	case RESUME_PHASE_START:
-		result = vdo_start_operation(&vdo->admin.state, VDO_ADMIN_STATE_RESUMING);
+		result = vdo_start_operation(&vdo->admin.state,
+					     VDO_ADMIN_STATE_RESUMING);
 		if (result != VDO_SUCCESS) {
 			vdo_continue_completion(completion, result);
 			return;
@@ -2568,15 +2539,14 @@ static int perform_grow_logical(struct vdo *vdo, block_count_t new_logical_block
 		return VDO_SUCCESS;
 	}
 
-	uds_log_info("Resizing logical to %llu", (unsigned long long) new_logical_blocks);
+	uds_log_info("Resizing logical to %llu",
+		     (unsigned long long) new_logical_blocks);
 	if (vdo->block_map->next_entry_count != new_logical_blocks)
 		return VDO_PARAMETER_MISMATCH;
 
-	result = perform_admin_operation(vdo,
-					 GROW_LOGICAL_PHASE_START,
+	result = perform_admin_operation(vdo, GROW_LOGICAL_PHASE_START,
 					 grow_logical_callback,
-					 handle_logical_growth_error,
-					 "grow logical");
+					 handle_logical_growth_error, "grow logical");
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -2592,8 +2562,8 @@ static void copy_callback(int read_err, unsigned long write_err, void *context)
 	vdo_continue_completion(completion, result);
 }
 
-static void
-partition_to_region(struct partition *partition, struct vdo *vdo, struct dm_io_region *region)
+static void partition_to_region(struct partition *partition, struct vdo *vdo,
+				struct dm_io_region *region)
 {
 	physical_block_number_t pbn = partition->offset - vdo->geometry.bio_offset;
 
@@ -2611,7 +2581,8 @@ partition_to_region(struct partition *partition, struct vdo *vdo, struct dm_io_r
  * @id: The ID of the partition to copy.
  * @parent: The completion to notify when the copy is complete.
  */
-static void copy_partition(struct vdo *vdo, enum partition_id id, struct vdo_completion *parent)
+static void copy_partition(struct vdo *vdo, enum partition_id id,
+			   struct vdo_completion *parent)
 {
 	struct dm_io_region read_region, write_regions[1];
 	struct partition *from = vdo_get_known_partition(&vdo->layout, id);
@@ -2619,13 +2590,8 @@ static void copy_partition(struct vdo *vdo, enum partition_id id, struct vdo_com
 
 	partition_to_region(from, vdo, &read_region);
 	partition_to_region(to, vdo, &write_regions[0]);
-	dm_kcopyd_copy(vdo->partition_copier,
-		       &read_region,
-		       1,
-		       write_regions,
-		       0,
-		       copy_callback,
-		       parent);
+	dm_kcopyd_copy(vdo->partition_copier, &read_region, 1, write_regions, 0,
+		       copy_callback, parent);
 }
 
 /**
@@ -2680,7 +2646,8 @@ static void grow_physical_callback(struct vdo_completion *completion)
 
 	case GROW_PHYSICAL_PHASE_END:
 		vdo->depot->summary_origin =
-			vdo_get_known_partition(&vdo->layout, VDO_SLAB_SUMMARY_PARTITION)->offset;
+			vdo_get_known_partition(&vdo->layout,
+						VDO_SLAB_SUMMARY_PARTITION)->offset;
 		vdo->recovery_journal->origin =
 			vdo_get_known_partition(&vdo->layout,
 						VDO_RECOVERY_JOURNAL_PARTITION)->offset;
@@ -2746,11 +2713,9 @@ static int perform_grow_physical(struct vdo *vdo, block_count_t new_physical_blo
 	if (prepared_depot_size != new_depot_size)
 		return VDO_PARAMETER_MISMATCH;
 
-	result = perform_admin_operation(vdo,
-					 GROW_PHYSICAL_PHASE_START,
+	result = perform_admin_operation(vdo, GROW_PHYSICAL_PHASE_START,
 					 grow_physical_callback,
-					 handle_physical_growth_error,
-					 "grow physical");
+					 handle_physical_growth_error, "grow physical");
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -2769,7 +2734,8 @@ static int perform_grow_physical(struct vdo *vdo, block_count_t new_physical_blo
  *
  * Return: VDO_SUCCESS or an error.
  */
-static int __must_check apply_new_vdo_configuration(struct vdo *vdo, struct device_config *config)
+static int __must_check apply_new_vdo_configuration(struct vdo *vdo,
+						    struct device_config *config)
 {
 	int result;
 
@@ -2797,19 +2763,15 @@ static int vdo_preresume_registered(struct dm_target *ti, struct vdo *vdo)
 	if (backing_blocks < config->physical_blocks) {
 		/* FIXME: can this still happen? */
 		uds_log_error("resume of device '%s' failed: backing device has %llu blocks but VDO physical size is %llu blocks",
-			      device_name,
-			      (unsigned long long) backing_blocks,
+			      device_name, (unsigned long long) backing_blocks,
 			      (unsigned long long) config->physical_blocks);
 		return -EINVAL;
 	}
 
 	if (vdo_get_admin_state(vdo) == VDO_ADMIN_STATE_PRE_LOADED) {
 		uds_log_info("starting device '%s'", device_name);
-		result = perform_admin_operation(vdo,
-						 LOAD_PHASE_START,
-						 load_callback,
-						 handle_load_error,
-						 "load");
+		result = perform_admin_operation(vdo, LOAD_PHASE_START, load_callback,
+						 handle_load_error, "load");
 		if ((result != VDO_SUCCESS) && (result != VDO_READ_ONLY)) {
 			/*
 			 * Something has gone very wrong. Make sure everything has drained and
@@ -2818,10 +2780,8 @@ static int vdo_preresume_registered(struct dm_target *ti, struct vdo *vdo)
 			uds_log_error_strerror(result,
 					       "Start failed, could not load VDO metadata");
 			vdo->suspend_type = VDO_ADMIN_STATE_STOPPING;
-			perform_admin_operation(vdo,
-						SUSPEND_PHASE_START,
-						suspend_callback,
-						suspend_callback,
+			perform_admin_operation(vdo, SUSPEND_PHASE_START,
+						suspend_callback, suspend_callback,
 						"suspend");
 			return result;
 		}
@@ -2860,11 +2820,8 @@ static int vdo_preresume_registered(struct dm_target *ti, struct vdo *vdo)
 		return VDO_SUCCESS;
 	}
 
-	result = perform_admin_operation(vdo,
-					 RESUME_PHASE_START,
-					 resume_callback,
-					 resume_callback,
-					 "resume");
+	result = perform_admin_operation(vdo, RESUME_PHASE_START, resume_callback,
+					 resume_callback, "resume");
 	BUG_ON(result == VDO_INVALID_ADMIN_STATE);
 	if (result == VDO_READ_ONLY) {
 		/* Even if the vdo is read-only, it has still resumed. */
@@ -2872,7 +2829,8 @@ static int vdo_preresume_registered(struct dm_target *ti, struct vdo *vdo)
 	}
 
 	if (result != VDO_SUCCESS)
-		uds_log_error("resume of device '%s' failed with error: %d", device_name, result);
+		uds_log_error("resume of device '%s' failed with error: %d", device_name,
+			      result);
 
 	return result;
 }
@@ -2895,7 +2853,8 @@ static void vdo_resume(struct dm_target *ti)
 {
 	struct registered_thread instance_thread;
 
-	uds_register_thread_device_id(&instance_thread, &get_vdo_for_target(ti)->instance);
+	uds_register_thread_device_id(&instance_thread,
+				      &get_vdo_for_target(ti)->instance);
 	uds_log_info("device '%s' resumed", vdo_get_device_name(ti));
 	uds_unregister_thread_device_id();
 }

--- a/drivers/md/dm-vdo-target.c
+++ b/drivers/md/dm-vdo-target.c
@@ -1530,7 +1530,7 @@ static bool __must_check vdo_is_named(struct vdo *vdo, const void *context)
 	struct dm_target *ti = vdo->device_config->owning_target;
 	const char *device_name = vdo_get_device_name(ti);
 
-	return strcmp(device_name, (const char *) context) == 0;
+	return strcmp(device_name, context) == 0;
 }
 
 /**
@@ -1931,7 +1931,7 @@ static int vdo_ctr(struct dm_target *ti, unsigned int argc, char **argv)
 
 	uds_register_allocating_thread(&allocating_thread, NULL);
 	device_name = vdo_get_device_name(ti);
-	vdo = vdo_find_matching(vdo_is_named, (const void *) device_name);
+	vdo = vdo_find_matching(vdo_is_named, device_name);
 	if (vdo == NULL) {
 		result = construct_new_vdo(ti, argc, argv);
 	} else {

--- a/drivers/md/dm-vdo/action-manager.c
+++ b/drivers/md/dm-vdo/action-manager.c
@@ -190,15 +190,16 @@ static void apply_to_zone(struct vdo_completion *completion)
 			__func__);
 
 	zone = manager->acting_zone++;
-	if (manager->acting_zone == manager->zones)
+	if (manager->acting_zone == manager->zones) {
 		/*
 		 * We are about to apply to the last zone. Once that is finished, we're done, so go
 		 * back to the initiator thread and finish up.
 		 */
 		prepare_for_conclusion(manager);
-	else
+	} else {
 		/* Prepare to come back on the next zone */
 		prepare_for_next_zone(manager);
+	}
 
 	manager->current_action->zone_action(manager->context, zone, completion);
 }

--- a/drivers/md/dm-vdo/action-manager.c
+++ b/drivers/md/dm-vdo/action-manager.c
@@ -76,8 +76,7 @@ static bool no_default_action(void *context __always_unused)
 }
 
 /* Implements vdo_action_preamble. */
-static void no_preamble(void *context __always_unused,
-			struct vdo_completion *completion)
+static void no_preamble(void *context __always_unused, struct vdo_completion *completion)
 {
 	vdo_finish_completion(completion);
 }
@@ -103,10 +102,8 @@ static int no_conclusion(void *context __always_unused)
  */
 int vdo_make_action_manager(zone_count_t zones,
 			    vdo_zone_thread_getter *get_zone_thread_id,
-			    thread_id_t initiator_thread_id,
-			    void *context,
-			    vdo_action_scheduler *scheduler,
-			    struct vdo *vdo,
+			    thread_id_t initiator_thread_id, void *context,
+			    vdo_action_scheduler *scheduler, struct vdo *vdo,
 			    struct action_manager **manager_ptr)
 {
 	struct action_manager *manager;
@@ -127,10 +124,8 @@ int vdo_make_action_manager(zone_count_t zones,
 	manager->actions[0].next = &manager->actions[1];
 	manager->current_action = manager->actions[1].next =
 		&manager->actions[0];
-	vdo_set_admin_state_code(&manager->state,
-				 VDO_ADMIN_STATE_NORMAL_OPERATION);
-	vdo_initialize_completion(&manager->completion, vdo,
-				  VDO_ACTION_COMPLETION);
+	vdo_set_admin_state_code(&manager->state, VDO_ADMIN_STATE_NORMAL_OPERATION);
+	vdo_initialize_completion(&manager->completion, vdo, VDO_ACTION_COMPLETION);
 	*manager_ptr = manager;
 	return VDO_SUCCESS;
 }
@@ -164,8 +159,7 @@ static void preserve_error(struct vdo_completion *completion)
 
 static void prepare_for_next_zone(struct action_manager *manager)
 {
-	vdo_prepare_completion_for_requeue(&manager->completion,
-					   apply_to_zone,
+	vdo_prepare_completion_for_requeue(&manager->completion, apply_to_zone,
 					   preserve_error,
 					   get_acting_zone_thread_id(manager),
 					   manager->current_action->parent);
@@ -173,10 +167,8 @@ static void prepare_for_next_zone(struct action_manager *manager)
 
 static void prepare_for_conclusion(struct action_manager *manager)
 {
-	vdo_prepare_completion_for_requeue(&manager->completion,
-					   finish_action_callback,
-					   preserve_error,
-					   manager->initiator_thread_id,
+	vdo_prepare_completion_for_requeue(&manager->completion, finish_action_callback,
+					   preserve_error, manager->initiator_thread_id,
 					   manager->current_action->parent);
 }
 
@@ -186,8 +178,7 @@ static void apply_to_zone(struct vdo_completion *completion)
 	struct action_manager *manager = as_action_manager(completion);
 
 	ASSERT_LOG_ONLY((vdo_get_callback_thread_id() == get_acting_zone_thread_id(manager)),
-			"%s() called on acting zones's thread",
-			__func__);
+			"%s() called on acting zones's thread", __func__);
 
 	zone = manager->acting_zone++;
 	if (manager->acting_zone == manager->zones) {
@@ -230,8 +221,7 @@ static void launch_current_action(struct action_manager *manager)
 		prepare_for_conclusion(manager);
 	} else {
 		manager->acting_zone = 0;
-		vdo_prepare_completion_for_requeue(&manager->completion,
-						   apply_to_zone,
+		vdo_prepare_completion_for_requeue(&manager->completion, apply_to_zone,
 						   handle_preamble_error,
 						   get_acting_zone_thread_id(manager),
 						   manager->current_action->parent);
@@ -300,18 +290,12 @@ static void finish_action_callback(struct vdo_completion *completion)
  *
  * Return: true if the action was scheduled.
  */
-bool vdo_schedule_action(struct action_manager *manager,
-			 vdo_action_preamble *preamble,
-			 vdo_zone_action *action,
-			 vdo_action_conclusion *conclusion,
+bool vdo_schedule_action(struct action_manager *manager, vdo_action_preamble *preamble,
+			 vdo_zone_action *action, vdo_action_conclusion *conclusion,
 			 struct vdo_completion *parent)
 {
-	return vdo_schedule_operation(manager,
-				      VDO_ADMIN_STATE_OPERATING,
-				      preamble,
-				      action,
-				      conclusion,
-				      parent);
+	return vdo_schedule_operation(manager, VDO_ADMIN_STATE_OPERATING, preamble,
+				      action, conclusion, parent);
 }
 
 /**
@@ -335,18 +319,12 @@ bool vdo_schedule_action(struct action_manager *manager,
  */
 bool vdo_schedule_operation(struct action_manager *manager,
 			    const struct admin_state_code *operation,
-			    vdo_action_preamble *preamble,
-			    vdo_zone_action *action,
+			    vdo_action_preamble *preamble, vdo_zone_action *action,
 			    vdo_action_conclusion *conclusion,
 			    struct vdo_completion *parent)
 {
-	return vdo_schedule_operation_with_context(manager,
-						   operation,
-						   preamble,
-						   action,
-						   conclusion,
-						   NULL,
-						   parent);
+	return vdo_schedule_operation_with_context(manager, operation, preamble, action,
+						   conclusion, NULL, parent);
 }
 
 /**
@@ -375,8 +353,7 @@ bool vdo_schedule_operation_with_context(struct action_manager *manager,
 					 vdo_action_preamble *preamble,
 					 vdo_zone_action *action,
 					 vdo_action_conclusion *conclusion,
-					 void *context,
-					 struct vdo_completion *parent)
+					 void *context, struct vdo_completion *parent)
 {
 	struct action *current_action;
 

--- a/drivers/md/dm-vdo/action-manager.h
+++ b/drivers/md/dm-vdo/action-manager.h
@@ -39,8 +39,8 @@
  * @zone_number: The number of zone to which the action is being applied
  * @parent: The object to notify when the action is complete
  */
-typedef void vdo_zone_action(void *context, zone_count_t zone_number,
-			     struct vdo_completion *parent);
+typedef void (*vdo_zone_action_fn)(void *context, zone_count_t zone_number,
+				   struct vdo_completion *parent);
 
 /*
  * A function which is to be applied asynchronously on an action manager's initiator thread as the
@@ -48,7 +48,7 @@ typedef void vdo_zone_action(void *context, zone_count_t zone_number,
  * @context: The object which holds the per-zone context for the action
  * @parent: The object to notify when the action is complete
  */
-typedef void vdo_action_preamble(void *context, struct vdo_completion *parent);
+typedef void (*vdo_action_preamble_fn)(void *context, struct vdo_completion *parent);
 
 /*
  * A function which will run on the action manager's initiator thread as the conclusion of an
@@ -57,7 +57,7 @@ typedef void vdo_action_preamble(void *context, struct vdo_completion *parent);
  *
  * Return: VDO_SUCCESS or an error
  */
-typedef int vdo_action_conclusion(void *context);
+typedef int (*vdo_action_conclusion_fn)(void *context);
 
 /*
  * A function to schedule an action.
@@ -65,21 +65,21 @@ typedef int vdo_action_conclusion(void *context);
  *
  * Return: true if an action was scheduled
  */
-typedef bool vdo_action_scheduler(void *context);
+typedef bool (*vdo_action_scheduler_fn)(void *context);
 
 /*
  * A function to get the id of the thread associated with a given zone.
  * @context: The action context
  * @zone_number: The number of the zone for which the thread ID is desired
  */
-typedef thread_id_t vdo_zone_thread_getter(void *context, zone_count_t zone_number);
+typedef thread_id_t (*vdo_zone_thread_getter_fn)(void *context, zone_count_t zone_number);
 
 struct action_manager;
 
 int __must_check vdo_make_action_manager(zone_count_t zones,
-					 vdo_zone_thread_getter *get_zone_thread_id,
+					 vdo_zone_thread_getter_fn get_zone_thread_id,
 					 thread_id_t initiator_thread_id, void *context,
-					 vdo_action_scheduler *scheduler,
+					 vdo_action_scheduler_fn scheduler,
 					 struct vdo *vdo,
 					 struct action_manager **manager_ptr);
 
@@ -90,21 +90,21 @@ void * __must_check vdo_get_current_action_context(struct action_manager *manage
 
 bool vdo_schedule_default_action(struct action_manager *manager);
 
-bool vdo_schedule_action(struct action_manager *manager, vdo_action_preamble *preamble,
-			 vdo_zone_action *action, vdo_action_conclusion *conclusion,
+bool vdo_schedule_action(struct action_manager *manager, vdo_action_preamble_fn preamble,
+			 vdo_zone_action_fn action, vdo_action_conclusion_fn conclusion,
 			 struct vdo_completion *parent);
 
 bool vdo_schedule_operation(struct action_manager *manager,
 			    const struct admin_state_code *operation,
-			    vdo_action_preamble *preamble, vdo_zone_action *action,
-			    vdo_action_conclusion *conclusion,
+			    vdo_action_preamble_fn preamble, vdo_zone_action_fn action,
+			    vdo_action_conclusion_fn conclusion,
 			    struct vdo_completion *parent);
 
 bool vdo_schedule_operation_with_context(struct action_manager *manager,
 					 const struct admin_state_code *operation,
-					 vdo_action_preamble *preamble,
-					 vdo_zone_action *action,
-					 vdo_action_conclusion *conclusion,
+					 vdo_action_preamble_fn preamble,
+					 vdo_zone_action_fn action,
+					 vdo_action_conclusion_fn conclusion,
 					 void *context, struct vdo_completion *parent);
 
 #endif /* VDO_ACTION_MANAGER_H */

--- a/drivers/md/dm-vdo/action-manager.h
+++ b/drivers/md/dm-vdo/action-manager.h
@@ -39,8 +39,7 @@
  * @zone_number: The number of zone to which the action is being applied
  * @parent: The object to notify when the action is complete
  */
-typedef void vdo_zone_action(void *context,
-			     zone_count_t zone_number,
+typedef void vdo_zone_action(void *context, zone_count_t zone_number,
 			     struct vdo_completion *parent);
 
 /*
@@ -77,14 +76,12 @@ typedef thread_id_t vdo_zone_thread_getter(void *context, zone_count_t zone_numb
 
 struct action_manager;
 
-int __must_check
-vdo_make_action_manager(zone_count_t zones,
-			vdo_zone_thread_getter *get_zone_thread_id,
-			thread_id_t initiator_thread_id,
-			void *context,
-			vdo_action_scheduler *scheduler,
-			struct vdo *vdo,
-			struct action_manager **manager_ptr);
+int __must_check vdo_make_action_manager(zone_count_t zones,
+					 vdo_zone_thread_getter *get_zone_thread_id,
+					 thread_id_t initiator_thread_id, void *context,
+					 vdo_action_scheduler *scheduler,
+					 struct vdo *vdo,
+					 struct action_manager **manager_ptr);
 
 const struct admin_state_code *__must_check
 vdo_get_current_manager_operation(struct action_manager *manager);
@@ -93,16 +90,13 @@ void * __must_check vdo_get_current_action_context(struct action_manager *manage
 
 bool vdo_schedule_default_action(struct action_manager *manager);
 
-bool vdo_schedule_action(struct action_manager *manager,
-			 vdo_action_preamble *preamble,
-			 vdo_zone_action *action,
-			 vdo_action_conclusion *conclusion,
+bool vdo_schedule_action(struct action_manager *manager, vdo_action_preamble *preamble,
+			 vdo_zone_action *action, vdo_action_conclusion *conclusion,
 			 struct vdo_completion *parent);
 
 bool vdo_schedule_operation(struct action_manager *manager,
 			    const struct admin_state_code *operation,
-			    vdo_action_preamble *preamble,
-			    vdo_zone_action *action,
+			    vdo_action_preamble *preamble, vdo_zone_action *action,
 			    vdo_action_conclusion *conclusion,
 			    struct vdo_completion *parent);
 
@@ -111,7 +105,6 @@ bool vdo_schedule_operation_with_context(struct action_manager *manager,
 					 vdo_action_preamble *preamble,
 					 vdo_zone_action *action,
 					 vdo_action_conclusion *conclusion,
-					 void *context,
-					 struct vdo_completion *parent);
+					 void *context, struct vdo_completion *parent);
 
 #endif /* VDO_ACTION_MANAGER_H */

--- a/drivers/md/dm-vdo/admin-state.c
+++ b/drivers/md/dm-vdo/admin-state.c
@@ -215,14 +215,14 @@ bool vdo_finish_operation(struct admin_state *state, int result)
 /**
  * begin_operation() - Begin an operation if it may be started given the current state.
  * @waiter A completion to notify when the operation is complete; may be NULL.
- * @initiator The vdo_admin_initiator to call if the operation may begin; may be NULL.
+ * @initiator The vdo_admin_initiator_fn to call if the operation may begin; may be NULL.
  *
  * Return: VDO_SUCCESS or an error.
  */
 static int __must_check begin_operation(struct admin_state *state,
 					const struct admin_state_code *operation,
 					struct vdo_completion *waiter,
-					vdo_admin_initiator *initiator)
+					vdo_admin_initiator_fn initiator)
 {
 	int result;
 	const struct admin_state_code *next_state = get_next_state(state, operation);
@@ -260,14 +260,14 @@ static int __must_check begin_operation(struct admin_state *state,
 /**
  * start_operation() - Start an operation if it may be started given the current state.
  * @waiter     A completion to notify when the operation is complete.
- * @initiator The vdo_admin_initiator to call if the operation may begin; may be NULL.
+ * @initiator The vdo_admin_initiator_fn to call if the operation may begin; may be NULL.
  *
  * Return: true if the operation was started.
  */
 static inline bool __must_check start_operation(struct admin_state *state,
 						const struct admin_state_code *operation,
 						struct vdo_completion *waiter,
-						vdo_admin_initiator *initiator)
+						vdo_admin_initiator_fn initiator)
 {
 	return (begin_operation(state, operation, waiter, initiator) == VDO_SUCCESS);
 }
@@ -315,13 +315,13 @@ static bool __must_check assert_vdo_drain_operation(const struct admin_state_cod
  * vdo_start_draining() - Initiate a drain operation if the current state permits it.
  * @operation The type of drain to initiate.
  * @waiter The completion to notify when the drain is complete.
- * @initiator The vdo_admin_initiator to call if the operation may begin; may be NULL.
+ * @initiator The vdo_admin_initiator_fn to call if the operation may begin; may be NULL.
  *
  * Return: true if the drain was initiated, if not the waiter will be notified.
  */
 bool vdo_start_draining(struct admin_state *state,
 			const struct admin_state_code *operation,
-			struct vdo_completion *waiter, vdo_admin_initiator *initiator)
+			struct vdo_completion *waiter, vdo_admin_initiator_fn initiator)
 {
 	const struct admin_state_code *code = vdo_get_admin_state_code(state);
 
@@ -379,13 +379,13 @@ bool vdo_assert_load_operation(const struct admin_state_code *operation,
  * vdo_start_loading() - Initiate a load operation if the current state permits it.
  * @operation The type of load to initiate.
  * @waiter The completion to notify when the load is complete (may be NULL).
- * @initiator The vdo_admin_initiator to call if the operation may begin; may be NULL.
+ * @initiator The vdo_admin_initiator_fn to call if the operation may begin; may be NULL.
  *
  * Return: true if the load was initiated, if not the waiter will be notified.
  */
 bool vdo_start_loading(struct admin_state *state,
 		       const struct admin_state_code *operation,
-		       struct vdo_completion *waiter, vdo_admin_initiator *initiator)
+		       struct vdo_completion *waiter, vdo_admin_initiator_fn initiator)
 {
 	return (vdo_assert_load_operation(operation, waiter) &&
 		start_operation(state, operation, waiter, initiator));
@@ -429,13 +429,13 @@ static bool __must_check assert_vdo_resume_operation(const struct admin_state_co
  * vdo_start_resuming() - Initiate a resume operation if the current state permits it.
  * @operation The type of resume to start.
  * @waiter The completion to notify when the resume is complete (may be NULL).
- * @initiator The vdo_admin_initiator to call if the operation may begin; may be NULL.
+ * @initiator The vdo_admin_initiator_fn to call if the operation may begin; may be NULL.
  *
  * Return: true if the resume was initiated, if not the waiter will be notified.
  */
 bool vdo_start_resuming(struct admin_state *state,
 			const struct admin_state_code *operation,
-			struct vdo_completion *waiter, vdo_admin_initiator *initiator)
+			struct vdo_completion *waiter, vdo_admin_initiator_fn initiator)
 {
 	return (assert_vdo_resume_operation(operation, waiter) &&
 		start_operation(state, operation, waiter, initiator));
@@ -491,14 +491,14 @@ int vdo_start_operation(struct admin_state *state,
 /**
  * vdo_start_operation_with_waiter() - Attempt to start an operation.
  * @waiter the completion to notify when the operation completes or fails to start; may be NULL.
- * @initiator The vdo_admin_initiator to call if the operation may begin; may be NULL.
+ * @initiator The vdo_admin_initiator_fn to call if the operation may begin; may be NULL.
  *
  * Return: VDO_SUCCESS if the operation was started, VDO_INVALID_ADMIN_STATE if not
  */
 int vdo_start_operation_with_waiter(struct admin_state *state,
 				    const struct admin_state_code *operation,
 				    struct vdo_completion *waiter,
-				    vdo_admin_initiator *initiator)
+				    vdo_admin_initiator_fn initiator)
 {
 	return (check_code(operation->operating, operation, "operation", waiter) ?
 		begin_operation(state, operation, waiter, initiator) :

--- a/drivers/md/dm-vdo/admin-state.c
+++ b/drivers/md/dm-vdo/admin-state.c
@@ -165,10 +165,11 @@ get_next_state(const struct admin_state *state, const struct admin_state_code *o
 	if (operation == VDO_ADMIN_STATE_SAVING)
 		return (code == VDO_ADMIN_STATE_NORMAL_OPERATION ? VDO_ADMIN_STATE_SAVED : NULL);
 
-	if (operation == VDO_ADMIN_STATE_SUSPENDING)
+	if (operation == VDO_ADMIN_STATE_SUSPENDING) {
 		return (code == VDO_ADMIN_STATE_NORMAL_OPERATION
 			? VDO_ADMIN_STATE_SUSPENDED
 			: NULL);
+	}
 
 	if (operation == VDO_ADMIN_STATE_STOPPING)
 		return (code == VDO_ADMIN_STATE_NORMAL_OPERATION ? VDO_ADMIN_STATE_STOPPED : NULL);
@@ -176,9 +177,10 @@ get_next_state(const struct admin_state *state, const struct admin_state_code *o
 	if (operation == VDO_ADMIN_STATE_PRE_LOADING)
 		return (code == VDO_ADMIN_STATE_INITIALIZED ? VDO_ADMIN_STATE_PRE_LOADED : NULL);
 
-	if (operation == VDO_ADMIN_STATE_SUSPENDED_OPERATION)
+	if (operation == VDO_ADMIN_STATE_SUSPENDED_OPERATION) {
 		return (((code == VDO_ADMIN_STATE_SUSPENDED) ||
 			 (code == VDO_ADMIN_STATE_SAVED)) ? code : NULL);
+	}
 
 	return VDO_ADMIN_STATE_NORMAL_OPERATION;
 }

--- a/drivers/md/dm-vdo/admin-state.c
+++ b/drivers/md/dm-vdo/admin-state.c
@@ -154,8 +154,8 @@ const struct admin_state_code *VDO_ADMIN_STATE_RESUMING = &VDO_CODE_RESUMING;
  * Return: The state to set when the operation completes or NULL if the operation can not be
  *         started in the current state.
  */
-static const struct admin_state_code *
-get_next_state(const struct admin_state *state, const struct admin_state_code *operation)
+static const struct admin_state_code *get_next_state(const struct admin_state *state,
+						     const struct admin_state_code *operation)
 {
 	const struct admin_state_code *code = vdo_get_admin_state_code(state);
 
@@ -283,9 +283,7 @@ static inline bool __must_check start_operation(struct admin_state *state,
  *
  * Return: The result of the check.
  */
-static bool check_code(bool valid,
-		       const struct admin_state_code *code,
-		       const char *what,
+static bool check_code(bool valid, const struct admin_state_code *code, const char *what,
 		       struct vdo_completion *waiter)
 {
 	int result;
@@ -307,8 +305,8 @@ static bool check_code(bool valid,
  *
  * Return: true if the specified operation is a drain.
  */
-static bool __must_check
-assert_vdo_drain_operation(const struct admin_state_code *operation, struct vdo_completion *waiter)
+static bool __must_check assert_vdo_drain_operation(const struct admin_state_code *operation,
+						    struct vdo_completion *waiter)
 {
 	return check_code(operation->draining, operation, "drain operation", waiter);
 }
@@ -323,8 +321,7 @@ assert_vdo_drain_operation(const struct admin_state_code *operation, struct vdo_
  */
 bool vdo_start_draining(struct admin_state *state,
 			const struct admin_state_code *operation,
-			struct vdo_completion *waiter,
-			vdo_admin_initiator *initiator)
+			struct vdo_completion *waiter, vdo_admin_initiator *initiator)
 {
 	const struct admin_state_code *code = vdo_get_admin_state_code(state);
 
@@ -337,10 +334,8 @@ bool vdo_start_draining(struct admin_state *state,
 	}
 
 	if (!code->normal) {
-		uds_log_error_strerror(VDO_INVALID_ADMIN_STATE,
-				       "can't start %s from %s",
-				       operation->name,
-				       code->name);
+		uds_log_error_strerror(VDO_INVALID_ADMIN_STATE, "can't start %s from %s",
+				       operation->name, code->name);
 		vdo_continue_completion(waiter, VDO_INVALID_ADMIN_STATE);
 		return false;
 	}
@@ -390,8 +385,7 @@ bool vdo_assert_load_operation(const struct admin_state_code *operation,
  */
 bool vdo_start_loading(struct admin_state *state,
 		       const struct admin_state_code *operation,
-		       struct vdo_completion *waiter,
-		       vdo_admin_initiator *initiator)
+		       struct vdo_completion *waiter, vdo_admin_initiator *initiator)
 {
 	return (vdo_assert_load_operation(operation, waiter) &&
 		start_operation(state, operation, waiter, initiator));
@@ -427,10 +421,8 @@ bool vdo_finish_loading_with_result(struct admin_state *state, int result)
 static bool __must_check assert_vdo_resume_operation(const struct admin_state_code *operation,
 						     struct vdo_completion *waiter)
 {
-	return check_code(operation == VDO_ADMIN_STATE_RESUMING,
-			  operation,
-			  "resume operation",
-			  waiter);
+	return check_code(operation == VDO_ADMIN_STATE_RESUMING, operation,
+			  "resume operation", waiter);
 }
 
 /**
@@ -443,8 +435,7 @@ static bool __must_check assert_vdo_resume_operation(const struct admin_state_co
  */
 bool vdo_start_resuming(struct admin_state *state,
 			const struct admin_state_code *operation,
-			struct vdo_completion *waiter,
-			vdo_admin_initiator *initiator)
+			struct vdo_completion *waiter, vdo_admin_initiator *initiator)
 {
 	return (assert_vdo_resume_operation(operation, waiter) &&
 		start_operation(state, operation, waiter, initiator));
@@ -491,7 +482,8 @@ int vdo_resume_if_quiescent(struct admin_state *state)
  *
  * Return: VDO_SUCCESS if the operation was started, VDO_INVALID_ADMIN_STATE if not
  */
-int vdo_start_operation(struct admin_state *state, const struct admin_state_code *operation)
+int vdo_start_operation(struct admin_state *state,
+			const struct admin_state_code *operation)
 {
 	return vdo_start_operation_with_waiter(state, operation, NULL, NULL);
 }

--- a/drivers/md/dm-vdo/admin-state.h
+++ b/drivers/md/dm-vdo/admin-state.h
@@ -62,9 +62,9 @@ struct admin_state {
 };
 
 /**
- * typedef vdo_admin_initiator - A method to be called once an admin operation may be initiated.
+ * typedef vdo_admin_initiator_fn - A method to be called once an admin operation may be initiated.
  */
-typedef void vdo_admin_initiator(struct admin_state *state);
+typedef void (*vdo_admin_initiator_fn)(struct admin_state *state);
 
 static inline const struct admin_state_code * __must_check
 vdo_get_admin_state_code(const struct admin_state *state)
@@ -141,7 +141,7 @@ bool __must_check vdo_assert_load_operation(const struct admin_state_code *opera
 
 bool vdo_start_loading(struct admin_state *state,
 		       const struct admin_state_code *operation,
-		       struct vdo_completion *waiter, vdo_admin_initiator *initiator);
+		       struct vdo_completion *waiter, vdo_admin_initiator_fn initiator);
 
 bool vdo_finish_loading(struct admin_state *state);
 
@@ -149,7 +149,7 @@ bool vdo_finish_loading_with_result(struct admin_state *state, int result);
 
 bool vdo_start_resuming(struct admin_state *state,
 			const struct admin_state_code *operation,
-			struct vdo_completion *waiter, vdo_admin_initiator *initiator);
+			struct vdo_completion *waiter, vdo_admin_initiator_fn initiator);
 
 bool vdo_finish_resuming(struct admin_state *state);
 
@@ -159,7 +159,7 @@ int vdo_resume_if_quiescent(struct admin_state *state);
 
 bool vdo_start_draining(struct admin_state *state,
 			const struct admin_state_code *operation,
-			struct vdo_completion *waiter, vdo_admin_initiator *initiator);
+			struct vdo_completion *waiter, vdo_admin_initiator_fn initiator);
 
 bool vdo_finish_draining(struct admin_state *state);
 
@@ -171,7 +171,7 @@ int vdo_start_operation(struct admin_state *state,
 int vdo_start_operation_with_waiter(struct admin_state *state,
 				    const struct admin_state_code *operation,
 				    struct vdo_completion *waiter,
-				    vdo_admin_initiator *initiator);
+				    vdo_admin_initiator_fn initiator);
 
 bool vdo_finish_operation(struct admin_state *state, int result);
 

--- a/drivers/md/dm-vdo/admin-state.h
+++ b/drivers/md/dm-vdo/admin-state.h
@@ -78,8 +78,8 @@ vdo_get_admin_state_code(const struct admin_state *state)
  * This function should be used primarily for initialization and by adminState internals. Most uses
  * should go through the operation interfaces.
  */
-static inline void
-vdo_set_admin_state_code(struct admin_state *state, const struct admin_state_code *code)
+static inline void vdo_set_admin_state_code(struct admin_state *state,
+					    const struct admin_state_code *code)
 {
 	WRITE_ONCE(state->current_state, code);
 }
@@ -136,13 +136,12 @@ static inline bool __must_check vdo_is_state_quiescent(const struct admin_state 
 	return vdo_get_admin_state_code(state)->quiescent;
 }
 
-bool __must_check
-vdo_assert_load_operation(const struct admin_state_code *operation, struct vdo_completion *waiter);
+bool __must_check vdo_assert_load_operation(const struct admin_state_code *operation,
+					    struct vdo_completion *waiter);
 
 bool vdo_start_loading(struct admin_state *state,
 		       const struct admin_state_code *operation,
-		       struct vdo_completion *waiter,
-		       vdo_admin_initiator *initiator);
+		       struct vdo_completion *waiter, vdo_admin_initiator *initiator);
 
 bool vdo_finish_loading(struct admin_state *state);
 
@@ -150,8 +149,7 @@ bool vdo_finish_loading_with_result(struct admin_state *state, int result);
 
 bool vdo_start_resuming(struct admin_state *state,
 			const struct admin_state_code *operation,
-			struct vdo_completion *waiter,
-			vdo_admin_initiator *initiator);
+			struct vdo_completion *waiter, vdo_admin_initiator *initiator);
 
 bool vdo_finish_resuming(struct admin_state *state);
 
@@ -161,14 +159,14 @@ int vdo_resume_if_quiescent(struct admin_state *state);
 
 bool vdo_start_draining(struct admin_state *state,
 			const struct admin_state_code *operation,
-			struct vdo_completion *waiter,
-			vdo_admin_initiator *initiator);
+			struct vdo_completion *waiter, vdo_admin_initiator *initiator);
 
 bool vdo_finish_draining(struct admin_state *state);
 
 bool vdo_finish_draining_with_result(struct admin_state *state, int result);
 
-int vdo_start_operation(struct admin_state *state, const struct admin_state_code *operation);
+int vdo_start_operation(struct admin_state *state,
+			const struct admin_state_code *operation);
 
 int vdo_start_operation_with_waiter(struct admin_state *state,
 				    const struct admin_state_code *operation,

--- a/drivers/md/dm-vdo/block-map.c
+++ b/drivers/md/dm-vdo/block-map.c
@@ -97,7 +97,7 @@ struct cursor {
 struct cursors {
 	struct block_map_zone *zone;
 	struct vio_pool *pool;
-	vdo_entry_callback *entry_callback;
+	vdo_entry_callback_fn entry_callback;
 	struct vdo_completion *parent;
 	root_count_t active_roots;
 	struct cursor cursors[];
@@ -504,7 +504,7 @@ static void complete_with_page(struct page_info *info,
  * @waiter: The page completion, as a waiter.
  * @result_ptr: A pointer to the error code.
  *
- * Implements waiter_callback.
+ * Implements waiter_callback_fn.
  */
 static void complete_waiter_with_error(struct waiter *waiter, void *result_ptr)
 {
@@ -518,7 +518,7 @@ static void complete_waiter_with_error(struct waiter *waiter, void *result_ptr)
  * @waiter: The page completion, as a waiter.
  * @page_info: The page info to complete with.
  *
- * Implements waiter_callback.
+ * Implements waiter_callback_fn.
  */
 static void complete_waiter_with_page(struct waiter *waiter, void *page_info)
 {
@@ -769,7 +769,7 @@ static int __must_check launch_page_load(struct page_info *info,
 					 physical_block_number_t pbn)
 {
 	int result;
-	vdo_action *callback;
+	vdo_action_fn callback;
 	struct vdo_page_cache *cache = info->cache;
 
 	assert_io_allowed(cache);
@@ -786,8 +786,8 @@ static int __must_check launch_page_load(struct page_info *info,
 	cache->outstanding_reads++;
 	ADD_ONCE(cache->stats.pages_loaded, 1);
 	callback = (cache->rebuilding ? handle_rebuild_read_error : handle_load_error);
-	submit_metadata_vio(info->vio, pbn, load_cache_page_endio,
-			    callback, REQ_OP_READ | REQ_PRIO);
+	submit_metadata_vio(info->vio, pbn, load_cache_page_endio, callback,
+			    REQ_OP_READ | REQ_PRIO);
 	return VDO_SUCCESS;
 }
 
@@ -870,7 +870,7 @@ static void launch_page_save(struct page_info *info)
  *                           requesting a given page number.
  * @context: A pointer to the pbn of the desired page.
  *
- * Implements waiter_match.
+ * Implements waiter_match_fn.
  *
  * Return: true if the page completion is for the desired page number.
  */
@@ -1055,8 +1055,7 @@ static void page_is_written_out(struct vdo_completion *completion)
 
 	if (!page->header.initialized) {
 		page->header.initialized = true;
-		submit_metadata_vio(info->vio, info->pbn,
-				    write_cache_page_endio,
+		submit_metadata_vio(info->vio, info->pbn, write_cache_page_endio,
 				    handle_page_write_error,
 				    (REQ_OP_WRITE | REQ_PRIO | REQ_PREFLUSH));
 		return;
@@ -1211,8 +1210,8 @@ static void load_page_for_completion(struct page_info *info,
  */
 void vdo_get_page(struct vdo_page_completion *page_completion,
 		  struct block_map_zone *zone, physical_block_number_t pbn,
-		  bool writable, void *parent, vdo_action *callback,
-		  vdo_action *error_handler, bool requeue)
+		  bool writable, void *parent, vdo_action_fn callback,
+		  vdo_action_fn error_handler, bool requeue)
 {
 	struct vdo_page_cache *cache = &zone->page_cache;
 	struct vdo_completion *completion = &page_completion->completion;
@@ -1497,7 +1496,7 @@ static void set_generation(struct block_map_zone *zone, struct tree_page *page,
 
 static void write_page(struct tree_page *tree_page, struct pooled_vio *vio);
 
-/* Implements waiter_callback */
+/* Implements waiter_callback_fn */
 static void write_page_callback(struct waiter *waiter, void *context)
 {
 	write_page(container_of(waiter, struct tree_page, waiter), context);
@@ -1576,8 +1575,8 @@ static void finish_page_write(struct vdo_completion *completion)
 			.generation = page->writing_generation,
 		};
 
-		vdo_notify_all_waiters(&zone->flush_waiters,
-				       write_page_if_not_dirtied, &context);
+		vdo_notify_all_waiters(&zone->flush_waiters, write_page_if_not_dirtied,
+				       &context);
 		if (dirty && attempt_increment(zone)) {
 			write_page(page, pooled);
 			return;
@@ -1588,11 +1587,11 @@ static void finish_page_write(struct vdo_completion *completion)
 
 	if (dirty) {
 		enqueue_page(page, zone);
-	} else if ((zone->flusher == NULL) && vdo_has_waiters(&zone->flush_waiters) &&
+	} else if ((zone->flusher == NULL) &&
+		   vdo_has_waiters(&zone->flush_waiters) &&
 		   attempt_increment(zone)) {
-		zone->flusher =
-			container_of(vdo_dequeue_next_waiter(&zone->flush_waiters),
-				     struct tree_page, waiter);
+		zone->flusher = container_of(vdo_dequeue_next_waiter(&zone->flush_waiters),
+					     struct tree_page, waiter);
 		write_page(zone->flusher, pooled);
 		return;
 	}
@@ -1632,9 +1631,8 @@ static void write_initialized_page(struct vdo_completion *completion)
 	if (zone->flusher == tree_page)
 		operation |= REQ_PREFLUSH;
 
-	submit_metadata_vio(vio, vdo_get_block_map_page_pbn(page),
-			    write_page_endio, handle_write_error,
-			    operation);
+	submit_metadata_vio(vio, vdo_get_block_map_page_pbn(page), write_page_endio,
+			    handle_write_error, operation);
 }
 
 static void write_page_endio(struct bio *bio)
@@ -1879,8 +1877,8 @@ static void load_page(struct waiter *waiter, void *context)
 	physical_block_number_t pbn = lock->tree_slots[lock->height - 1].block_map_slot.pbn;
 
 	pooled->vio.completion.parent = data_vio;
-	submit_metadata_vio(&pooled->vio, pbn, load_page_endio,
-			    handle_io_error, REQ_OP_READ | REQ_PRIO);
+	submit_metadata_vio(&pooled->vio, pbn, load_page_endio, handle_io_error,
+			    REQ_OP_READ | REQ_PRIO);
 }
 
 /*
@@ -1904,8 +1902,8 @@ static int attempt_page_lock(struct block_map_zone *zone, struct data_vio *data_
 	};
 	lock->key = key.key;
 
-	result = vdo_int_map_put(zone->loading_pages, lock->key,
-				 lock, false, (void **) &lock_holder);
+	result = vdo_int_map_put(zone->loading_pages, lock->key, lock, false,
+				 (void **) &lock_holder);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -2628,7 +2626,7 @@ static void traverse(struct cursor *cursor)
  *                   which to load pages.
  * @context: The pooled_vio just acquired.
  *
- * Implements waiter_callback.
+ * Implements waiter_callback_fn.
  */
 static void launch_cursor(struct waiter *waiter, void *context)
 {
@@ -2678,7 +2676,7 @@ static struct boundary compute_boundary(struct block_map *map, root_count_t root
  * @callback: A function to call with the pbn of each allocated node in the forest.
  * @parent: The completion to notify on each traversed PBN, and when the traversal is complete.
  */
-void vdo_traverse_forest(struct block_map *map, vdo_entry_callback *callback,
+void vdo_traverse_forest(struct block_map *map, vdo_entry_callback_fn callback,
 			 struct vdo_completion *parent)
 {
 	root_count_t root;
@@ -2776,7 +2774,7 @@ static int __must_check initialize_block_map_zone(struct block_map *map,
 	return VDO_SUCCESS;
 }
 
-/* Implements vdo_zone_thread_getter */
+/* Implements vdo_zone_thread_getter_fn */
 static thread_id_t get_block_map_zone_thread_id(void *context, zone_count_t zone_number)
 {
 	struct block_map *map = context;
@@ -2784,7 +2782,7 @@ static thread_id_t get_block_map_zone_thread_id(void *context, zone_count_t zone
 	return map->zones[zone_number].thread_id;
 }
 
-/* Implements vdo_action_preamble */
+/* Implements vdo_action_preamble_fn */
 static void prepare_for_era_advance(void *context, struct vdo_completion *parent)
 {
 	struct block_map *map = context;
@@ -2793,7 +2791,7 @@ static void prepare_for_era_advance(void *context, struct vdo_completion *parent
 	vdo_finish_completion(parent);
 }
 
-/* Implements vdo_zone_action */
+/* Implements vdo_zone_action_fn */
 static void advance_block_map_zone_era(void *context, zone_count_t zone_number,
 				       struct vdo_completion *parent)
 {
@@ -2809,7 +2807,7 @@ static void advance_block_map_zone_era(void *context, zone_count_t zone_number,
  * Schedule an era advance if necessary. This method should not be called directly. Rather, call
  * vdo_schedule_default_action() on the block map's action manager.
  *
- * Implements vdo_action_scheduler.
+ * Implements vdo_action_scheduler_fn.
  */
 static bool schedule_era_advance(void *context)
 {
@@ -2971,7 +2969,7 @@ void vdo_advance_block_map_era(struct block_map *map,
 	vdo_schedule_default_action(map->action_manager);
 }
 
-/* Implements vdo_admin_initiator */
+/* Implements vdo_admin_initiator_fn */
 static void initiate_drain(struct admin_state *state)
 {
 	struct block_map_zone *zone = container_of(state, struct block_map_zone, state);
@@ -2988,7 +2986,7 @@ static void initiate_drain(struct admin_state *state)
 	check_for_drain_complete(zone);
 }
 
-/* Implements vdo_zone_action. */
+/* Implements vdo_zone_action_fn. */
 static void drain_zone(void *context, zone_count_t zone_number,
 		       struct vdo_completion *parent)
 {
@@ -3007,7 +3005,7 @@ void vdo_drain_block_map(struct block_map *map, const struct admin_state_code *o
 			       parent);
 }
 
-/* Implements vdo_zone_action. */
+/* Implements vdo_zone_action_fn. */
 static void resume_block_map_zone(void *context, zone_count_t zone_number,
 				  struct vdo_completion *parent)
 {
@@ -3041,7 +3039,7 @@ int vdo_prepare_to_grow_block_map(struct block_map *map,
 	return make_forest(map, new_logical_blocks);
 }
 
-/* Implements vdo_action_preamble */
+/* Implements vdo_action_preamble_fn */
 static void grow_forest(void *context, struct vdo_completion *completion)
 {
 	replace_forest(context);
@@ -3082,7 +3080,7 @@ static void handle_page_error(struct vdo_completion *completion)
 
 /* Fetch the mapping page for a block map update, and call the provided handler when fetched. */
 static void fetch_mapping_page(struct data_vio *data_vio, bool modifiable,
-			       vdo_action *action)
+			       vdo_action_fn action)
 {
 	struct block_map_zone *zone = data_vio->logical.zone->block_map_zone;
 

--- a/drivers/md/dm-vdo/block-map.c
+++ b/drivers/md/dm-vdo/block-map.c
@@ -191,11 +191,9 @@ static int initialize_info(struct vdo_page_cache *cache)
 		info->state = PS_FREE;
 		info->pbn = NO_PAGE;
 
-		result = create_metadata_vio(cache->vdo,
-					     VIO_TYPE_BLOCK_MAP,
+		result = create_metadata_vio(cache->vdo, VIO_TYPE_BLOCK_MAP,
 					     VIO_PRIORITY_METADATA, info,
-					     get_page_buffer(info),
-					     &info->vio);
+					     get_page_buffer(info), &info->vio);
 		if (result != VDO_SUCCESS)
 			return result;
 
@@ -225,7 +223,8 @@ static int __must_check allocate_cache_components(struct vdo_page_cache *cache)
 	u64 size = cache->page_count * (u64) VDO_BLOCK_SIZE;
 	int result;
 
-	result = uds_allocate(cache->page_count, struct page_info, "page infos", &cache->infos);
+	result = uds_allocate(cache->page_count, struct page_info, "page infos",
+			      &cache->infos);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -244,15 +243,14 @@ static int __must_check allocate_cache_components(struct vdo_page_cache *cache)
  * assert_on_cache_thread() - Assert that a function has been called on the VDO page cache's
  *                            thread.
  */
-static inline void assert_on_cache_thread(struct vdo_page_cache *cache, const char *function_name)
+static inline void assert_on_cache_thread(struct vdo_page_cache *cache,
+					  const char *function_name)
 {
 	thread_id_t thread_id = vdo_get_callback_thread_id();
 
 	ASSERT_LOG_ONLY((thread_id == cache->zone->thread_id),
 			"%s() must only be called on cache thread %d, not thread %d",
-			function_name,
-			cache->zone->thread_id,
-			thread_id);
+			function_name, cache->zone->thread_id, thread_id);
 }
 
 /** assert_io_allowed() - Assert that a page cache may issue I/O. */
@@ -291,7 +289,8 @@ static const char * __must_check get_page_state_name(enum vdo_page_buffer_state 
 
 	BUILD_BUG_ON(ARRAY_SIZE(state_names) != PAGE_STATE_COUNT);
 
-	result = ASSERT(state < ARRAY_SIZE(state_names), "Unknown page_state value %d", state);
+	result = ASSERT(state < ARRAY_SIZE(state_names),
+			"Unknown page_state value %d", state);
 	if (result != UDS_SUCCESS)
 		return "[UNKNOWN PAGE STATE]";
 
@@ -348,8 +347,7 @@ static void update_lru(struct page_info *info)
  * set_info_state() - Set the state of a page_info and put it on the right list, adjusting
  *                    counters.
  */
-static void
-set_info_state(struct page_info *info, enum vdo_page_buffer_state new_state)
+static void set_info_state(struct page_info *info, enum vdo_page_buffer_state new_state)
 {
 	if (new_state == info->state)
 		return;
@@ -409,7 +407,8 @@ static int reset_page_info(struct page_info *info)
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = ASSERT(!vdo_has_waiters(&info->waiting), "VDO Page must not have waiters");
+	result = ASSERT(!vdo_has_waiters(&info->waiting),
+			"VDO Page must not have waiters");
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -428,7 +427,8 @@ static struct page_info * __must_check find_free_page(struct vdo_page_cache *cac
 {
 	struct page_info *info;
 
-	info = list_first_entry_or_null(&cache->free_list, struct page_info, state_entry);
+	info = list_first_entry_or_null(&cache->free_list, struct page_info,
+					state_entry);
 	if (info != NULL)
 		list_del_init(&info->state_entry);
 
@@ -441,8 +441,8 @@ static struct page_info * __must_check find_free_page(struct vdo_page_cache *cac
  *
  * Return: The page info for the page if available, or NULL if not.
  */
-static struct page_info * __must_check
-find_page(struct vdo_page_cache *cache, physical_block_number_t pbn)
+static struct page_info * __must_check find_page(struct vdo_page_cache *cache,
+						 physical_block_number_t pbn)
 {
 	if ((cache->last_found != NULL) && (cache->last_found->pbn == pbn))
 		return cache->last_found;
@@ -479,7 +479,8 @@ static struct page_info * __must_check select_lru_page(struct vdo_page_cache *ca
  * @info: The page info representing the result page.
  * @vdo_page_comp: The VDO page completion to complete.
  */
-static void complete_with_page(struct page_info *info, struct vdo_page_completion *vdo_page_comp)
+static void complete_with_page(struct page_info *info,
+			       struct vdo_page_completion *vdo_page_comp)
 {
 	bool available = vdo_page_comp->writable ? is_present(info) : is_valid(info);
 
@@ -488,8 +489,7 @@ static void complete_with_page(struct page_info *info, struct vdo_page_completio
 				       "Requested cache page %llu in state %s is not %s",
 				       (unsigned long long) info->pbn,
 				       get_page_state_name(info->state),
-				       vdo_page_comp->writable ? "present" :
-				       "valid");
+				       vdo_page_comp->writable ? "present" : "valid");
 		vdo_fail_completion(&vdo_page_comp->completion, VDO_BAD_PAGE);
 		return;
 	}
@@ -532,7 +532,8 @@ static void complete_waiter_with_page(struct waiter *waiter, void *page_info)
  *
  * Return: The number of pages distributed.
  */
-static unsigned int distribute_page_over_queue(struct page_info *info, struct wait_queue *queue)
+static unsigned int distribute_page_over_queue(struct page_info *info,
+					       struct wait_queue *queue)
 {
 	size_t pages;
 
@@ -556,24 +557,28 @@ static unsigned int distribute_page_over_queue(struct page_info *info, struct wa
  * Once triggered, all enqueued completions will get this error. Any future requests will result in
  * this error as well.
  */
-static void set_persistent_error(struct vdo_page_cache *cache, const char *context, int result)
+static void set_persistent_error(struct vdo_page_cache *cache, const char *context,
+				 int result)
 {
 	struct page_info *info;
 	/* If we're already read-only, there's no need to log. */
 	struct vdo *vdo = cache->zone->block_map->vdo;
 
 	if ((result != VDO_READ_ONLY) && !vdo_is_read_only(vdo)) {
-		uds_log_error_strerror(result, "VDO Page Cache persistent error: %s", context);
+		uds_log_error_strerror(result, "VDO Page Cache persistent error: %s",
+				       context);
 		vdo_enter_read_only_mode(vdo, result);
 	}
 
 	assert_on_cache_thread(cache, __func__);
 
-	vdo_notify_all_waiters(&cache->free_waiters, complete_waiter_with_error, &result);
+	vdo_notify_all_waiters(&cache->free_waiters, complete_waiter_with_error,
+			       &result);
 	cache->waiter_count = 0;
 
 	for (info = cache->infos; info < cache->infos + cache->page_count; info++)
-		vdo_notify_all_waiters(&info->waiting, complete_waiter_with_error, &result);
+		vdo_notify_all_waiters(&info->waiting, complete_waiter_with_error,
+				       &result);
 }
 
 /**
@@ -583,8 +588,8 @@ static void set_persistent_error(struct vdo_page_cache *cache, const char *conte
  *
  * Return: VDO_SUCCESS if the page was valid, otherwise as error
  */
-static int __must_check
-validate_completed_page(struct vdo_page_completion *completion, bool writable)
+static int __must_check validate_completed_page(struct vdo_page_completion *completion,
+						bool writable)
 {
 	int result;
 
@@ -592,7 +597,8 @@ validate_completed_page(struct vdo_page_completion *completion, bool writable)
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = ASSERT(completion->info != NULL, "VDO Page Completion must be complete");
+	result = ASSERT(completion->info != NULL,
+			"VDO Page Completion must be complete");
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -601,7 +607,8 @@ validate_completed_page(struct vdo_page_completion *completion, bool writable)
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = ASSERT(is_valid(completion->info), "VDO Page Completion page must be valid");
+	result = ASSERT(is_valid(completion->info),
+			"VDO Page Completion page must be valid");
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -758,7 +765,8 @@ static void load_cache_page_endio(struct bio *bio)
  *
  * Return: VDO_SUCCESS or an error code.
  */
-static int __must_check launch_page_load(struct page_info *info, physical_block_number_t pbn)
+static int __must_check launch_page_load(struct page_info *info,
+					 physical_block_number_t pbn)
 {
 	int result;
 	vdo_action *callback;
@@ -778,11 +786,8 @@ static int __must_check launch_page_load(struct page_info *info, physical_block_
 	cache->outstanding_reads++;
 	ADD_ONCE(cache->stats.pages_loaded, 1);
 	callback = (cache->rebuilding ? handle_rebuild_read_error : handle_load_error);
-	submit_metadata_vio(info->vio,
-			    pbn,
-			    load_cache_page_endio,
-			    callback,
-			    REQ_OP_READ | REQ_PRIO);
+	submit_metadata_vio(info->vio, pbn, load_cache_page_endio,
+			    callback, REQ_OP_READ | REQ_PRIO);
 	return VDO_SUCCESS;
 }
 
@@ -911,10 +916,8 @@ static void allocate_free_page(struct page_info *info)
 	 * Remove all entries which match the page number in question and push them onto the page
 	 * info's wait queue.
 	 */
-	vdo_dequeue_matching_waiters(&cache->free_waiters,
-				     completion_needs_page,
-				     &pbn,
-				     &info->waiting);
+	vdo_dequeue_matching_waiters(&cache->free_waiters, completion_needs_page,
+				     &pbn, &info->waiting);
 	cache->waiter_count -= vdo_count_waiters(&info->waiting);
 
 	result = launch_page_load(info, pbn);
@@ -946,7 +949,8 @@ static void discard_a_page(struct vdo_page_cache *cache)
 		return;
 	}
 
-	ASSERT_LOG_ONLY(!is_in_flight(info), "page selected for discard is not in flight");
+	ASSERT_LOG_ONLY(!is_in_flight(info),
+			"page selected for discard is not in flight");
 
 	cache->discard_count++;
 	info->write_status = WRITE_STATUS_DISCARD;
@@ -1008,8 +1012,7 @@ static void handle_page_write_error(struct vdo_completion *completion)
 
 	/* If we're already read-only, write failures are to be expected. */
 	if (result != VDO_READ_ONLY) {
-		static DEFINE_RATELIMIT_STATE(error_limiter,
-					      DEFAULT_RATELIMIT_INTERVAL,
+		static DEFINE_RATELIMIT_STATE(error_limiter, DEFAULT_RATELIMIT_INTERVAL,
 					      DEFAULT_RATELIMIT_BURST);
 
 		if (__ratelimit(&error_limiter)) {
@@ -1052,8 +1055,7 @@ static void page_is_written_out(struct vdo_completion *completion)
 
 	if (!page->header.initialized) {
 		page->header.initialized = true;
-		submit_metadata_vio(info->vio,
-				    info->pbn,
+		submit_metadata_vio(info->vio, info->pbn,
 				    write_cache_page_endio,
 				    handle_page_write_error,
 				    (REQ_OP_WRITE | REQ_PRIO | REQ_PREFLUSH));
@@ -1107,7 +1109,8 @@ static void write_pages(struct vdo_completion *flush_completion)
 	cache->pages_in_flush = 0;
 	while (pages_in_flush-- > 0) {
 		struct page_info *info =
-			list_first_entry(&cache->outgoing_list, struct page_info, state_entry);
+			list_first_entry(&cache->outgoing_list, struct page_info,
+					 state_entry);
 
 		list_del_init(&info->state_entry);
 		if (vdo_is_read_only(info->cache->zone->block_map->vdo)) {
@@ -1120,11 +1123,8 @@ static void write_pages(struct vdo_completion *flush_completion)
 			continue;
 		}
 		ADD_ONCE(info->cache->stats.pages_saved, 1);
-		submit_metadata_vio(info->vio,
-				    info->pbn,
-				    write_cache_page_endio,
-				    handle_page_write_error,
-				    REQ_OP_WRITE | REQ_PRIO);
+		submit_metadata_vio(info->vio, info->pbn, write_cache_page_endio,
+				    handle_page_write_error, REQ_OP_WRITE | REQ_PRIO);
 	}
 
 	if (has_unflushed_pages) {
@@ -1182,8 +1182,8 @@ void vdo_release_page_completion(struct vdo_completion *completion)
  * load_page_for_completion() - Helper function to load a page as described by a VDO Page
  *                              Completion.
  */
-static void
-load_page_for_completion(struct page_info *info, struct vdo_page_completion *vdo_page_comp)
+static void load_page_for_completion(struct page_info *info,
+				     struct vdo_page_completion *vdo_page_comp)
 {
 	int result;
 
@@ -1210,13 +1210,9 @@ load_page_for_completion(struct page_info *info, struct vdo_page_completion *vdo
  * when they are done with the page to clear the busy mark.
  */
 void vdo_get_page(struct vdo_page_completion *page_completion,
-		  struct block_map_zone *zone,
-		  physical_block_number_t pbn,
-		  bool writable,
-		  void *parent,
-		  vdo_action *callback,
-		  vdo_action *error_handler,
-		  bool requeue)
+		  struct block_map_zone *zone, physical_block_number_t pbn,
+		  bool writable, void *parent, vdo_action *callback,
+		  vdo_action *error_handler, bool requeue)
 {
 	struct vdo_page_cache *cache = &zone->page_cache;
 	struct vdo_completion *completion = &page_completion->completion;
@@ -1233,11 +1229,8 @@ void vdo_get_page(struct vdo_page_completion *page_completion,
 	};
 
 	vdo_initialize_completion(completion, cache->vdo, VDO_PAGE_COMPLETION);
-	vdo_prepare_completion(completion,
-			       callback,
-			       error_handler,
-			       cache->zone->thread_id,
-			       parent);
+	vdo_prepare_completion(completion, callback, error_handler,
+			       cache->zone->thread_id, parent);
 	completion->requeue = requeue;
 
 	if (page_completion->writable && vdo_is_read_only(cache->zone->block_map->vdo)) {
@@ -1314,7 +1307,8 @@ void vdo_request_page_write(struct vdo_completion *completion)
  *
  * Return: VDO_SUCCESS or an error
  */
-int vdo_get_cached_page(struct vdo_completion *completion, struct block_map_page **page_ptr)
+int vdo_get_cached_page(struct vdo_completion *completion,
+			struct block_map_page **page_ptr)
 {
 	int result;
 	struct vdo_page_completion *vpc;
@@ -1358,11 +1352,10 @@ int vdo_invalidate_page_cache(struct vdo_page_cache *cache)
  *
  * Return: The requested page.
  */
-static struct tree_page * __must_check
-get_tree_page_by_index(struct forest *forest,
-		       root_count_t root_index,
-		       height_t height,
-		       page_number_t page_index)
+static struct tree_page * __must_check get_tree_page_by_index(struct forest *forest,
+							      root_count_t root_index,
+							      height_t height,
+							      page_number_t page_index)
 {
 	page_number_t offset = 0;
 	size_t segment;
@@ -1383,18 +1376,16 @@ get_tree_page_by_index(struct forest *forest,
 }
 
 /* Get the page referred to by the lock's tree slot at its current height. */
-static inline struct tree_page *
-get_tree_page(const struct block_map_zone *zone, const struct tree_lock *lock)
+static inline struct tree_page *get_tree_page(const struct block_map_zone *zone,
+					      const struct tree_lock *lock)
 {
-	return get_tree_page_by_index(zone->block_map->forest,
-				      lock->root_index,
+	return get_tree_page_by_index(zone->block_map->forest, lock->root_index,
 				      lock->height,
 				      lock->tree_slots[lock->height].page_index);
 }
 
 /** vdo_copy_valid_page() - Validate and copy a buffer to a page. */
-bool vdo_copy_valid_page(char *buffer,
-			 nonce_t nonce,
+bool vdo_copy_valid_page(char *buffer, nonce_t nonce,
 			 physical_block_number_t pbn,
 			 struct block_map_page *page)
 {
@@ -1468,8 +1459,7 @@ static void release_generation(struct block_map_zone *zone, u8 generation)
 	int result;
 
 	result = ASSERT((zone->dirty_page_counts[generation] > 0),
-			"dirty page count underflow for generation %u",
-			generation);
+			"dirty page count underflow for generation %u", generation);
 	if (result != VDO_SUCCESS) {
 		enter_zone_read_only_mode(zone, result);
 		return;
@@ -1481,8 +1471,8 @@ static void release_generation(struct block_map_zone *zone, u8 generation)
 		zone->oldest_generation++;
 }
 
-static void
-set_generation(struct block_map_zone *zone, struct tree_page *page, u8 new_generation)
+static void set_generation(struct block_map_zone *zone, struct tree_page *page,
+			   u8 new_generation)
 {
 	u32 new_count;
 	int result;
@@ -1494,8 +1484,7 @@ set_generation(struct block_map_zone *zone, struct tree_page *page, u8 new_gener
 
 	page->generation = new_generation;
 	new_count = ++zone->dirty_page_counts[new_generation];
-	result = ASSERT((new_count != 0),
-			"dirty page count overflow for generation %u",
+	result = ASSERT((new_count != 0), "dirty page count overflow for generation %u",
 			new_generation);
 	if (result != VDO_SUCCESS) {
 		enter_zone_read_only_mode(zone, result);
@@ -1587,7 +1576,8 @@ static void finish_page_write(struct vdo_completion *completion)
 			.generation = page->writing_generation,
 		};
 
-		vdo_notify_all_waiters(&zone->flush_waiters, write_page_if_not_dirtied, &context);
+		vdo_notify_all_waiters(&zone->flush_waiters,
+				       write_page_if_not_dirtied, &context);
 		if (dirty && attempt_increment(zone)) {
 			write_page(page, pooled);
 			return;
@@ -1598,12 +1588,11 @@ static void finish_page_write(struct vdo_completion *completion)
 
 	if (dirty) {
 		enqueue_page(page, zone);
-	} else if ((zone->flusher == NULL) &&
-		   vdo_has_waiters(&zone->flush_waiters) &&
+	} else if ((zone->flusher == NULL) && vdo_has_waiters(&zone->flush_waiters) &&
 		   attempt_increment(zone)) {
-		zone->flusher = container_of(vdo_dequeue_next_waiter(&zone->flush_waiters),
-					     struct tree_page,
-					     waiter);
+		zone->flusher =
+			container_of(vdo_dequeue_next_waiter(&zone->flush_waiters),
+				     struct tree_page, waiter);
 		write_page(zone->flusher, pooled);
 		return;
 	}
@@ -1643,10 +1632,8 @@ static void write_initialized_page(struct vdo_completion *completion)
 	if (zone->flusher == tree_page)
 		operation |= REQ_PREFLUSH;
 
-	submit_metadata_vio(vio,
-			    vdo_get_block_map_page_pbn(page),
-			    write_page_endio,
-			    handle_write_error,
+	submit_metadata_vio(vio, vdo_get_block_map_page_pbn(page),
+			    write_page_endio, handle_write_error,
 			    operation);
 }
 
@@ -1658,8 +1645,7 @@ static void write_page_endio(struct bio *bio)
 
 	continue_vio_after_io(&vio->vio,
 			      (page->header.initialized ?
-			       finish_page_write :
-			       write_initialized_page),
+			       finish_page_write : write_initialized_page),
 			      zone->thread_id);
 }
 
@@ -1703,10 +1689,8 @@ static void write_page(struct tree_page *tree_page, struct pooled_vio *vio)
 	}
 
 	page->header.initialized = true;
-	submit_metadata_vio(&vio->vio,
-			    vdo_get_block_map_page_pbn(page),
-			    write_page_endio,
-			    handle_write_error,
+	submit_metadata_vio(&vio->vio, vdo_get_block_map_page_pbn(page),
+			    write_page_endio, handle_write_error,
 			    REQ_OP_WRITE | REQ_PRIO);
 }
 
@@ -1719,16 +1703,13 @@ static void release_page_lock(struct data_vio *data_vio, char *what)
 
 	ASSERT_LOG_ONLY(lock->locked,
 			"release of unlocked block map page %s for key %llu in tree %u",
-			what, (unsigned long long) lock->key,
-			lock->root_index);
+			what, (unsigned long long) lock->key, lock->root_index);
 
 	zone = data_vio->logical.zone->block_map_zone;
 	lock_holder = vdo_int_map_remove(zone->loading_pages, lock->key);
 	ASSERT_LOG_ONLY((lock_holder == lock),
 			"block map page %s mismatch for key %llu in tree %u",
-			what,
-			(unsigned long long) lock->key,
-			lock->root_index);
+			what, (unsigned long long) lock->key, lock->root_index);
 	lock->locked = false;
 }
 
@@ -1766,8 +1747,7 @@ static void abort_lookup(struct data_vio *data_vio, int result, char *what)
 	if (data_vio->tree_lock.locked) {
 		release_page_lock(data_vio, what);
 		vdo_notify_all_waiters(&data_vio->tree_lock.waiters,
-				       abort_lookup_for_waiter,
-				       &result);
+				       abort_lookup_for_waiter, &result);
 	}
 
 	finish_lookup(data_vio, result);
@@ -1778,8 +1758,9 @@ static void abort_load(struct data_vio *data_vio, int result)
 	abort_lookup(data_vio, result, "load");
 }
 
-static bool __must_check
-is_invalid_tree_entry(const struct vdo *vdo, const struct data_location *mapping, height_t height)
+static bool __must_check is_invalid_tree_entry(const struct vdo *vdo,
+					       const struct data_location *mapping,
+					       height_t height)
 {
 	if (!vdo_is_valid_location(mapping) ||
 	    vdo_is_state_compressed(mapping->state) ||
@@ -1794,9 +1775,11 @@ is_invalid_tree_entry(const struct vdo *vdo, const struct data_location *mapping
 }
 
 static void load_block_map_page(struct block_map_zone *zone, struct data_vio *data_vio);
-static void allocate_block_map_page(struct block_map_zone *zone, struct data_vio *data_vio);
+static void allocate_block_map_page(struct block_map_zone *zone,
+				    struct data_vio *data_vio);
 
-static void continue_with_loaded_page(struct data_vio *data_vio, struct block_map_page *page)
+static void continue_with_loaded_page(struct data_vio *data_vio,
+				      struct block_map_page *page)
 {
 	struct tree_lock *lock = &data_vio->tree_lock;
 	struct block_map_tree_slot slot = lock->tree_slots[lock->height];
@@ -1806,8 +1789,7 @@ static void continue_with_loaded_page(struct data_vio *data_vio, struct block_ma
 	if (is_invalid_tree_entry(vdo_from_data_vio(data_vio), &mapping, lock->height)) {
 		uds_log_error_strerror(VDO_BAD_MAPPING,
 				       "Invalid block map tree PBN: %llu with state %u for page index %u at height %u",
-				       (unsigned long long) mapping.pbn,
-				       mapping.state,
+				       (unsigned long long) mapping.pbn, mapping.state,
 				       lock->tree_slots[lock->height - 1].page_index,
 				       lock->height - 1);
 		abort_load(data_vio, VDO_BAD_MAPPING);
@@ -1816,7 +1798,8 @@ static void continue_with_loaded_page(struct data_vio *data_vio, struct block_ma
 
 	if (!vdo_is_mapped_location(&mapping)) {
 		/* The page we need is unallocated */
-		allocate_block_map_page(data_vio->logical.zone->block_map_zone, data_vio);
+		allocate_block_map_page(data_vio->logical.zone->block_map_zone,
+					data_vio);
 		return;
 	}
 
@@ -1884,7 +1867,8 @@ static void load_page_endio(struct bio *bio)
 	struct vio *vio = bio->bi_private;
 	struct data_vio *data_vio = vio->completion.parent;
 
-	continue_vio_after_io(vio, finish_block_map_page_load, data_vio->logical.zone->thread_id);
+	continue_vio_after_io(vio, finish_block_map_page_load,
+			      data_vio->logical.zone->thread_id);
 }
 
 static void load_page(struct waiter *waiter, void *context)
@@ -1895,11 +1879,8 @@ static void load_page(struct waiter *waiter, void *context)
 	physical_block_number_t pbn = lock->tree_slots[lock->height - 1].block_map_slot.pbn;
 
 	pooled->vio.completion.parent = data_vio;
-	submit_metadata_vio(&pooled->vio,
-			    pbn,
-			    load_page_endio,
-			    handle_io_error,
-			    REQ_OP_READ | REQ_PRIO);
+	submit_metadata_vio(&pooled->vio, pbn, load_page_endio,
+			    handle_io_error, REQ_OP_READ | REQ_PRIO);
 }
 
 /*
@@ -1923,11 +1904,8 @@ static int attempt_page_lock(struct block_map_zone *zone, struct data_vio *data_
 	};
 	lock->key = key.key;
 
-	result = vdo_int_map_put(zone->loading_pages,
-				 lock->key,
-				 lock,
-				 false,
-				 (void **) &lock_holder);
+	result = vdo_int_map_put(zone->loading_pages, lock->key,
+				 lock, false, (void **) &lock_holder);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -1963,7 +1941,8 @@ static void allocation_failure(struct vdo_completion *completion)
 {
 	struct data_vio *data_vio = as_data_vio(completion);
 
-	if (vdo_requeue_completion_if_needed(completion, data_vio->logical.zone->thread_id))
+	if (vdo_requeue_completion_if_needed(completion,
+					     data_vio->logical.zone->thread_id))
 		return;
 
 	abort_lookup(data_vio, completion->result, "allocation");
@@ -2061,12 +2040,11 @@ static void write_expired_elements(struct block_map_zone *zone)
  * @new_period: The period in which the element has now been dirtied, or 0 if it does not hold a
  *              lock.
  */
-static void
-add_to_dirty_lists(struct block_map_zone *zone,
-		   struct list_head *entry,
-		   enum block_map_page_type type,
-		   sequence_number_t old_period,
-		   sequence_number_t new_period)
+static void add_to_dirty_lists(struct block_map_zone *zone,
+			       struct list_head *entry,
+			       enum block_map_page_type type,
+			       sequence_number_t old_period,
+			       sequence_number_t new_period)
 {
 	struct dirty_lists *dirty_lists = zone->dirty_lists;
 
@@ -2107,9 +2085,7 @@ static void finish_block_map_allocation(struct vdo_completion *completion)
 	/* Record the allocation. */
 	page = (struct block_map_page *) tree_page->page_buffer;
 	old_lock = tree_page->recovery_lock;
-	vdo_update_block_map_page(page,
-				  data_vio,
-				  pbn,
+	vdo_update_block_map_page(page, data_vio, pbn,
 				  VDO_MAPPING_STATE_UNCOMPRESSED,
 				  &tree_page->recovery_lock);
 
@@ -2126,11 +2102,8 @@ static void finish_block_map_allocation(struct vdo_completion *completion)
 		/* Put the page on a dirty list */
 		if (old_lock == 0)
 			INIT_LIST_HEAD(&tree_page->entry);
-		add_to_dirty_lists(zone,
-				   &tree_page->entry,
-				   VDO_TREE_PAGE,
-				   old_lock,
-				   tree_page->recovery_lock);
+		add_to_dirty_lists(zone, &tree_page->entry, VDO_TREE_PAGE,
+				   old_lock, tree_page->recovery_lock);
 	}
 
 	tree_lock->height--;
@@ -2139,13 +2112,13 @@ static void finish_block_map_allocation(struct vdo_completion *completion)
 		tree_page = get_tree_page(zone, tree_lock);
 		vdo_format_block_map_page(tree_page->page_buffer,
 					  zone->block_map->nonce,
-					  pbn,
-					  false);
+					  pbn, false);
 	}
 
 	/* Release our claim to the allocation and wake any waiters */
 	release_page_lock(data_vio, "allocation");
-	vdo_notify_all_waiters(&tree_lock->waiters, continue_allocation_for_waiter, &pbn);
+	vdo_notify_all_waiters(&tree_lock->waiters, continue_allocation_for_waiter,
+			       &pbn);
 	if (tree_lock->height == 0) {
 		finish_lookup(data_vio, VDO_SUCCESS);
 		return;
@@ -2185,7 +2158,8 @@ static void journal_block_map_allocation(struct vdo_completion *completion)
 
 	assert_data_vio_in_journal_zone(data_vio);
 
-	set_data_vio_allocated_zone_callback(data_vio, set_block_map_page_reference_count);
+	set_data_vio_allocated_zone_callback(data_vio,
+					     set_block_map_page_reference_count);
 	vdo_add_recovery_journal_entry(completion->vdo->recovery_journal, data_vio);
 }
 
@@ -2215,7 +2189,8 @@ static void allocate_block(struct vdo_completion *completion)
 	launch_data_vio_journal_callback(data_vio, journal_block_map_allocation);
 }
 
-static void allocate_block_map_page(struct block_map_zone *zone, struct data_vio *data_vio)
+static void allocate_block_map_page(struct block_map_zone *zone,
+				    struct data_vio *data_vio)
 {
 	int result;
 
@@ -2234,10 +2209,8 @@ static void allocate_block_map_page(struct block_map_zone *zone, struct data_vio
 	if (!data_vio->tree_lock.locked)
 		return;
 
-	data_vio_allocate_data_block(data_vio,
-				     VIO_BLOCK_MAP_WRITE_LOCK,
-				     allocate_block,
-				     allocation_failure);
+	data_vio_allocate_data_block(data_vio, VIO_BLOCK_MAP_WRITE_LOCK,
+				     allocate_block, allocation_failure);
 }
 
 /**
@@ -2294,8 +2267,7 @@ void vdo_find_block_map_slot(struct data_vio *data_vio)
 	if (is_invalid_tree_entry(vdo_from_data_vio(data_vio), &mapping, lock->height)) {
 		uds_log_error_strerror(VDO_BAD_MAPPING,
 				       "Invalid block map tree PBN: %llu with state %u for page index %u at height %u",
-				       (unsigned long long) mapping.pbn,
-				       mapping.state,
+				       (unsigned long long) mapping.pbn, mapping.state,
 				       lock->tree_slots[lock->height - 1].page_index,
 				       lock->height - 1);
 		abort_load(data_vio, VDO_BAD_MAPPING);
@@ -2323,8 +2295,8 @@ void vdo_find_block_map_slot(struct data_vio *data_vio)
  * Find the PBN of a leaf block map page. This method may only be used after all allocated tree
  * pages have been loaded, otherwise, it may give the wrong answer (0).
  */
-physical_block_number_t
-vdo_find_block_map_page_pbn(struct block_map *map, page_number_t page_number)
+physical_block_number_t vdo_find_block_map_page_pbn(struct block_map *map,
+						    page_number_t page_number)
 {
 	struct data_location mapping;
 	struct tree_page *tree_page;
@@ -2364,10 +2336,8 @@ void vdo_write_tree_page(struct tree_page *page, struct block_map_zone *zone)
 	enqueue_page(page, zone);
 }
 
-static int make_segment(struct forest *old_forest,
-			block_count_t new_pages,
-			struct boundary *new_boundary,
-			struct forest *forest)
+static int make_segment(struct forest *old_forest, block_count_t new_pages,
+			struct boundary *new_boundary, struct forest *forest)
 {
 	size_t index = (old_forest == NULL) ? 0 : old_forest->segments;
 	struct tree_page *page_ptr;
@@ -2383,25 +2353,21 @@ static int make_segment(struct forest *old_forest,
 	if (result != VDO_SUCCESS)
 		return result;
 
-	result = uds_allocate(forest->segments,
-			      struct tree_page *,
-			      "forest page pointers",
-			      &forest->pages);
+	result = uds_allocate(forest->segments, struct tree_page *,
+			      "forest page pointers", &forest->pages);
 	if (result != VDO_SUCCESS)
 		return result;
 
-	result = uds_allocate(new_pages,
-			      struct tree_page,
-			      "new forest pages",
-			      &forest->pages[index]);
+	result = uds_allocate(new_pages, struct tree_page,
+			      "new forest pages", &forest->pages[index]);
 	if (result != VDO_SUCCESS)
 		return result;
 
 	if (index > 0) {
-		memcpy(forest->boundaries,
-		       old_forest->boundaries,
+		memcpy(forest->boundaries, old_forest->boundaries,
 		       index * sizeof(struct boundary));
-		memcpy(forest->pages, old_forest->pages, index * sizeof(struct tree_page *));
+		memcpy(forest->pages, old_forest->pages,
+		       index * sizeof(struct tree_page *));
 	}
 
 	memcpy(&(forest->boundaries[index]), new_boundary, sizeof(struct boundary));
@@ -2420,14 +2386,12 @@ static int make_segment(struct forest *old_forest,
 
 		int result = uds_allocate(forest->segments,
 					  struct block_map_tree_segment,
-					  "tree root segments",
-					  &tree->segments);
+					  "tree root segments", &tree->segments);
 		if (result != VDO_SUCCESS)
 			return result;
 
 		if (index > 0) {
-			memcpy(tree->segments,
-			       old_forest->trees[root].segments,
+			memcpy(tree->segments, old_forest->trees[root].segments,
 			       index * sizeof(struct block_map_tree_segment));
 		}
 
@@ -2442,8 +2406,7 @@ static int make_segment(struct forest *old_forest,
 				struct block_map_page *page =
 					vdo_format_block_map_page(page_ptr->page_buffer,
 								  forest->map->nonce,
-								  VDO_INVALID_PBN,
-								  true);
+								  VDO_INVALID_PBN, true);
 				page->entries[0] =
 					vdo_pack_block_map_entry(forest->map->root_origin + root,
 								 VDO_MAPPING_STATE_UNCOMPRESSED);
@@ -2576,8 +2539,7 @@ static void finish_traversal_load(struct vdo_completion *completion)
 
 	vdo_copy_valid_page(cursor->vio->vio.data,
 			    cursor->parent->zone->block_map->nonce,
-			    pbn_from_vio_bio(cursor->vio->vio.bio),
-			    page);
+			    pbn_from_vio_bio(cursor->vio->vio.bio), page);
 	traverse(cursor);
 }
 
@@ -2586,7 +2548,8 @@ static void traversal_endio(struct bio *bio)
 	struct vio *vio = bio->bi_private;
 	struct cursor *cursor = vio->completion.parent;
 
-	continue_vio_after_io(vio, finish_traversal_load, cursor->parent->zone->thread_id);
+	continue_vio_after_io(vio, finish_traversal_load,
+			      cursor->parent->zone->thread_id);
 }
 
 /**
@@ -2636,7 +2599,8 @@ static void traverse(struct cursor *cursor)
 
 				if (result != VDO_SUCCESS) {
 					page->entries[level->slot] = UNMAPPED_BLOCK_MAP_ENTRY;
-					vdo_write_tree_page(tree_page, cursor->parent->zone);
+					vdo_write_tree_page(tree_page,
+							    cursor->parent->zone);
 					continue;
 				}
 			}
@@ -2649,10 +2613,8 @@ static void traverse(struct cursor *cursor)
 			next_level->page_index = entry_index;
 			next_level->slot = 0;
 			level->slot++;
-			submit_metadata_vio(&cursor->vio->vio,
-					    location.pbn,
-					    traversal_endio,
-					    continue_traversal,
+			submit_metadata_vio(&cursor->vio->vio, location.pbn,
+					    traversal_endio, continue_traversal,
 					    REQ_OP_READ | REQ_PRIO);
 			return;
 		}
@@ -2716,19 +2678,15 @@ static struct boundary compute_boundary(struct block_map *map, root_count_t root
  * @callback: A function to call with the pbn of each allocated node in the forest.
  * @parent: The completion to notify on each traversed PBN, and when the traversal is complete.
  */
-void vdo_traverse_forest(struct block_map *map,
-			 vdo_entry_callback *callback,
+void vdo_traverse_forest(struct block_map *map, vdo_entry_callback *callback,
 			 struct vdo_completion *parent)
 {
 	root_count_t root;
 	struct cursors *cursors;
 	int result;
 
-	result = uds_allocate_extended(struct cursors,
-				       map->root_count,
-				       struct cursor,
-				       __func__,
-				       &cursors);
+	result = uds_allocate_extended(struct cursors, map->root_count,
+				       struct cursor, __func__, &cursors);
 	if (result != VDO_SUCCESS) {
 		vdo_fail_completion(parent, result);
 		return;
@@ -2775,10 +2733,8 @@ static int __must_check initialize_block_map_zone(struct block_map *map,
 	zone->thread_id = vdo->thread_config.logical_threads[zone_number];
 	zone->block_map = map;
 
-	result = uds_allocate_extended(struct dirty_lists,
-				       maximum_age,
-				       dirty_era_t,
-				       __func__,
+	result = uds_allocate_extended(struct dirty_lists, maximum_age,
+				       dirty_era_t, __func__,
 				       &zone->dirty_lists);
 	if (result != VDO_SUCCESS)
 		return result;
@@ -2796,13 +2752,9 @@ static int __must_check initialize_block_map_zone(struct block_map *map,
 	if (result != VDO_SUCCESS)
 		return result;
 
-	result = make_vio_pool(vdo,
-			       BLOCK_MAP_VIO_POOL_SIZE,
-			       zone->thread_id,
-			       VIO_TYPE_BLOCK_MAP_INTERIOR,
-			       VIO_PRIORITY_METADATA,
-			       zone,
-			       &zone->vio_pool);
+	result = make_vio_pool(vdo, BLOCK_MAP_VIO_POOL_SIZE,
+			       zone->thread_id, VIO_TYPE_BLOCK_MAP_INTERIOR,
+			       VIO_PRIORITY_METADATA, zone, &zone->vio_pool);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -2842,8 +2794,7 @@ static void prepare_for_era_advance(void *context, struct vdo_completion *parent
 }
 
 /* Implements vdo_zone_action */
-static void advance_block_map_zone_era(void *context,
-				       zone_count_t zone_number,
+static void advance_block_map_zone_era(void *context, zone_count_t zone_number,
 				       struct vdo_completion *parent)
 {
 	struct block_map *map = context;
@@ -2867,11 +2818,8 @@ static bool schedule_era_advance(void *context)
 	if (map->current_era_point == map->pending_era_point)
 		return false;
 
-	return vdo_schedule_action(map->action_manager,
-				   prepare_for_era_advance,
-				   advance_block_map_zone_era,
-				   NULL,
-				   NULL);
+	return vdo_schedule_action(map->action_manager, prepare_for_era_advance,
+				   advance_block_map_zone_era, NULL, NULL);
 }
 
 static void uninitialize_block_map_zone(struct block_map_zone *zone)
@@ -2911,13 +2859,9 @@ void vdo_free_block_map(struct block_map *map)
 }
 
 /* @journal may be NULL. */
-int vdo_decode_block_map(struct block_map_state_2_0 state,
-			 block_count_t logical_blocks,
-			 struct vdo *vdo,
-			 struct recovery_journal *journal,
-			 nonce_t nonce,
-			 page_count_t cache_size,
-			 block_count_t maximum_age,
+int vdo_decode_block_map(struct block_map_state_2_0 state, block_count_t logical_blocks,
+			 struct vdo *vdo, struct recovery_journal *journal,
+			 nonce_t nonce, page_count_t cache_size, block_count_t maximum_age,
 			 struct block_map **map_ptr)
 {
 	struct block_map *map;
@@ -2933,9 +2877,7 @@ int vdo_decode_block_map(struct block_map_state_2_0 state,
 
 	result = uds_allocate_extended(struct block_map,
 				       vdo->thread_config.logical_zone_count,
-				       struct block_map_zone,
-				       __func__,
-				       &map);
+				       struct block_map_zone, __func__, &map);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -2956,19 +2898,17 @@ int vdo_decode_block_map(struct block_map_state_2_0 state,
 
 	map->zone_count = vdo->thread_config.logical_zone_count;
 	for (zone = 0; zone < map->zone_count; zone++) {
-		result = initialize_block_map_zone(map, zone, vdo, cache_size, maximum_age);
+		result = initialize_block_map_zone(map, zone, vdo, cache_size,
+						   maximum_age);
 		if (result != VDO_SUCCESS) {
 			vdo_free_block_map(map);
 			return result;
 		}
 	}
 
-	result = vdo_make_action_manager(map->zone_count,
-					 get_block_map_zone_thread_id,
+	result = vdo_make_action_manager(map->zone_count, get_block_map_zone_thread_id,
 					 vdo_get_recovery_journal_thread_id(journal),
-					 map,
-					 schedule_era_advance,
-					 vdo,
+					 map, schedule_era_advance, vdo,
 					 &map->action_manager);
 	if (result != VDO_SUCCESS) {
 		vdo_free_block_map(map);
@@ -2991,7 +2931,8 @@ struct block_map_state_2_0 vdo_record_block_map(const struct block_map *map)
 }
 
 /* The block map needs to know the journals' sequence number to initialize the eras. */
-void vdo_initialize_block_map_from_journal(struct block_map *map, struct recovery_journal *journal)
+void vdo_initialize_block_map_from_journal(struct block_map *map,
+					   struct recovery_journal *journal)
 {
 	zone_count_t z = 0;
 
@@ -3020,7 +2961,8 @@ zone_count_t vdo_compute_logical_zone(struct data_vio *data_vio)
 	return (tree_lock->root_index % map->zone_count);
 }
 
-void vdo_advance_block_map_era(struct block_map *map, sequence_number_t recovery_block_number)
+void vdo_advance_block_map_era(struct block_map *map,
+			       sequence_number_t recovery_block_number)
 {
 	if (map == NULL)
 		return;
@@ -3035,8 +2977,7 @@ static void initiate_drain(struct admin_state *state)
 	struct block_map_zone *zone = container_of(state, struct block_map_zone, state);
 
 	ASSERT_LOG_ONLY((zone->active_lookups == 0),
-			"%s() called with no active lookups",
-			__func__);
+			"%s() called with no active lookups", __func__);
 
 	if (!vdo_is_state_suspending(state)) {
 		while (zone->dirty_lists->oldest_period < zone->dirty_lists->next_period)
@@ -3048,27 +2989,27 @@ static void initiate_drain(struct admin_state *state)
 }
 
 /* Implements vdo_zone_action. */
-static void drain_zone(void *context, zone_count_t zone_number, struct vdo_completion *parent)
+static void drain_zone(void *context, zone_count_t zone_number,
+		       struct vdo_completion *parent)
 {
 	struct block_map *map = context;
 	struct block_map_zone *zone = &map->zones[zone_number];
 
 	vdo_start_draining(&zone->state,
 			   vdo_get_current_manager_operation(map->action_manager),
-			   parent,
-			   initiate_drain);
+			   parent, initiate_drain);
 }
 
-void vdo_drain_block_map(struct block_map *map,
-			 const struct admin_state_code *operation,
+void vdo_drain_block_map(struct block_map *map, const struct admin_state_code *operation,
 			 struct vdo_completion *parent)
 {
-	vdo_schedule_operation(map->action_manager, operation, NULL, drain_zone, NULL, parent);
+	vdo_schedule_operation(map->action_manager, operation, NULL, drain_zone, NULL,
+			       parent);
 }
 
 /* Implements vdo_zone_action. */
-static void
-resume_block_map_zone(void *context, zone_count_t zone_number, struct vdo_completion *parent)
+static void resume_block_map_zone(void *context, zone_count_t zone_number,
+				  struct vdo_completion *parent)
 {
 	struct block_map *map = context;
 	struct block_map_zone *zone = &map->zones[zone_number];
@@ -3078,16 +3019,13 @@ resume_block_map_zone(void *context, zone_count_t zone_number, struct vdo_comple
 
 void vdo_resume_block_map(struct block_map *map, struct vdo_completion *parent)
 {
-	vdo_schedule_operation(map->action_manager,
-			       VDO_ADMIN_STATE_RESUMING,
-			       NULL,
-			       resume_block_map_zone,
-			       NULL,
-			       parent);
+	vdo_schedule_operation(map->action_manager, VDO_ADMIN_STATE_RESUMING,
+			       NULL, resume_block_map_zone, NULL, parent);
 }
 
 /* Allocate an expanded collection of trees, for a future growth. */
-int vdo_prepare_to_grow_block_map(struct block_map *map, block_count_t new_logical_blocks)
+int vdo_prepare_to_grow_block_map(struct block_map *map,
+				  block_count_t new_logical_blocks)
 {
 	if (map->next_entry_count == new_logical_blocks)
 		return VDO_SUCCESS;
@@ -3115,10 +3053,7 @@ void vdo_grow_block_map(struct block_map *map, struct vdo_completion *parent)
 {
 	vdo_schedule_operation(map->action_manager,
 			       VDO_ADMIN_STATE_SUSPENDED_OPERATION,
-			       grow_forest,
-			       NULL,
-			       NULL,
-			       parent);
+			       grow_forest, NULL, NULL, parent);
 }
 
 void vdo_abandon_block_map_growth(struct block_map *map)
@@ -3146,7 +3081,8 @@ static void handle_page_error(struct vdo_completion *completion)
 }
 
 /* Fetch the mapping page for a block map update, and call the provided handler when fetched. */
-static void fetch_mapping_page(struct data_vio *data_vio, bool modifiable, vdo_action *action)
+static void fetch_mapping_page(struct data_vio *data_vio, bool modifiable,
+			       vdo_action *action)
 {
 	struct block_map_zone *zone = data_vio->logical.zone->block_map_zone;
 
@@ -3155,14 +3091,10 @@ static void fetch_mapping_page(struct data_vio *data_vio, bool modifiable, vdo_a
 		return;
 	}
 
-	vdo_get_page(&data_vio->page_completion,
-		     zone,
+	vdo_get_page(&data_vio->page_completion, zone,
 		     data_vio->tree_lock.tree_slots[0].block_map_slot.pbn,
-		     modifiable,
-		     &data_vio->vio.completion,
-		     action,
-		     handle_page_error,
-		     false);
+		     modifiable, &data_vio->vio.completion,
+		     action, handle_page_error, false);
 }
 
 /**
@@ -3184,8 +3116,8 @@ static void clear_mapped_location(struct data_vio *data_vio)
  * Return: VDO_SUCCESS or VDO_BAD_MAPPING if the map entry is invalid or an error code for any
  *         other failure
  */
-static int __must_check
-set_mapped_location(struct data_vio *data_vio, const struct block_map_entry *entry)
+static int __must_check set_mapped_location(struct data_vio *data_vio,
+					    const struct block_map_entry *entry)
 {
 	/* Unpack the PBN for logging purposes even if the entry is invalid. */
 	struct data_location mapped = vdo_unpack_block_map_entry(entry);
@@ -3194,8 +3126,7 @@ set_mapped_location(struct data_vio *data_vio, const struct block_map_entry *ent
 		int result;
 
 		result = vdo_get_physical_zone(vdo_from_data_vio(data_vio),
-					       mapped.pbn,
-					       &data_vio->mapped.zone);
+					       mapped.pbn, &data_vio->mapped.zone);
 		if (result == VDO_SUCCESS) {
 			data_vio->mapped.pbn = mapped.pbn;
 			data_vio->mapped.state = mapped.state;
@@ -3216,8 +3147,7 @@ set_mapped_location(struct data_vio *data_vio, const struct block_map_entry *ent
 	 */
 	uds_log_error_strerror(VDO_BAD_MAPPING,
 			       "PBN %llu with state %u read from the block map was invalid",
-			       (unsigned long long) mapped.pbn,
-			       mapped.state);
+			       (unsigned long long) mapped.pbn, mapped.state);
 
 	/*
 	 * A read VIO has no option but to report the bad mapping--reading zeros would be hiding
@@ -3263,8 +3193,7 @@ static void get_mapping_from_fetched_page(struct vdo_completion *completion)
 	finish_processing_page(completion, result);
 }
 
-void vdo_update_block_map_page(struct block_map_page *page,
-			       struct data_vio *data_vio,
+void vdo_update_block_map_page(struct block_map_page *page, struct data_vio *data_vio,
 			       physical_block_number_t pbn,
 			       enum block_mapping_state mapping_state,
 			       sequence_number_t *recovery_lock)
@@ -3284,14 +3213,12 @@ void vdo_update_block_map_page(struct block_map_page *page,
 	new_locked = data_vio->recovery_sequence_number;
 
 	if ((old_locked == 0) || (old_locked > new_locked)) {
-		vdo_acquire_recovery_journal_block_reference(journal,
-							     new_locked,
+		vdo_acquire_recovery_journal_block_reference(journal, new_locked,
 							     VDO_ZONE_TYPE_LOGICAL,
 							     zone->zone_number);
 
 		if (old_locked > 0) {
-			vdo_release_recovery_journal_block_reference(journal,
-								     old_locked,
+			vdo_release_recovery_journal_block_reference(journal, old_locked,
 								     VDO_ZONE_TYPE_LOGICAL,
 								     zone->zone_number);
 		}
@@ -3330,16 +3257,11 @@ static void put_mapping_in_fetched_page(struct vdo_completion *completion)
 	info = vpc->info;
 	old_lock = info->recovery_lock;
 	vdo_update_block_map_page((struct block_map_page *) get_page_buffer(info),
-				  data_vio,
-				  data_vio->new_mapped.pbn,
-				  data_vio->new_mapped.state,
-				  &info->recovery_lock);
+				  data_vio, data_vio->new_mapped.pbn,
+				  data_vio->new_mapped.state, &info->recovery_lock);
 	set_info_state(info, PS_DIRTY);
-	add_to_dirty_lists(info->cache->zone,
-			   &info->state_entry,
-			   VDO_CACHE_PAGE,
-			   old_lock,
-			   info->recovery_lock);
+	add_to_dirty_lists(info->cache->zone, &info->state_entry,
+			   VDO_CACHE_PAGE, old_lock, info->recovery_lock);
 	finish_processing_page(completion, VDO_SUCCESS);
 }
 

--- a/drivers/md/dm-vdo/block-map.c
+++ b/drivers/md/dm-vdo/block-map.c
@@ -184,7 +184,7 @@ static int initialize_info(struct vdo_page_cache *cache)
 	struct page_info *info;
 
 	INIT_LIST_HEAD(&cache->free_list);
-	for (info = cache->infos; info < cache->infos + cache->page_count; ++info) {
+	for (info = cache->infos; info < cache->infos + cache->page_count; info++) {
 		int result;
 
 		info->cache = cache;
@@ -570,7 +570,7 @@ static void set_persistent_error(struct vdo_page_cache *cache, const char *conte
 	vdo_notify_all_waiters(&cache->free_waiters, complete_waiter_with_error, &result);
 	cache->waiter_count = 0;
 
-	for (info = cache->infos; info < cache->infos + cache->page_count; ++info)
+	for (info = cache->infos; info < cache->infos + cache->page_count; info++)
 		vdo_notify_all_waiters(&info->waiting, complete_waiter_with_error, &result);
 }
 
@@ -944,7 +944,7 @@ static void discard_a_page(struct vdo_page_cache *cache)
 
 	ASSERT_LOG_ONLY(!is_in_flight(info), "page selected for discard is not in flight");
 
-	++cache->discard_count;
+	cache->discard_count++;
 	info->write_status = WRITE_STATUS_DISCARD;
 	launch_page_save(info);
 }
@@ -957,7 +957,7 @@ static void discard_page_for_completion(struct vdo_page_completion *vdo_page_com
 {
 	struct vdo_page_cache *cache = vdo_page_comp->cache;
 
-	++cache->waiter_count;
+	cache->waiter_count++;
 	vdo_enqueue_waiter(&cache->free_waiters, &vdo_page_comp->waiter);
 	discard_a_page(cache);
 }
@@ -1261,7 +1261,7 @@ void vdo_get_page(struct vdo_page_completion *page_completion,
 			if (!is_present(info))
 				ADD_ONCE(cache->stats.read_outgoing, 1);
 			update_lru(info);
-			++info->busy;
+			info->busy++;
 			complete_with_page(info, page_completion);
 			return;
 		}
@@ -2869,7 +2869,7 @@ static void uninitialize_block_map_zone(struct block_map_zone *zone)
 	if (cache->infos != NULL) {
 		struct page_info *info;
 
-		for (info = cache->infos; info < cache->infos + cache->page_count; ++info)
+		for (info = cache->infos; info < cache->infos + cache->page_count; info++)
 			free_vio(uds_forget(info->vio));
 	}
 

--- a/drivers/md/dm-vdo/block-map.c
+++ b/drivers/md/dm-vdo/block-map.c
@@ -522,7 +522,7 @@ static void complete_waiter_with_error(struct waiter *waiter, void *result_ptr)
  */
 static void complete_waiter_with_page(struct waiter *waiter, void *page_info)
 {
-	complete_with_page((struct page_info *) page_info, page_completion_from_waiter(waiter));
+	complete_with_page(page_info, page_completion_from_waiter(waiter));
 }
 
 /**
@@ -1511,7 +1511,7 @@ static void write_page(struct tree_page *tree_page, struct pooled_vio *vio);
 /* Implements waiter_callback */
 static void write_page_callback(struct waiter *waiter, void *context)
 {
-	write_page(container_of(waiter, struct tree_page, waiter), (struct pooled_vio *) context);
+	write_page(container_of(waiter, struct tree_page, waiter), context);
 }
 
 static void acquire_vio(struct waiter *waiter, struct block_map_zone *zone)
@@ -1835,7 +1835,7 @@ static void continue_load_for_waiter(struct waiter *waiter, void *context)
 	struct data_vio *data_vio = waiter_as_data_vio(waiter);
 
 	data_vio->tree_lock.height--;
-	continue_with_loaded_page(data_vio, (struct block_map_page *) context);
+	continue_with_loaded_page(data_vio, context);
 }
 
 static void finish_block_map_page_load(struct vdo_completion *completion)

--- a/drivers/md/dm-vdo/block-map.h
+++ b/drivers/md/dm-vdo/block-map.h
@@ -265,15 +265,15 @@ struct block_map {
 };
 
 /**
- * typedef vdo_entry_callback - A function to be called for each allocated PBN when traversing the
- *                              forest.
+ * typedef vdo_entry_callback_fn - A function to be called for each allocated PBN when traversing
+ *                                 the forest.
  * @pbn: A PBN of a tree node.
  * @completion: The parent completion of the traversal.
  *
  * Return: VDO_SUCCESS or an error.
  */
-typedef int vdo_entry_callback(physical_block_number_t pbn,
-			       struct vdo_completion *completion);
+typedef int (*vdo_entry_callback_fn)(physical_block_number_t pbn,
+				     struct vdo_completion *completion);
 
 static inline struct vdo_page_completion *as_vdo_page_completion(struct vdo_completion *completion)
 {
@@ -285,8 +285,8 @@ void vdo_release_page_completion(struct vdo_completion *completion);
 
 void vdo_get_page(struct vdo_page_completion *page_completion,
 		  struct block_map_zone *zone, physical_block_number_t pbn,
-		  bool writable, void *parent, vdo_action *callback,
-		  vdo_action *error_handler, bool requeue);
+		  bool writable, void *parent, vdo_action_fn callback,
+		  vdo_action_fn error_handler, bool requeue);
 
 void vdo_request_page_write(struct vdo_completion *completion);
 
@@ -312,7 +312,7 @@ physical_block_number_t vdo_find_block_map_page_pbn(struct block_map *map,
 
 void vdo_write_tree_page(struct tree_page *page, struct block_map_zone *zone);
 
-void vdo_traverse_forest(struct block_map *map, vdo_entry_callback *callback,
+void vdo_traverse_forest(struct block_map *map, vdo_entry_callback_fn callback,
 			 struct vdo_completion *parent);
 
 int __must_check vdo_decode_block_map(struct block_map_state_2_0 state,

--- a/drivers/md/dm-vdo/block-map.h
+++ b/drivers/md/dm-vdo/block-map.h
@@ -272,7 +272,8 @@ struct block_map {
  *
  * Return: VDO_SUCCESS or an error.
  */
-typedef int vdo_entry_callback(physical_block_number_t pbn, struct vdo_completion *completion);
+typedef int vdo_entry_callback(physical_block_number_t pbn,
+			       struct vdo_completion *completion);
 
 static inline struct vdo_page_completion *as_vdo_page_completion(struct vdo_completion *completion)
 {
@@ -283,13 +284,9 @@ static inline struct vdo_page_completion *as_vdo_page_completion(struct vdo_comp
 void vdo_release_page_completion(struct vdo_completion *completion);
 
 void vdo_get_page(struct vdo_page_completion *page_completion,
-		  struct block_map_zone *zone,
-		  physical_block_number_t pbn,
-		  bool writable,
-		  void *parent,
-		  vdo_action *callback,
-		  vdo_action *error_handler,
-		  bool requeue);
+		  struct block_map_zone *zone, physical_block_number_t pbn,
+		  bool writable, void *parent, vdo_action *callback,
+		  vdo_action *error_handler, bool requeue);
 
 void vdo_request_page_write(struct vdo_completion *completion);
 
@@ -304,39 +301,33 @@ vdo_as_block_map_page(struct tree_page *tree_page)
 	return (struct block_map_page *) tree_page->page_buffer;
 }
 
-bool vdo_copy_valid_page(char *buffer,
-			 nonce_t nonce,
+bool vdo_copy_valid_page(char *buffer, nonce_t nonce,
 			 physical_block_number_t pbn,
 			 struct block_map_page *page);
 
 void vdo_find_block_map_slot(struct data_vio *data_vio);
 
-physical_block_number_t
-vdo_find_block_map_page_pbn(struct block_map *map, page_number_t page_number);
+physical_block_number_t vdo_find_block_map_page_pbn(struct block_map *map,
+						    page_number_t page_number);
 
 void vdo_write_tree_page(struct tree_page *page, struct block_map_zone *zone);
 
-void vdo_traverse_forest(struct block_map *map,
-			 vdo_entry_callback *callback,
+void vdo_traverse_forest(struct block_map *map, vdo_entry_callback *callback,
 			 struct vdo_completion *parent);
 
 int __must_check vdo_decode_block_map(struct block_map_state_2_0 state,
-				      block_count_t logical_blocks,
-				      struct vdo *vdo,
-				      struct recovery_journal *journal,
-				      nonce_t nonce,
-				      page_count_t cache_size,
-				      block_count_t maximum_age,
+				      block_count_t logical_blocks, struct vdo *vdo,
+				      struct recovery_journal *journal, nonce_t nonce,
+				      page_count_t cache_size, block_count_t maximum_age,
 				      struct block_map **map_ptr);
 
-void vdo_drain_block_map(struct block_map *map,
-			 const struct admin_state_code *operation,
+void vdo_drain_block_map(struct block_map *map, const struct admin_state_code *operation,
 			 struct vdo_completion *parent);
 
 void vdo_resume_block_map(struct block_map *map, struct vdo_completion *parent);
 
-int __must_check
-vdo_prepare_to_grow_block_map(struct block_map *map, block_count_t new_logical_blocks);
+int __must_check vdo_prepare_to_grow_block_map(struct block_map *map,
+					       block_count_t new_logical_blocks);
 
 void vdo_grow_block_map(struct block_map *map, struct vdo_completion *parent);
 
@@ -344,18 +335,17 @@ void vdo_abandon_block_map_growth(struct block_map *map);
 
 void vdo_free_block_map(struct block_map *map);
 
-struct block_map_state_2_0 __must_check
-vdo_record_block_map(const struct block_map *map);
+struct block_map_state_2_0 __must_check vdo_record_block_map(const struct block_map *map);
 
 void vdo_initialize_block_map_from_journal(struct block_map *map,
 					   struct recovery_journal *journal);
 
 zone_count_t vdo_compute_logical_zone(struct data_vio *data_vio);
 
-void vdo_advance_block_map_era(struct block_map *map, sequence_number_t recovery_block_number);
+void vdo_advance_block_map_era(struct block_map *map,
+			       sequence_number_t recovery_block_number);
 
-void vdo_update_block_map_page(struct block_map_page *page,
-			       struct data_vio *data_vio,
+void vdo_update_block_map_page(struct block_map_page *page, struct data_vio *data_vio,
 			       physical_block_number_t pbn,
 			       enum block_mapping_state mapping_state,
 			       sequence_number_t *recovery_lock);

--- a/drivers/md/dm-vdo/chapter-index.c
+++ b/drivers/md/dm-vdo/chapter-index.c
@@ -13,14 +13,14 @@
 #include "uds.h"
 
 int uds_make_open_chapter_index(struct open_chapter_index **chapter_index,
-				const struct geometry *geometry,
-				u64 volume_nonce)
+				const struct geometry *geometry, u64 volume_nonce)
 {
 	int result;
 	size_t memory_size;
 	struct open_chapter_index *index;
 
-	result = uds_allocate(1, struct open_chapter_index, "open chapter index", &index);
+	result = uds_allocate(1, struct open_chapter_index, "open chapter index",
+			      &index);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -31,13 +31,11 @@ int uds_make_open_chapter_index(struct open_chapter_index **chapter_index,
 	memory_size = ((geometry->index_pages_per_chapter + 1) * geometry->bytes_per_page);
 	index->geometry = geometry;
 	index->volume_nonce = volume_nonce;
-	result = uds_initialize_delta_index(&index->delta_index,
-					    1,
+	result = uds_initialize_delta_index(&index->delta_index, 1,
 					    geometry->delta_lists_per_chapter,
 					    geometry->chapter_mean_delta,
 					    geometry->chapter_payload_bits,
-					    memory_size,
-					    'm');
+					    memory_size, 'm');
 	if (result != UDS_SUCCESS) {
 		uds_free(index);
 		return result;
@@ -87,18 +85,14 @@ int uds_put_open_chapter_index_record(struct open_chapter_index *chapter_index,
 
 	result = ASSERT(page_number < record_pages,
 			"Page number within chapter (%u) exceeds the maximum value %u",
-			page_number,
-			record_pages);
+			page_number, record_pages);
 	if (result != UDS_SUCCESS)
 		return UDS_INVALID_ARGUMENT;
 
 	address = uds_hash_to_chapter_delta_address(name, geometry);
 	list_number = uds_hash_to_chapter_delta_list(name, geometry);
-	result = uds_get_delta_index_entry(&chapter_index->delta_index,
-					   list_number,
-					   address,
-					   name->name,
-					   &entry);
+	result = uds_get_delta_index_entry(&chapter_index->delta_index, list_number,
+					   address, name->name, &entry);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -126,9 +120,7 @@ int uds_put_open_chapter_index_record(struct open_chapter_index *chapter_index,
  * @lists_packed: The number of delta lists that were packed onto this page
  */
 int uds_pack_open_chapter_index_page(struct open_chapter_index *chapter_index,
-				     u8 *memory,
-				     u32 first_list,
-				     bool last_page,
+				     u8 *memory, u32 first_list, bool last_page,
 				     u32 *lists_packed)
 {
 	int result;
@@ -144,12 +136,9 @@ int uds_pack_open_chapter_index_page(struct open_chapter_index *chapter_index,
 	s32 list_number;
 
 	for (;;) {
-		result = uds_pack_delta_index_page(delta_index,
-						   nonce,
-						   memory,
+		result = uds_pack_delta_index_page(delta_index, nonce, memory,
 						   geometry->bytes_per_page,
-						   chapter_number,
-						   first_list,
+						   chapter_number, first_list,
 						   lists_packed);
 		if (result != UDS_SUCCESS)
 			return result;
@@ -189,7 +178,8 @@ int uds_pack_open_chapter_index_page(struct open_chapter_index *chapter_index,
 				return UDS_OVERFLOW;
 
 			next_list = first_list + list_number--,
-			result = uds_start_delta_index_search(delta_index, next_list, 0, &entry);
+			result = uds_start_delta_index_search(delta_index, next_list, 0,
+							      &entry);
 			if (result != UDS_SUCCESS)
 				return result;
 
@@ -209,24 +199,20 @@ int uds_pack_open_chapter_index_page(struct open_chapter_index *chapter_index,
 
 	if (removals > 0)
 		uds_log_warning("To avoid chapter index page overflow in chapter %llu, %u entries were removed from the chapter index",
-				(unsigned long long) chapter_number,
-				removals);
+				(unsigned long long) chapter_number, removals);
 
 	return UDS_SUCCESS;
 }
 
 /* Make a new chapter index page, initializing it with the data from a given index_page buffer. */
 int uds_initialize_chapter_index_page(struct delta_index_page *index_page,
-				      const struct geometry *geometry,
-				      u8 *page_buffer,
+				      const struct geometry *geometry, u8 *page_buffer,
 				      u64 volume_nonce)
 {
-	return uds_initialize_delta_index_page(index_page,
-					       volume_nonce,
+	return uds_initialize_delta_index_page(index_page, volume_nonce,
 					       geometry->chapter_mean_delta,
 					       geometry->chapter_payload_bits,
-					       page_buffer,
-					       geometry->bytes_per_page);
+					       page_buffer, geometry->bytes_per_page);
 }
 
 /* Validate a chapter index page read during rebuild. */
@@ -243,7 +229,8 @@ int uds_validate_chapter_index_page(const struct delta_index_page *index_page,
 	for (list_number = first; list_number <= last; list_number++) {
 		struct delta_index_entry entry;
 
-		result = uds_start_delta_index_search(delta_index, list_number - first, 0, &entry);
+		result = uds_start_delta_index_search(delta_index, list_number - first,
+						      0, &entry);
 		if (result != UDS_SUCCESS)
 			return result;
 
@@ -290,11 +277,8 @@ int uds_search_chapter_index_page(struct delta_index_page *index_page,
 	u32 sub_list_number = delta_list_number - index_page->lowest_list_number;
 	struct delta_index_entry entry;
 
-	result = uds_get_delta_index_entry(delta_index,
-					   sub_list_number,
-					   address,
-					   name->name,
-					   &entry);
+	result = uds_get_delta_index_entry(delta_index, sub_list_number, address,
+					   name->name, &entry);
 	if (result != UDS_SUCCESS)
 		return result;
 

--- a/drivers/md/dm-vdo/chapter-index.c
+++ b/drivers/md/dm-vdo/chapter-index.c
@@ -153,10 +153,11 @@ int uds_pack_open_chapter_index_page(struct open_chapter_index *chapter_index,
 						   lists_packed);
 		if (result != UDS_SUCCESS)
 			return result;
-		if ((first_list + *lists_packed) == list_count)
+
+		if ((first_list + *lists_packed) == list_count) {
 			/* All lists are packed. */
 			break;
-		else if (*lists_packed == 0) {
+		} else if (*lists_packed == 0) {
 			/*
 			 * The next delta list does not fit on a page. This delta list will be
 			 * removed.
@@ -201,6 +202,7 @@ int uds_pack_open_chapter_index_page(struct open_chapter_index *chapter_index,
 			result = uds_remove_delta_index_entry(&entry);
 			if (result != UDS_SUCCESS)
 				return result;
+
 			removals++;
 		} while (!entry.at_end);
 	}
@@ -247,12 +249,13 @@ int uds_validate_chapter_index_page(const struct delta_index_page *index_page,
 
 		for (;;) {
 			result = uds_next_delta_index_entry(&entry);
-			if (result != UDS_SUCCESS)
+			if (result != UDS_SUCCESS) {
 				/*
 				 * A random bit stream is highly likely to arrive here when we go
 				 * past the end of the delta list.
 				 */
 				return result;
+			}
 
 			if (entry.at_end)
 				break;

--- a/drivers/md/dm-vdo/chapter-index.h
+++ b/drivers/md/dm-vdo/chapter-index.h
@@ -45,15 +45,12 @@ int __must_check uds_put_open_chapter_index_record(struct open_chapter_index *ch
 						   u32 page_number);
 
 int __must_check uds_pack_open_chapter_index_page(struct open_chapter_index *chapter_index,
-						  u8 *memory,
-						  u32 first_list,
-						  bool last_page,
-						  u32 *lists_packed);
+						  u8 *memory, u32 first_list,
+						  bool last_page, u32 *lists_packed);
 
 int __must_check uds_initialize_chapter_index_page(struct delta_index_page *index_page,
 						   const struct geometry *geometry,
-						   u8 *page_buffer,
-						   u64 volume_nonce);
+						   u8 *page_buffer, u64 volume_nonce);
 
 int __must_check uds_validate_chapter_index_page(const struct delta_index_page *index_page,
 						 const struct geometry *geometry);

--- a/drivers/md/dm-vdo/completion.c
+++ b/drivers/md/dm-vdo/completion.c
@@ -113,8 +113,7 @@ void vdo_enqueue_completion(struct vdo_completion *completion,
 
 	if (ASSERT(thread_id < vdo->thread_config.thread_count,
 		   "thread_id %u (completion type %d) is less than thread count %u",
-		   thread_id,
-		   completion->type,
+		   thread_id, completion->type,
 		   vdo->thread_config.thread_count) != UDS_SUCCESS)
 		BUG();
 

--- a/drivers/md/dm-vdo/completion.h
+++ b/drivers/md/dm-vdo/completion.h
@@ -28,8 +28,7 @@ static inline void vdo_run_completion(struct vdo_completion *completion)
 
 void vdo_set_completion_result(struct vdo_completion *completion, int result);
 
-void vdo_initialize_completion(struct vdo_completion *completion,
-			       struct vdo *vdo,
+void vdo_initialize_completion(struct vdo_completion *completion, struct vdo *vdo,
 			       enum vdo_completion_type type);
 
 /**
@@ -83,12 +82,11 @@ static inline void vdo_fail_completion(struct vdo_completion *completion, int re
  *
  * Return: VDO_SUCCESS or an error
  */
-static inline int
-vdo_assert_completion_type(struct vdo_completion *completion, enum vdo_completion_type expected)
+static inline int vdo_assert_completion_type(struct vdo_completion *completion,
+					     enum vdo_completion_type expected)
 {
 	return ASSERT(expected == completion->type,
-		      "completion type should be %u, not %u",
-		      expected,
+		      "completion type should be %u, not %u", expected,
 		      completion->type);
 }
 
@@ -119,8 +117,7 @@ static inline void vdo_launch_completion_callback(struct vdo_completion *complet
 static inline void vdo_prepare_completion(struct vdo_completion *completion,
 					  vdo_action *callback,
 					  vdo_action *error_handler,
-					  thread_id_t callback_thread_id,
-					  void *parent)
+					  thread_id_t callback_thread_id, void *parent)
 {
 	vdo_reset_completion(completion);
 	vdo_set_completion_callback(completion, callback, callback_thread_id);
@@ -134,14 +131,14 @@ static inline void vdo_prepare_completion(struct vdo_completion *completion,
  *
  * Resets the completion, and then sets its callback, error handler, callback thread, and parent.
  */
-static inline void
-vdo_prepare_completion_for_requeue(struct vdo_completion *completion,
-				   vdo_action *callback,
-				   vdo_action *error_handler,
-				   thread_id_t callback_thread_id,
-				   void *parent)
+static inline void vdo_prepare_completion_for_requeue(struct vdo_completion *completion,
+						      vdo_action *callback,
+						      vdo_action *error_handler,
+						      thread_id_t callback_thread_id,
+						      void *parent)
 {
-	vdo_prepare_completion(completion, callback, error_handler, callback_thread_id, parent);
+	vdo_prepare_completion(completion, callback, error_handler,
+			       callback_thread_id, parent);
 	completion->requeue = true;
 }
 

--- a/drivers/md/dm-vdo/completion.h
+++ b/drivers/md/dm-vdo/completion.h
@@ -91,7 +91,7 @@ static inline int vdo_assert_completion_type(struct vdo_completion *completion,
 }
 
 static inline void vdo_set_completion_callback(struct vdo_completion *completion,
-					       vdo_action *callback,
+					       vdo_action_fn callback,
 					       thread_id_t callback_thread_id)
 {
 	completion->callback = callback;
@@ -102,7 +102,7 @@ static inline void vdo_set_completion_callback(struct vdo_completion *completion
  * vdo_launch_completion_callback() - Set the callback for a completion and launch it immediately.
  */
 static inline void vdo_launch_completion_callback(struct vdo_completion *completion,
-						  vdo_action *callback,
+						  vdo_action_fn callback,
 						  thread_id_t callback_thread_id)
 {
 	vdo_set_completion_callback(completion, callback, callback_thread_id);
@@ -115,8 +115,8 @@ static inline void vdo_launch_completion_callback(struct vdo_completion *complet
  * Resets the completion, and then sets its callback, error handler, callback thread, and parent.
  */
 static inline void vdo_prepare_completion(struct vdo_completion *completion,
-					  vdo_action *callback,
-					  vdo_action *error_handler,
+					  vdo_action_fn callback,
+					  vdo_action_fn error_handler,
 					  thread_id_t callback_thread_id, void *parent)
 {
 	vdo_reset_completion(completion);
@@ -132,8 +132,8 @@ static inline void vdo_prepare_completion(struct vdo_completion *completion,
  * Resets the completion, and then sets its callback, error handler, callback thread, and parent.
  */
 static inline void vdo_prepare_completion_for_requeue(struct vdo_completion *completion,
-						      vdo_action *callback,
-						      vdo_action *error_handler,
+						      vdo_action_fn callback,
+						      vdo_action_fn error_handler,
 						      thread_id_t callback_thread_id,
 						      void *parent)
 {

--- a/drivers/md/dm-vdo/config.c
+++ b/drivers/md/dm-vdo/config.c
@@ -57,8 +57,7 @@ static bool are_matching_configurations(struct configuration *saved_config,
 
 	if (saved_config->cache_chapters != user->cache_chapters) {
 		uds_log_error("Cache size (%u) does not match (%u)",
-			      saved_config->cache_chapters,
-			      user->cache_chapters);
+			      saved_config->cache_chapters, user->cache_chapters);
 		result = false;
 	}
 
@@ -71,8 +70,7 @@ static bool are_matching_configurations(struct configuration *saved_config,
 
 	if (saved_geometry->bytes_per_page != geometry->bytes_per_page) {
 		uds_log_error("Bytes per page value (%zu) does not match (%zu)",
-			      saved_geometry->bytes_per_page,
-			      geometry->bytes_per_page);
+			      saved_geometry->bytes_per_page, geometry->bytes_per_page);
 		result = false;
 	}
 
@@ -94,7 +92,8 @@ static bool are_matching_configurations(struct configuration *saved_config,
 }
 
 /* Read the configuration and validate it against the provided one. */
-int uds_validate_config_contents(struct buffered_reader *reader, struct configuration *user_config)
+int uds_validate_config_contents(struct buffered_reader *reader,
+				 struct configuration *user_config)
 {
 	int result;
 	struct configuration config;
@@ -104,12 +103,12 @@ int uds_validate_config_contents(struct buffered_reader *reader, struct configur
 	u8 buffer[sizeof(struct uds_configuration_6_02)];
 	size_t offset = 0;
 
-	result = uds_verify_buffered_data(reader, INDEX_CONFIG_MAGIC, INDEX_CONFIG_MAGIC_LENGTH);
+	result = uds_verify_buffered_data(reader, INDEX_CONFIG_MAGIC,
+					  INDEX_CONFIG_MAGIC_LENGTH);
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = uds_read_from_buffered_reader(reader,
-					       version_buffer,
+	result = uds_read_from_buffered_reader(reader, version_buffer,
 					       INDEX_CONFIG_VERSION_LENGTH);
 	if (result != UDS_SUCCESS)
 		return uds_log_error_strerror(result, "cannot read index config version");
@@ -149,13 +148,16 @@ int uds_validate_config_contents(struct buffered_reader *reader, struct configur
 	} else {
 		u8 remapping[sizeof(u64) + sizeof(u64)];
 
-		result = uds_read_from_buffered_reader(reader, remapping, sizeof(remapping));
+		result = uds_read_from_buffered_reader(reader, remapping,
+						       sizeof(remapping));
 		if (result != UDS_SUCCESS)
 			return uds_log_error_strerror(result, "cannot read converted config");
 
 		offset = 0;
-		decode_u64_le(remapping, &offset, &user_config->geometry->remapped_virtual);
-		decode_u64_le(remapping, &offset, &user_config->geometry->remapped_physical);
+		decode_u64_le(remapping, &offset,
+			      &user_config->geometry->remapped_virtual);
+		decode_u64_le(remapping, &offset,
+			      &user_config->geometry->remapped_physical);
 	}
 
 	if (!are_matching_configurations(&config, &geometry, user_config)) {
@@ -172,16 +174,14 @@ int uds_validate_config_contents(struct buffered_reader *reader, struct configur
  * been reduced by one chapter.
  */
 int uds_write_config_contents(struct buffered_writer *writer,
-			      struct configuration *config,
-			      u32 version)
+			      struct configuration *config, u32 version)
 {
 	int result;
 	struct geometry *geometry = config->geometry;
 	u8 buffer[sizeof(struct uds_configuration_8_02)];
 	size_t offset = 0;
 
-	result = uds_write_to_buffered_writer(writer,
-					      INDEX_CONFIG_MAGIC,
+	result = uds_write_to_buffered_writer(writer, INDEX_CONFIG_MAGIC,
 					      INDEX_CONFIG_MAGIC_LENGTH);
 	if (result != UDS_SUCCESS)
 		return result;
@@ -191,14 +191,12 @@ int uds_write_config_contents(struct buffered_writer *writer,
 	 * as version 6.02 so that it is still compatible with older versions of UDS.
 	 */
 	if (version >= 4) {
-		result = uds_write_to_buffered_writer(writer,
-						      INDEX_CONFIG_VERSION_8_02,
+		result = uds_write_to_buffered_writer(writer, INDEX_CONFIG_VERSION_8_02,
 						      INDEX_CONFIG_VERSION_LENGTH);
 		if (result != UDS_SUCCESS)
 			return result;
 	} else {
-		result = uds_write_to_buffered_writer(writer,
-						      INDEX_CONFIG_VERSION_6_02,
+		result = uds_write_to_buffered_writer(writer, INDEX_CONFIG_VERSION_6_02,
 						      INDEX_CONFIG_VERSION_LENGTH);
 		if (result != UDS_SUCCESS)
 			return result;
@@ -215,8 +213,7 @@ int uds_write_config_contents(struct buffered_writer *writer,
 	encode_u64_le(buffer, &offset, config->nonce);
 
 	result = ASSERT(offset == sizeof(struct uds_configuration_6_02),
-			"%zu bytes encoded, of %zu expected",
-			offset,
+			"%zu bytes encoded, of %zu expected", offset,
 			sizeof(struct uds_configuration_6_02));
 	if (result != UDS_SUCCESS)
 		return result;
@@ -230,10 +227,8 @@ int uds_write_config_contents(struct buffered_writer *writer,
 }
 
 /* Compute configuration parameters that depend on memory size. */
-static int compute_memory_sizes(uds_memory_config_size_t mem_gb,
-				bool sparse,
-				u32 *chapters_per_volume,
-				u32 *record_pages_per_chapter,
+static int compute_memory_sizes(uds_memory_config_size_t mem_gb, bool sparse,
+				u32 *chapters_per_volume, u32 *record_pages_per_chapter,
 				u32 *sparse_chapters_per_volume)
 {
 	u32 reduced_chapters = 0;
@@ -300,8 +295,7 @@ static unsigned int __must_check normalize_zone_count(unsigned int requested)
 		zone_count = MAX_ZONES;
 
 	uds_log_info("Using %u indexing zone%s for concurrency.",
-		     zone_count,
-		     zone_count == 1 ? "" : "s");
+		     zone_count, zone_count == 1 ? "" : "s");
 	return zone_count;
 }
 
@@ -318,7 +312,8 @@ static unsigned int __must_check normalize_read_threads(unsigned int requested)
 	return read_threads;
 }
 
-int uds_make_configuration(const struct uds_parameters *params, struct configuration **config_ptr)
+int uds_make_configuration(const struct uds_parameters *params,
+			   struct configuration **config_ptr)
 {
 	struct configuration *config;
 	u32 chapters_per_volume = 0;
@@ -326,10 +321,8 @@ int uds_make_configuration(const struct uds_parameters *params, struct configura
 	u32 sparse_chapters_per_volume = 0;
 	int result;
 
-	result = compute_memory_sizes(params->memory_size,
-				      params->sparse,
-				      &chapters_per_volume,
-				      &record_pages_per_chapter,
+	result = compute_memory_sizes(params->memory_size, params->sparse,
+				      &chapters_per_volume, &record_pages_per_chapter,
 				      &sparse_chapters_per_volume);
 	if (result != UDS_SUCCESS)
 		return result;
@@ -338,12 +331,8 @@ int uds_make_configuration(const struct uds_parameters *params, struct configura
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = uds_make_geometry(DEFAULT_BYTES_PER_PAGE,
-				   record_pages_per_chapter,
-				   chapters_per_volume,
-				   sparse_chapters_per_volume,
-				   0,
-				   0,
+	result = uds_make_geometry(DEFAULT_BYTES_PER_PAGE, record_pages_per_chapter,
+				   chapters_per_volume, sparse_chapters_per_volume, 0, 0,
 				   &config->geometry);
 	if (result != UDS_SUCCESS) {
 		uds_free_configuration(config);

--- a/drivers/md/dm-vdo/config.h
+++ b/drivers/md/dm-vdo/config.h
@@ -108,17 +108,16 @@ struct uds_configuration_6_02 {
 	u64 nonce;
 } __packed;
 
-int __must_check
-uds_make_configuration(const struct uds_parameters *params, struct configuration **config_ptr);
+int __must_check uds_make_configuration(const struct uds_parameters *params,
+					struct configuration **config_ptr);
 
 void uds_free_configuration(struct configuration *config);
 
-int __must_check
-uds_validate_config_contents(struct buffered_reader *reader, struct configuration *config);
+int __must_check uds_validate_config_contents(struct buffered_reader *reader,
+					      struct configuration *config);
 
 int __must_check uds_write_config_contents(struct buffered_writer *writer,
-					   struct configuration *config,
-					   u32 version);
+					   struct configuration *config, u32 version);
 
 void uds_log_configuration(struct configuration *config);
 

--- a/drivers/md/dm-vdo/cpu.h
+++ b/drivers/md/dm-vdo/cpu.h
@@ -39,7 +39,8 @@ static inline void uds_prefetch_address(const void *address, bool for_write)
  * @size: the number of bytes in the address range
  * @for_write: must be constant at compile time--false if for reading, true if for writing
  */
-static inline void uds_prefetch_range(const void *start, unsigned int size, bool for_write)
+static inline void uds_prefetch_range(const void *start, unsigned int size,
+				      bool for_write)
 {
 	/*
 	 * Count the number of cache lines to fetch, allowing for the address range to span an

--- a/drivers/md/dm-vdo/data-vio.c
+++ b/drivers/md/dm-vdo/data-vio.c
@@ -234,7 +234,8 @@ static bool check_for_drain_complete_locked(struct data_vio_pool *pool)
 	if (pool->limiter.busy > 0)
 		return false;
 
-	ASSERT_LOG_ONLY((pool->discard_limiter.busy == 0), "no outstanding discard permits");
+	ASSERT_LOG_ONLY((pool->discard_limiter.busy == 0),
+			"no outstanding discard permits");
 
 	return (bio_list_empty(&pool->limiter.new_waiters) &&
 		bio_list_empty(&pool->discard_limiter.new_waiters));
@@ -302,8 +303,7 @@ static void copy_to_bio(struct bio *bio, char *data_ptr)
 	}
 }
 
-struct data_vio_compression_status
-get_data_vio_compression_status(struct data_vio *data_vio)
+struct data_vio_compression_status get_data_vio_compression_status(struct data_vio *data_vio)
 {
 	u32 packed = atomic_read(&data_vio->compression.status);
 
@@ -432,11 +432,8 @@ static void attempt_logical_block_lock(struct vdo_completion *completion)
 		return;
 	}
 
-	result = vdo_int_map_put(lock->zone->lbn_operations,
-				 lock->lbn,
-				 data_vio,
-				 false,
-				 (void **) &lock_holder);
+	result = vdo_int_map_put(lock->zone->lbn_operations, lock->lbn,
+				 data_vio, false, (void **) &lock_holder);
 	if (result != VDO_SUCCESS) {
 		continue_data_vio_with_error(data_vio, result);
 		return;
@@ -462,7 +459,7 @@ static void attempt_logical_block_lock(struct vdo_completion *completion)
 	 * yet have an allocation, prevent it from blocking in the packer and wait on it.
 	 */
 	if (!data_vio->write && READ_ONCE(lock_holder->allocation_succeeded)) {
-		copy_to_bio(data_vio->user_bio, (lock_holder->vio.data + data_vio->offset));
+		copy_to_bio(data_vio->user_bio, lock_holder->vio.data + data_vio->offset);
 		acknowledge_data_vio(data_vio);
 		complete_data_vio(completion);
 		return;
@@ -477,7 +474,8 @@ static void attempt_logical_block_lock(struct vdo_completion *completion)
 	 */
 	if (lock_holder->write && cancel_data_vio_compression(lock_holder)) {
 		data_vio->compression.lock_holder = lock_holder;
-		launch_data_vio_packer_callback(data_vio, vdo_remove_lock_holder_from_packer);
+		launch_data_vio_packer_callback(data_vio,
+						vdo_remove_lock_holder_from_packer);
 	}
 }
 
@@ -611,8 +609,7 @@ static void get_waiters(struct limiter *limiter)
 	bio_list_init(&limiter->new_waiters);
 }
 
-static inline
-struct data_vio *get_available_data_vio(struct data_vio_pool *pool)
+static inline struct data_vio *get_available_data_vio(struct data_vio_pool *pool)
 {
 	struct data_vio *data_vio =
 		list_first_entry(&pool->available, struct data_vio, pool_entry);
@@ -633,8 +630,7 @@ static void update_limiter(struct limiter *limiter)
 
 	ASSERT_LOG_ONLY((limiter->release_count <= limiter->busy),
 			"Release count %u is not more than busy count %u",
-			limiter->release_count,
-			limiter->busy);
+			limiter->release_count, limiter->busy);
 
 	get_waiters(limiter);
 	for (; (limiter->release_count > 0) && !bio_list_empty(waiters); limiter->release_count--)
@@ -668,7 +664,8 @@ static void schedule_releases(struct data_vio_pool *pool)
 		return;
 
 	pool->completion.requeue = true;
-	vdo_launch_completion_with_priority(&pool->completion, CPU_Q_COMPLETE_VIO_PRIORITY);
+	vdo_launch_completion_with_priority(&pool->completion,
+					    CPU_Q_COMPLETE_VIO_PRIORITY);
 }
 
 static void reuse_or_release_resources(struct data_vio_pool *pool,
@@ -727,8 +724,7 @@ static void process_release_callback(struct vdo_completion *completion)
 		if (entry == NULL)
 			break;
 
-		data_vio = as_data_vio(container_of(entry,
-						    struct vdo_completion,
+		data_vio = as_data_vio(container_of(entry, struct vdo_completion,
 						    work_queue_entry_link));
 		acknowledge_data_vio(data_vio);
 		reuse_or_release_resources(pool, data_vio, &returned);
@@ -762,10 +758,8 @@ static void process_release_callback(struct vdo_completion *completion)
 	if (to_wake > 0)
 		wake_up_nr(&pool->limiter.blocked_threads, to_wake);
 
-	if (discards_to_wake > 0) {
-		wake_up_nr(&pool->discard_limiter.blocked_threads,
-			   discards_to_wake);
-	}
+	if (discards_to_wake > 0)
+		wake_up_nr(&pool->discard_limiter.blocked_threads, discards_to_wake);
 
 	if (reschedule)
 		schedule_releases(pool);
@@ -773,10 +767,8 @@ static void process_release_callback(struct vdo_completion *completion)
 		vdo_finish_draining(&pool->state);
 }
 
-static void initialize_limiter(struct limiter *limiter,
-			       struct data_vio_pool *pool,
-			       assigner *assigner,
-			       data_vio_count_t limit)
+static void initialize_limiter(struct limiter *limiter, struct data_vio_pool *pool,
+			       assigner *assigner, data_vio_count_t limit)
 {
 	limiter->pool = pool;
 	limiter->assigner = assigner;
@@ -798,28 +790,32 @@ static int initialize_data_vio(struct data_vio *data_vio, struct vdo *vdo)
 	int result;
 
 	BUILD_BUG_ON(VDO_BLOCK_SIZE > PAGE_SIZE);
-	result = uds_allocate_memory(VDO_BLOCK_SIZE, 0, "data_vio data", &data_vio->vio.data);
+	result = uds_allocate_memory(VDO_BLOCK_SIZE, 0, "data_vio data",
+				     &data_vio->vio.data);
 	if (result != VDO_SUCCESS)
-		return uds_log_error_strerror(result, "data_vio data allocation failure");
+		return uds_log_error_strerror(result,
+					      "data_vio data allocation failure");
 
-	result = uds_allocate_memory(VDO_BLOCK_SIZE,
-				     0,
-				     "compressed block",
+	result = uds_allocate_memory(VDO_BLOCK_SIZE, 0, "compressed block",
 				     &data_vio->compression.block);
 	if (result != VDO_SUCCESS) {
 		return uds_log_error_strerror(result,
 					      "data_vio compressed block allocation failure");
 	}
 
-	result = uds_allocate_memory(VDO_BLOCK_SIZE, 0, "vio scratch", &data_vio->scratch_block);
+	result = uds_allocate_memory(VDO_BLOCK_SIZE, 0, "vio scratch",
+				     &data_vio->scratch_block);
 	if (result != VDO_SUCCESS)
-		return uds_log_error_strerror(result, "data_vio scratch allocation failure");
+		return uds_log_error_strerror(result,
+					      "data_vio scratch allocation failure");
 
 	result = vdo_create_bio(&bio);
 	if (result != VDO_SUCCESS)
-		return uds_log_error_strerror(result, "data_vio data bio allocation failure");
+		return uds_log_error_strerror(result,
+					      "data_vio data bio allocation failure");
 
-	vdo_initialize_completion(&data_vio->decrement_completion, vdo, VDO_DECREMENT_COMPLETION);
+	vdo_initialize_completion(&data_vio->decrement_completion, vdo,
+				  VDO_DECREMENT_COMPLETION);
 	initialize_vio(&data_vio->vio, bio, 1, VIO_TYPE_DATA, VIO_PRIORITY_DATA, vdo);
 
 	return VDO_SUCCESS;
@@ -843,25 +839,22 @@ static void destroy_data_vio(struct data_vio *data_vio)
  * @discard_limit: The maximum number of data_vios which may be used for discards.
  * @pool: A pointer to hold the newly allocated pool.
  */
-int make_data_vio_pool(struct vdo *vdo,
-		       data_vio_count_t pool_size,
-		       data_vio_count_t discard_limit,
-		       struct data_vio_pool **pool_ptr)
+int make_data_vio_pool(struct vdo *vdo, data_vio_count_t pool_size,
+		       data_vio_count_t discard_limit, struct data_vio_pool **pool_ptr)
 {
 	int result;
 	struct data_vio_pool *pool;
 	data_vio_count_t i;
 
-	result = uds_allocate_extended(struct data_vio_pool,
-				       pool_size,
-				       struct data_vio,
-				       __func__,
-				       &pool);
+	result = uds_allocate_extended(struct data_vio_pool, pool_size, struct data_vio,
+				       __func__, &pool);
 	if (result != UDS_SUCCESS)
 		return result;
 
-	ASSERT_LOG_ONLY((discard_limit <= pool_size), "discard limit does not exceed pool size");
-	initialize_limiter(&pool->discard_limiter, pool, assign_discard_permit, discard_limit);
+	ASSERT_LOG_ONLY((discard_limit <= pool_size),
+			"discard limit does not exceed pool size");
+	initialize_limiter(&pool->discard_limiter, pool, assign_discard_permit,
+			   discard_limit);
 	pool->discard_limiter.permitted_waiters = &pool->permitted_discards;
 	initialize_limiter(&pool->limiter, pool, assign_data_vio_to_waiter, pool_size);
 	pool->limiter.permitted_waiters = &pool->limiter.waiters;
@@ -869,10 +862,8 @@ int make_data_vio_pool(struct vdo *vdo,
 	spin_lock_init(&pool->lock);
 	vdo_set_admin_state_code(&pool->state, VDO_ADMIN_STATE_NORMAL_OPERATION);
 	vdo_initialize_completion(&pool->completion, vdo, VDO_DATA_VIO_POOL_COMPLETION);
-	vdo_prepare_completion(&pool->completion,
-			       process_release_callback,
-			       process_release_callback,
-			       vdo->thread_config.cpu_thread,
+	vdo_prepare_completion(&pool->completion, process_release_callback,
+			       process_release_callback, vdo->thread_config.cpu_thread,
 			       NULL);
 
 	result = uds_make_funnel_queue(&pool->queue);
@@ -944,7 +935,8 @@ static bool acquire_permit(struct limiter *limiter, struct bio *bio)
 		DEFINE_WAIT(wait);
 
 		bio_list_add(&limiter->new_waiters, bio);
-		prepare_to_wait_exclusive(&limiter->blocked_threads, &wait, TASK_UNINTERRUPTIBLE);
+		prepare_to_wait_exclusive(&limiter->blocked_threads, &wait,
+					  TASK_UNINTERRUPTIBLE);
 		spin_unlock(&limiter->pool->lock);
 		io_schedule();
 		finish_wait(&limiter->blocked_threads, &wait);
@@ -972,7 +964,8 @@ void vdo_launch_bio(struct data_vio_pool *pool, struct bio *bio)
 
 	bio->bi_private = (void *) jiffies;
 	spin_lock(&pool->lock);
-	if ((bio_op(bio) == REQ_OP_DISCARD) && !acquire_permit(&pool->discard_limiter, bio))
+	if ((bio_op(bio) == REQ_OP_DISCARD) &&
+	    !acquire_permit(&pool->discard_limiter, bio))
 		return;
 
 	if (!acquire_permit(&pool->limiter, bio))
@@ -1000,8 +993,7 @@ static void initiate_drain(struct admin_state *state)
 static void assert_on_vdo_cpu_thread(const struct vdo *vdo, const char *name)
 {
 	ASSERT_LOG_ONLY((vdo_get_callback_thread_id() == vdo->thread_config.cpu_thread),
-			"%s called on cpu thread",
-			name);
+			"%s called on cpu thread", name);
 }
 
 /**
@@ -1011,7 +1003,8 @@ static void assert_on_vdo_cpu_thread(const struct vdo *vdo, const char *name)
 void drain_data_vio_pool(struct data_vio_pool *pool, struct vdo_completion *completion)
 {
 	assert_on_vdo_cpu_thread(completion->vdo, __func__);
-	vdo_start_draining(&pool->state, VDO_ADMIN_STATE_SUSPENDING, completion, initiate_drain);
+	vdo_start_draining(&pool->state, VDO_ADMIN_STATE_SUSPENDING, completion,
+			   initiate_drain);
 }
 
 /**
@@ -1026,13 +1019,11 @@ void resume_data_vio_pool(struct data_vio_pool *pool, struct vdo_completion *com
 
 static void dump_limiter(const char *name, struct limiter *limiter)
 {
-	uds_log_info("%s: %u of %u busy (max %u), %s",
-		     name,
-		     limiter->busy,
-		     limiter->limit,
-		     limiter->max_busy,
+	uds_log_info("%s: %u of %u busy (max %u), %s", name, limiter->busy,
+		     limiter->limit, limiter->max_busy,
 		     ((bio_list_empty(&limiter->waiters) &&
-		       bio_list_empty(&limiter->new_waiters)) ? "no waiters" : "has waiters"));
+		       bio_list_empty(&limiter->new_waiters)) ?
+		      "no waiters" : "has waiters"));
 }
 
 /**
@@ -1150,7 +1141,8 @@ static void update_data_vio_error_stats(struct data_vio *data_vio)
 			       get_data_vio_operation_name(data_vio));
 }
 
-static void perform_cleanup_stage(struct data_vio *data_vio, enum data_vio_cleanup_stage stage);
+static void perform_cleanup_stage(struct data_vio *data_vio,
+				  enum data_vio_cleanup_stage stage);
 
 /**
  * release_allocated_lock() - Release the PBN lock and/or the reference on the allocated block at
@@ -1198,16 +1190,15 @@ static void transfer_lock(struct data_vio *data_vio, struct lbn_lock *lock)
 	ASSERT_LOG_ONLY(lock->locked, "lbn_lock with waiters is not locked");
 
 	/* Another data_vio is waiting for the lock, transfer it in a single lock map operation. */
-	next_lock_holder = waiter_as_data_vio(vdo_dequeue_next_waiter(&lock->waiters));
+	next_lock_holder =
+		waiter_as_data_vio(vdo_dequeue_next_waiter(&lock->waiters));
 
 	/* Transfer the remaining lock waiters to the next lock holder. */
-	vdo_transfer_all_waiters(&lock->waiters, &next_lock_holder->logical.waiters);
+	vdo_transfer_all_waiters(&lock->waiters,
+				 &next_lock_holder->logical.waiters);
 
-	result = vdo_int_map_put(lock->zone->lbn_operations,
-				 lock->lbn,
-				 next_lock_holder,
-				 true,
-				 (void **) &lock_holder);
+	result = vdo_int_map_put(lock->zone->lbn_operations, lock->lbn,
+				 next_lock_holder, true, (void **) &lock_holder);
 	if (result != VDO_SUCCESS) {
 		continue_data_vio_with_error(next_lock_holder, result);
 		return;
@@ -1280,7 +1271,8 @@ static void finish_cleanup(struct data_vio *data_vio)
 
 	ASSERT_LOG_ONLY(data_vio->allocation.lock == NULL,
 			"complete data_vio has no allocation lock");
-	ASSERT_LOG_ONLY(data_vio->hash_lock == NULL, "complete data_vio has no hash lock");
+	ASSERT_LOG_ONLY(data_vio->hash_lock == NULL,
+			"complete data_vio has no hash lock");
 	if ((data_vio->remaining_discard <= VDO_BLOCK_SIZE) ||
 	    (completion->result != VDO_SUCCESS)) {
 		struct data_vio_pool *pool = completion->vdo->data_vio_pool;
@@ -1290,8 +1282,7 @@ static void finish_cleanup(struct data_vio *data_vio)
 		return;
 	}
 
-	data_vio->remaining_discard -= min_t(u32,
-					     data_vio->remaining_discard,
+	data_vio->remaining_discard -= min_t(u32, data_vio->remaining_discard,
 					     VDO_BLOCK_SIZE - data_vio->offset);
 	data_vio->is_partial = (data_vio->remaining_discard < VDO_BLOCK_SIZE);
 	data_vio->read = data_vio->is_partial;
@@ -1301,7 +1292,8 @@ static void finish_cleanup(struct data_vio *data_vio)
 }
 
 /** perform_cleanup_stage() - Perform the next step in the process of cleaning up a data_vio. */
-static void perform_cleanup_stage(struct data_vio *data_vio, enum data_vio_cleanup_stage stage)
+static void perform_cleanup_stage(struct data_vio *data_vio,
+				  enum data_vio_cleanup_stage stage)
 {
 	struct vdo *vdo = vdo_from_data_vio(data_vio);
 
@@ -1315,7 +1307,8 @@ static void perform_cleanup_stage(struct data_vio *data_vio, enum data_vio_clean
 
 	case VIO_RELEASE_ALLOCATED:
 		if (data_vio_has_allocation(data_vio)) {
-			launch_data_vio_allocated_zone_callback(data_vio, release_allocated_lock);
+			launch_data_vio_allocated_zone_callback(data_vio,
+								release_allocated_lock);
 			return;
 		}
 		fallthrough;
@@ -1401,8 +1394,7 @@ const char *get_data_vio_operation_name(struct data_vio *data_vio)
  */
 void data_vio_allocate_data_block(struct data_vio *data_vio,
 				  enum pbn_lock_type write_lock_type,
-				  vdo_action *callback,
-				  vdo_action *error_handler)
+				  vdo_action *callback, vdo_action *error_handler)
 {
 	struct allocation *allocation = &data_vio->allocation;
 
@@ -1432,8 +1424,7 @@ void release_data_vio_allocation_lock(struct data_vio *data_vio, bool reset)
 	if (reset || vdo_pbn_lock_has_provisional_reference(allocation->lock))
 		allocation->pbn = VDO_ZERO_BLOCK;
 
-	vdo_release_physical_zone_pbn_lock(allocation->zone,
-					   locked_pbn,
+	vdo_release_physical_zone_pbn_lock(allocation->zone, locked_pbn,
 					   uds_forget(allocation->lock));
 }
 
@@ -1443,26 +1434,21 @@ void release_data_vio_allocation_lock(struct data_vio *data_vio, bool reset)
  * @buffer: The buffer to receive the uncompressed data.
  */
 int uncompress_data_vio(struct data_vio *data_vio,
-			enum block_mapping_state mapping_state,
-			char *buffer)
+			enum block_mapping_state mapping_state, char *buffer)
 {
 	int size;
 	u16 fragment_offset, fragment_size;
 	struct compressed_block *block = data_vio->compression.block;
-	int result = vdo_get_compressed_block_fragment(mapping_state,
-						       block,
-						       &fragment_offset,
-						       &fragment_size);
+	int result = vdo_get_compressed_block_fragment(mapping_state, block,
+						       &fragment_offset, &fragment_size);
 
 	if (result != VDO_SUCCESS) {
 		uds_log_debug("%s: compressed fragment error %d", __func__, result);
 		return result;
 	}
 
-	size = LZ4_decompress_safe((block->data + fragment_offset),
-				   buffer,
-				   fragment_size,
-				   VDO_BLOCK_SIZE);
+	size = LZ4_decompress_safe((block->data + fragment_offset), buffer,
+				   fragment_size, VDO_BLOCK_SIZE);
 	if (size != VDO_BLOCK_SIZE) {
 		uds_log_debug("%s: lz4 error", __func__);
 		return VDO_INVALID_FRAGMENT;
@@ -1495,7 +1481,8 @@ static void modify_for_partial_write(struct vdo_completion *completion)
 
 	data_vio->is_zero = is_zero_block(data);
 	data_vio->read = false;
-	launch_data_vio_logical_callback(data_vio, continue_data_vio_with_block_map_slot);
+	launch_data_vio_logical_callback(data_vio,
+					 continue_data_vio_with_block_map_slot);
 }
 
 static void complete_read(struct vdo_completion *completion)
@@ -1538,7 +1525,8 @@ static void read_endio(struct bio *bio)
 		return;
 	}
 
-	launch_data_vio_cpu_callback(data_vio, complete_read, CPU_Q_COMPLETE_READ_PRIORITY);
+	launch_data_vio_cpu_callback(data_vio, complete_read,
+				     CPU_Q_COMPLETE_READ_PRIORITY);
 }
 
 static void complete_zero_read(struct vdo_completion *completion)
@@ -1572,41 +1560,29 @@ static void read_block(struct vdo_completion *completion)
 	int result = VDO_SUCCESS;
 
 	if (data_vio->mapped.pbn == VDO_ZERO_BLOCK) {
-		launch_data_vio_cpu_callback(data_vio,
-					     complete_zero_read,
+		launch_data_vio_cpu_callback(data_vio, complete_zero_read,
 					     CPU_Q_COMPLETE_VIO_PRIORITY);
 		return;
 	}
 
 	data_vio->last_async_operation = VIO_ASYNC_OP_READ_DATA_VIO;
 	if (vdo_is_state_compressed(data_vio->mapped.state)) {
-		result = vio_reset_bio(vio,
-				       (char *) data_vio->compression.block,
-				       read_endio,
-				       REQ_OP_READ,
-				       data_vio->mapped.pbn);
+		result = vio_reset_bio(vio, (char *) data_vio->compression.block,
+				       read_endio, REQ_OP_READ, data_vio->mapped.pbn);
 	} else {
 		int opf = ((data_vio->user_bio->bi_opf & PASSTHROUGH_FLAGS) | REQ_OP_READ);
 
 		if (data_vio->is_partial) {
-			result = vio_reset_bio(vio,
-					       vio->data,
-					       read_endio,
-					       opf,
+			result = vio_reset_bio(vio, vio->data, read_endio, opf,
 					       data_vio->mapped.pbn);
 		} else {
 			/* A full 4k read. Use the incoming bio to avoid having to copy the data */
 			bio_reset(vio->bio, vio->bio->bi_bdev, opf);
-			bio_init_clone(data_vio->user_bio->bi_bdev,
-				       vio->bio,
-				       data_vio->user_bio,
-				       GFP_KERNEL);
+			bio_init_clone(data_vio->user_bio->bi_bdev, vio->bio,
+				       data_vio->user_bio, GFP_KERNEL);
 
 			/* Copy over the original bio iovec and opflags. */
-			vdo_set_bio_properties(vio->bio,
-					       vio,
-					       read_endio,
-					       opf,
+			vdo_set_bio_properties(vio->bio, vio, read_endio, opf,
 					       data_vio->mapped.pbn);
 		}
 	}
@@ -1665,14 +1641,12 @@ static void update_block_map(struct vdo_completion *completion)
 
 static void decrement_reference_count(struct vdo_completion *completion)
 {
-	struct data_vio *data_vio = container_of(completion,
-						 struct data_vio,
+	struct data_vio *data_vio = container_of(completion, struct data_vio,
 						 decrement_completion);
 
 	assert_data_vio_in_mapped_zone(data_vio);
 
-	vdo_set_completion_callback(completion,
-				    update_block_map,
+	vdo_set_completion_callback(completion, update_block_map,
 				    data_vio->logical.zone->thread_id);
 	completion->error_handler = update_block_map;
 	vdo_modify_reference_count(completion, &data_vio->decrement_updater);
@@ -1714,7 +1688,8 @@ static void journal_remapping(struct vdo_completion *completion)
 		if (data_vio->mapped.pbn == VDO_ZERO_BLOCK)
 			set_data_vio_logical_callback(data_vio, update_block_map);
 	} else {
-		set_data_vio_new_mapped_zone_callback(data_vio, increment_reference_count);
+		set_data_vio_new_mapped_zone_callback(data_vio,
+						      increment_reference_count);
 	}
 
 	if (data_vio->mapped.pbn == VDO_ZERO_BLOCK) {
@@ -1796,8 +1771,7 @@ static void compress_data_vio(struct vdo_completion *completion)
 	 * need to copy it if this data_vio becomes a compressed write agent.
 	 */
 	size = LZ4_compress_default(data_vio->vio.data,
-				    data_vio->compression.block->data,
-				    VDO_BLOCK_SIZE,
+				    data_vio->compression.block->data, VDO_BLOCK_SIZE,
 				    VDO_MAX_COMPRESSED_FRAGMENT_SIZE,
 				    (char *) vdo_get_work_queue_private_data());
 	if ((size > 0) && (size < VDO_COMPRESSED_BLOCK_DATA_SIZE)) {
@@ -1817,7 +1791,8 @@ static void compress_data_vio(struct vdo_completion *completion)
 void launch_compress_data_vio(struct data_vio *data_vio)
 {
 	ASSERT_LOG_ONLY(!data_vio->is_duplicate, "compressing a non-duplicate block");
-	ASSERT_LOG_ONLY(data_vio->hash_lock != NULL, "data_vio to compress has a hash_lock");
+	ASSERT_LOG_ONLY(data_vio->hash_lock != NULL,
+			"data_vio to compress has a hash_lock");
 	ASSERT_LOG_ONLY(data_vio_has_allocation(data_vio),
 			"data_vio to compress has an allocation");
 
@@ -1845,7 +1820,8 @@ void launch_compress_data_vio(struct data_vio *data_vio)
 	}
 
 	data_vio->last_async_operation = VIO_ASYNC_OP_COMPRESS_DATA_VIO;
-	launch_data_vio_cpu_callback(data_vio, compress_data_vio, CPU_Q_COMPRESS_BLOCK_PRIORITY);
+	launch_data_vio_cpu_callback(data_vio, compress_data_vio,
+				     CPU_Q_COMPRESS_BLOCK_PRIORITY);
 }
 
 /**
@@ -1861,9 +1837,7 @@ static void hash_data_vio(struct vdo_completion *completion)
 	assert_data_vio_on_cpu_thread(data_vio);
 	ASSERT_LOG_ONLY(!data_vio->is_zero, "zero blocks should not be hashed");
 
-	murmurhash3_128(data_vio->vio.data,
-			VDO_BLOCK_SIZE,
-			0x62ea60be,
+	murmurhash3_128(data_vio->vio.data, VDO_BLOCK_SIZE, 0x62ea60be,
 			&data_vio->record_name);
 
 	data_vio->hash_zone = vdo_select_hash_zone(vdo_from_data_vio(data_vio)->hash_zones,
@@ -1895,7 +1869,8 @@ static void write_bio_finished(struct bio *bio)
 	struct data_vio *data_vio = vio_as_data_vio((struct vio *) bio->bi_private);
 
 	vdo_count_completed_bios(bio);
-	vdo_set_completion_result(&data_vio->vio.completion, blk_status_to_errno(bio->bi_status));
+	vdo_set_completion_result(&data_vio->vio.completion,
+				  blk_status_to_errno(bio->bi_status));
 	data_vio->downgrade_allocation_lock = true;
 	update_metadata_for_data_vio_write(data_vio, data_vio->allocation.lock);
 }
@@ -1926,10 +1901,8 @@ void write_data_vio(struct data_vio *data_vio)
 		 !set_data_vio_compression_status(data_vio, status, new_status));
 
 	/* Write the data from the data block buffer. */
-	result = vio_reset_bio(&data_vio->vio,
-			       data_vio->vio.data,
-			       write_bio_finished,
-			       REQ_OP_WRITE,
+	result = vio_reset_bio(&data_vio->vio, data_vio->vio.data,
+			       write_bio_finished, REQ_OP_WRITE,
 			       data_vio->allocation.pbn);
 	if (result != VDO_SUCCESS) {
 		continue_data_vio_with_error(data_vio, result);
@@ -1952,8 +1925,7 @@ static void acknowledge_write_callback(struct vdo_completion *completion)
 
 	ASSERT_LOG_ONLY((!vdo_uses_bio_ack_queue(vdo) ||
 			 (vdo_get_callback_thread_id() == vdo->thread_config.bio_ack_thread)),
-			"%s() called on bio ack queue",
-			__func__);
+			"%s() called on bio ack queue", __func__);
 	ASSERT_LOG_ONLY(data_vio_has_flush_generation_lock(data_vio),
 			"write VIO to be acknowledged has a flush generation lock");
 	acknowledge_data_vio(data_vio);
@@ -2020,7 +1992,8 @@ static void handle_allocation_error(struct vdo_completion *completion)
 
 static int assert_is_trim(struct data_vio *data_vio)
 {
-	int result = ASSERT(data_vio->is_trim, "data_vio with no block map page is a trim");
+	int result = ASSERT(data_vio->is_trim,
+			    "data_vio with no block map page is a trim");
 
 	return ((result == VDO_SUCCESS) ? result : VDO_READ_ONLY);
 }
@@ -2059,9 +2032,7 @@ void continue_data_vio_with_block_map_slot(struct vdo_completion *completion)
 	 * full-block zero write.
 	 */
 	if (!data_vio->is_zero && (!data_vio->is_trim || data_vio->is_partial)) {
-		data_vio_allocate_data_block(data_vio,
-					     VIO_WRITE_LOCK,
-					     allocate_block,
+		data_vio_allocate_data_block(data_vio, VIO_WRITE_LOCK, allocate_block,
 					     handle_allocation_error);
 		return;
 	}

--- a/drivers/md/dm-vdo/data-vio.h
+++ b/drivers/md/dm-vdo/data-vio.h
@@ -379,7 +379,7 @@ static inline void assert_data_vio_in_hash_zone(struct data_vio *data_vio)
 }
 
 static inline void set_data_vio_hash_zone_callback(struct data_vio *data_vio,
-						   vdo_action *callback)
+						   vdo_action_fn callback)
 {
 	vdo_set_completion_callback(&data_vio->vio.completion, callback,
 				    data_vio->hash_zone->thread_id);
@@ -390,7 +390,7 @@ static inline void set_data_vio_hash_zone_callback(struct data_vio *data_vio,
  *					  immediately.
  */
 static inline void launch_data_vio_hash_zone_callback(struct data_vio *data_vio,
-						      vdo_action *callback)
+						      vdo_action_fn callback)
 {
 	set_data_vio_hash_zone_callback(data_vio, callback);
 	vdo_launch_completion(&data_vio->vio.completion);
@@ -407,7 +407,7 @@ static inline void assert_data_vio_in_logical_zone(struct data_vio *data_vio)
 }
 
 static inline void set_data_vio_logical_callback(struct data_vio *data_vio,
-						 vdo_action *callback)
+						 vdo_action_fn callback)
 {
 	vdo_set_completion_callback(&data_vio->vio.completion, callback,
 				    data_vio->logical.zone->thread_id);
@@ -418,7 +418,7 @@ static inline void set_data_vio_logical_callback(struct data_vio *data_vio,
  *					immediately.
  */
 static inline void launch_data_vio_logical_callback(struct data_vio *data_vio,
-						    vdo_action *callback)
+						    vdo_action_fn callback)
 {
 	set_data_vio_logical_callback(data_vio, callback);
 	vdo_launch_completion(&data_vio->vio.completion);
@@ -436,7 +436,7 @@ static inline void assert_data_vio_in_allocated_zone(struct data_vio *data_vio)
 }
 
 static inline void set_data_vio_allocated_zone_callback(struct data_vio *data_vio,
-							vdo_action *callback)
+							vdo_action_fn callback)
 {
 	vdo_set_completion_callback(&data_vio->vio.completion, callback,
 				    data_vio->allocation.zone->thread_id);
@@ -448,7 +448,7 @@ static inline void set_data_vio_allocated_zone_callback(struct data_vio *data_vi
  *					       invoke it immediately.
  */
 static inline void launch_data_vio_allocated_zone_callback(struct data_vio *data_vio,
-							   vdo_action *callback)
+							   vdo_action_fn callback)
 {
 	set_data_vio_allocated_zone_callback(data_vio, callback);
 	vdo_launch_completion(&data_vio->vio.completion);
@@ -466,7 +466,7 @@ static inline void assert_data_vio_in_duplicate_zone(struct data_vio *data_vio)
 }
 
 static inline void set_data_vio_duplicate_zone_callback(struct data_vio *data_vio,
-							vdo_action *callback)
+							vdo_action_fn callback)
 {
 	vdo_set_completion_callback(&data_vio->vio.completion, callback,
 				    data_vio->duplicate.zone->thread_id);
@@ -478,7 +478,7 @@ static inline void set_data_vio_duplicate_zone_callback(struct data_vio *data_vi
  *					       invoke it immediately.
  */
 static inline void launch_data_vio_duplicate_zone_callback(struct data_vio *data_vio,
-							   vdo_action *callback)
+							   vdo_action_fn callback)
 {
 	set_data_vio_duplicate_zone_callback(data_vio, callback);
 	vdo_launch_completion(&data_vio->vio.completion);
@@ -495,7 +495,7 @@ static inline void assert_data_vio_in_mapped_zone(struct data_vio *data_vio)
 }
 
 static inline void set_data_vio_mapped_zone_callback(struct data_vio *data_vio,
-						     vdo_action *callback)
+						     vdo_action_fn callback)
 {
 	vdo_set_completion_callback(&data_vio->vio.completion, callback,
 				    data_vio->mapped.zone->thread_id);
@@ -513,7 +513,7 @@ static inline void assert_data_vio_in_new_mapped_zone(struct data_vio *data_vio)
 }
 
 static inline void set_data_vio_new_mapped_zone_callback(struct data_vio *data_vio,
-							 vdo_action *callback)
+							 vdo_action_fn callback)
 {
 	vdo_set_completion_callback(&data_vio->vio.completion, callback,
 				    data_vio->new_mapped.zone->thread_id);
@@ -531,7 +531,7 @@ static inline void assert_data_vio_in_journal_zone(struct data_vio *data_vio)
 }
 
 static inline void set_data_vio_journal_callback(struct data_vio *data_vio,
-						 vdo_action *callback)
+						 vdo_action_fn callback)
 {
 	thread_id_t journal_thread = vdo_from_data_vio(data_vio)->thread_config.journal_thread;
 
@@ -543,7 +543,7 @@ static inline void set_data_vio_journal_callback(struct data_vio *data_vio,
  *					immediately.
  */
 static inline void launch_data_vio_journal_callback(struct data_vio *data_vio,
-						    vdo_action *callback)
+						    vdo_action_fn callback)
 {
 	set_data_vio_journal_callback(data_vio, callback);
 	vdo_launch_completion(&data_vio->vio.completion);
@@ -561,7 +561,7 @@ static inline void assert_data_vio_in_packer_zone(struct data_vio *data_vio)
 }
 
 static inline void set_data_vio_packer_callback(struct data_vio *data_vio,
-						vdo_action *callback)
+						vdo_action_fn callback)
 {
 	thread_id_t packer_thread = vdo_from_data_vio(data_vio)->thread_config.packer_thread;
 
@@ -573,7 +573,7 @@ static inline void set_data_vio_packer_callback(struct data_vio *data_vio,
  *				       immediately.
  */
 static inline void launch_data_vio_packer_callback(struct data_vio *data_vio,
-						   vdo_action *callback)
+						   vdo_action_fn callback)
 {
 	set_data_vio_packer_callback(data_vio, callback);
 	vdo_launch_completion(&data_vio->vio.completion);
@@ -591,7 +591,7 @@ static inline void assert_data_vio_on_cpu_thread(struct data_vio *data_vio)
 }
 
 static inline void set_data_vio_cpu_callback(struct data_vio *data_vio,
-					     vdo_action *callback)
+					     vdo_action_fn callback)
 {
 	thread_id_t cpu_thread = vdo_from_data_vio(data_vio)->thread_config.cpu_thread;
 
@@ -603,7 +603,7 @@ static inline void set_data_vio_cpu_callback(struct data_vio *data_vio,
  *				    immediately.
  */
 static inline void launch_data_vio_cpu_callback(struct data_vio *data_vio,
-						vdo_action *callback,
+						vdo_action_fn callback,
 						enum vdo_completion_priority priority)
 {
 	set_data_vio_cpu_callback(data_vio, callback);
@@ -611,7 +611,7 @@ static inline void launch_data_vio_cpu_callback(struct data_vio *data_vio,
 }
 
 static inline void set_data_vio_bio_zone_callback(struct data_vio *data_vio,
-						  vdo_action *callback)
+						  vdo_action_fn callback)
 {
 	vdo_set_completion_callback(&data_vio->vio.completion, callback,
 				    get_vio_bio_zone_thread_id(&data_vio->vio));
@@ -622,7 +622,7 @@ static inline void set_data_vio_bio_zone_callback(struct data_vio *data_vio,
  *					 immediately.
  */
 static inline void launch_data_vio_bio_zone_callback(struct data_vio *data_vio,
-						     vdo_action *callback)
+						     vdo_action_fn callback)
 {
 	set_data_vio_bio_zone_callback(data_vio, callback);
 	vdo_launch_completion_with_priority(&data_vio->vio.completion,
@@ -635,7 +635,7 @@ static inline void launch_data_vio_bio_zone_callback(struct data_vio *data_vio,
  *					callback on the current thread.
  */
 static inline void launch_data_vio_on_bio_ack_queue(struct data_vio *data_vio,
-						    vdo_action *callback)
+						    vdo_action_fn callback)
 {
 	struct vdo_completion *completion = &data_vio->vio.completion;
 	struct vdo *vdo = completion->vdo;
@@ -652,7 +652,7 @@ static inline void launch_data_vio_on_bio_ack_queue(struct data_vio *data_vio,
 
 void data_vio_allocate_data_block(struct data_vio *data_vio,
 				  enum pbn_lock_type write_lock_type,
-				  vdo_action *callback, vdo_action *error_handler);
+				  vdo_action_fn callback, vdo_action_fn error_handler);
 
 void release_data_vio_allocation_lock(struct data_vio *data_vio, bool reset);
 

--- a/drivers/md/dm-vdo/data-vio.h
+++ b/drivers/md/dm-vdo/data-vio.h
@@ -296,8 +296,7 @@ static inline struct data_vio *waiter_as_data_vio(struct waiter *waiter)
 	return container_of(waiter, struct data_vio, waiter);
 }
 
-static inline struct data_vio *
-data_vio_from_reference_updater(struct reference_updater *updater)
+static inline struct data_vio *data_vio_from_reference_updater(struct reference_updater *updater)
 {
 	if (updater->increment)
 		return container_of(updater, struct data_vio, increment_updater);
@@ -328,10 +327,8 @@ bool cancel_data_vio_compression(struct data_vio *data_vio);
 
 struct data_vio_pool;
 
-int make_data_vio_pool(struct vdo *vdo,
-		       data_vio_count_t pool_size,
-		       data_vio_count_t discard_limit,
-		       struct data_vio_pool **pool_ptr);
+int make_data_vio_pool(struct vdo *vdo, data_vio_count_t pool_size,
+		       data_vio_count_t discard_limit, struct data_vio_pool **pool_ptr);
 void free_data_vio_pool(struct data_vio_pool *pool);
 void vdo_launch_bio(struct data_vio_pool *pool, struct bio *bio);
 void drain_data_vio_pool(struct data_vio_pool *pool, struct vdo_completion *completion);
@@ -341,8 +338,8 @@ void dump_data_vio_pool(struct data_vio_pool *pool, bool dump_vios);
 data_vio_count_t get_data_vio_pool_active_discards(struct data_vio_pool *pool);
 data_vio_count_t get_data_vio_pool_discard_limit(struct data_vio_pool *pool);
 data_vio_count_t get_data_vio_pool_maximum_discards(struct data_vio_pool *pool);
-int __must_check
-set_data_vio_pool_discard_limit(struct data_vio_pool *pool, data_vio_count_t limit);
+int __must_check set_data_vio_pool_discard_limit(struct data_vio_pool *pool,
+						 data_vio_count_t limit);
 data_vio_count_t get_data_vio_pool_active_requests(struct data_vio_pool *pool);
 data_vio_count_t get_data_vio_pool_request_limit(struct data_vio_pool *pool);
 data_vio_count_t get_data_vio_pool_maximum_requests(struct data_vio_pool *pool);
@@ -378,15 +375,13 @@ static inline void assert_data_vio_in_hash_zone(struct data_vio *data_vio)
 	 */
 	ASSERT_LOG_ONLY((expected == thread_id),
 			"data_vio for logical block %llu on thread %u, should be on hash zone thread %u",
-			(unsigned long long) data_vio->logical.lbn,
-			thread_id,
-			expected);
+			(unsigned long long) data_vio->logical.lbn, thread_id, expected);
 }
 
-static inline void set_data_vio_hash_zone_callback(struct data_vio *data_vio, vdo_action *callback)
+static inline void set_data_vio_hash_zone_callback(struct data_vio *data_vio,
+						   vdo_action *callback)
 {
-	vdo_set_completion_callback(&data_vio->vio.completion,
-				    callback,
+	vdo_set_completion_callback(&data_vio->vio.completion, callback,
 				    data_vio->hash_zone->thread_id);
 }
 
@@ -394,8 +389,8 @@ static inline void set_data_vio_hash_zone_callback(struct data_vio *data_vio, vd
  * launch_data_vio_hash_zone_callback() - Set a callback as a hash zone operation and invoke it
  *					  immediately.
  */
-static inline void
-launch_data_vio_hash_zone_callback(struct data_vio *data_vio, vdo_action *callback)
+static inline void launch_data_vio_hash_zone_callback(struct data_vio *data_vio,
+						      vdo_action *callback)
 {
 	set_data_vio_hash_zone_callback(data_vio, callback);
 	vdo_launch_completion(&data_vio->vio.completion);
@@ -408,15 +403,13 @@ static inline void assert_data_vio_in_logical_zone(struct data_vio *data_vio)
 
 	ASSERT_LOG_ONLY((expected == thread_id),
 			"data_vio for logical block %llu on thread %u, should be on thread %u",
-			(unsigned long long) data_vio->logical.lbn,
-			thread_id,
-			expected);
+			(unsigned long long) data_vio->logical.lbn, thread_id, expected);
 }
 
-static inline void set_data_vio_logical_callback(struct data_vio *data_vio, vdo_action *callback)
+static inline void set_data_vio_logical_callback(struct data_vio *data_vio,
+						 vdo_action *callback)
 {
-	vdo_set_completion_callback(&data_vio->vio.completion,
-				    callback,
+	vdo_set_completion_callback(&data_vio->vio.completion, callback,
 				    data_vio->logical.zone->thread_id);
 }
 
@@ -424,8 +417,8 @@ static inline void set_data_vio_logical_callback(struct data_vio *data_vio, vdo_
  * launch_data_vio_logical_callback() - Set a callback as a logical block operation and invoke it
  *					immediately.
  */
-static inline void
-launch_data_vio_logical_callback(struct data_vio *data_vio, vdo_action *callback)
+static inline void launch_data_vio_logical_callback(struct data_vio *data_vio,
+						    vdo_action *callback)
 {
 	set_data_vio_logical_callback(data_vio, callback);
 	vdo_launch_completion(&data_vio->vio.completion);
@@ -438,16 +431,14 @@ static inline void assert_data_vio_in_allocated_zone(struct data_vio *data_vio)
 
 	ASSERT_LOG_ONLY((expected == thread_id),
 			"struct data_vio for allocated physical block %llu on thread %u, should be on thread %u",
-			(unsigned long long) data_vio->allocation.pbn,
-			thread_id,
+			(unsigned long long) data_vio->allocation.pbn, thread_id,
 			expected);
 }
 
-static inline void
-set_data_vio_allocated_zone_callback(struct data_vio *data_vio, vdo_action *callback)
+static inline void set_data_vio_allocated_zone_callback(struct data_vio *data_vio,
+							vdo_action *callback)
 {
-	vdo_set_completion_callback(&data_vio->vio.completion,
-				    callback,
+	vdo_set_completion_callback(&data_vio->vio.completion, callback,
 				    data_vio->allocation.zone->thread_id);
 }
 
@@ -456,8 +447,8 @@ set_data_vio_allocated_zone_callback(struct data_vio *data_vio, vdo_action *call
  *					       data_vio's allocated zone and queue the data_vio and
  *					       invoke it immediately.
  */
-static inline void
-launch_data_vio_allocated_zone_callback(struct data_vio *data_vio, vdo_action *callback)
+static inline void launch_data_vio_allocated_zone_callback(struct data_vio *data_vio,
+							   vdo_action *callback)
 {
 	set_data_vio_allocated_zone_callback(data_vio, callback);
 	vdo_launch_completion(&data_vio->vio.completion);
@@ -470,16 +461,14 @@ static inline void assert_data_vio_in_duplicate_zone(struct data_vio *data_vio)
 
 	ASSERT_LOG_ONLY((expected == thread_id),
 			"data_vio for duplicate physical block %llu on thread %u, should be on thread %u",
-			(unsigned long long) data_vio->duplicate.pbn,
-			thread_id,
+			(unsigned long long) data_vio->duplicate.pbn, thread_id,
 			expected);
 }
 
-static inline void
-set_data_vio_duplicate_zone_callback(struct data_vio *data_vio, vdo_action *callback)
+static inline void set_data_vio_duplicate_zone_callback(struct data_vio *data_vio,
+							vdo_action *callback)
 {
-	vdo_set_completion_callback(&data_vio->vio.completion,
-				    callback,
+	vdo_set_completion_callback(&data_vio->vio.completion, callback,
 				    data_vio->duplicate.zone->thread_id);
 }
 
@@ -488,8 +477,8 @@ set_data_vio_duplicate_zone_callback(struct data_vio *data_vio, vdo_action *call
  *					       data_vio's duplicate zone and queue the data_vio and
  *					       invoke it immediately.
  */
-static inline void
-launch_data_vio_duplicate_zone_callback(struct data_vio *data_vio, vdo_action *callback)
+static inline void launch_data_vio_duplicate_zone_callback(struct data_vio *data_vio,
+							   vdo_action *callback)
 {
 	set_data_vio_duplicate_zone_callback(data_vio, callback);
 	vdo_launch_completion(&data_vio->vio.completion);
@@ -502,16 +491,13 @@ static inline void assert_data_vio_in_mapped_zone(struct data_vio *data_vio)
 
 	ASSERT_LOG_ONLY((expected == thread_id),
 			"data_vio for mapped physical block %llu on thread %u, should be on thread %u",
-			(unsigned long long) data_vio->mapped.pbn,
-			thread_id,
-			expected);
+			(unsigned long long) data_vio->mapped.pbn, thread_id, expected);
 }
 
-static inline void
-set_data_vio_mapped_zone_callback(struct data_vio *data_vio, vdo_action *callback)
+static inline void set_data_vio_mapped_zone_callback(struct data_vio *data_vio,
+						     vdo_action *callback)
 {
-	vdo_set_completion_callback(&data_vio->vio.completion,
-				    callback,
+	vdo_set_completion_callback(&data_vio->vio.completion, callback,
 				    data_vio->mapped.zone->thread_id);
 }
 
@@ -522,16 +508,14 @@ static inline void assert_data_vio_in_new_mapped_zone(struct data_vio *data_vio)
 
 	ASSERT_LOG_ONLY((expected == thread_id),
 			"data_vio for new_mapped physical block %llu on thread %u, should be on thread %u",
-			(unsigned long long) data_vio->new_mapped.pbn,
-			thread_id,
+			(unsigned long long) data_vio->new_mapped.pbn, thread_id,
 			expected);
 }
 
-static inline void
-set_data_vio_new_mapped_zone_callback(struct data_vio *data_vio, vdo_action *callback)
+static inline void set_data_vio_new_mapped_zone_callback(struct data_vio *data_vio,
+							 vdo_action *callback)
 {
-	vdo_set_completion_callback(&data_vio->vio.completion,
-				    callback,
+	vdo_set_completion_callback(&data_vio->vio.completion, callback,
 				    data_vio->new_mapped.zone->thread_id);
 }
 
@@ -542,12 +526,12 @@ static inline void assert_data_vio_in_journal_zone(struct data_vio *data_vio)
 
 	ASSERT_LOG_ONLY((journal_thread == thread_id),
 			"data_vio for logical block %llu on thread %u, should be on journal thread %u",
-			(unsigned long long) data_vio->logical.lbn,
-			thread_id,
+			(unsigned long long) data_vio->logical.lbn, thread_id,
 			journal_thread);
 }
 
-static inline void set_data_vio_journal_callback(struct data_vio *data_vio, vdo_action *callback)
+static inline void set_data_vio_journal_callback(struct data_vio *data_vio,
+						 vdo_action *callback)
 {
 	thread_id_t journal_thread = vdo_from_data_vio(data_vio)->thread_config.journal_thread;
 
@@ -558,8 +542,8 @@ static inline void set_data_vio_journal_callback(struct data_vio *data_vio, vdo_
  * launch_data_vio_journal_callback() - Set a callback as a journal operation and invoke it
  *					immediately.
  */
-static inline void
-launch_data_vio_journal_callback(struct data_vio *data_vio, vdo_action *callback)
+static inline void launch_data_vio_journal_callback(struct data_vio *data_vio,
+						    vdo_action *callback)
 {
 	set_data_vio_journal_callback(data_vio, callback);
 	vdo_launch_completion(&data_vio->vio.completion);
@@ -572,12 +556,12 @@ static inline void assert_data_vio_in_packer_zone(struct data_vio *data_vio)
 
 	ASSERT_LOG_ONLY((packer_thread == thread_id),
 			"data_vio for logical block %llu on thread %u, should be on packer thread %u",
-			(unsigned long long) data_vio->logical.lbn,
-			thread_id,
+			(unsigned long long) data_vio->logical.lbn, thread_id,
 			packer_thread);
 }
 
-static inline void set_data_vio_packer_callback(struct data_vio *data_vio, vdo_action *callback)
+static inline void set_data_vio_packer_callback(struct data_vio *data_vio,
+						vdo_action *callback)
 {
 	thread_id_t packer_thread = vdo_from_data_vio(data_vio)->thread_config.packer_thread;
 
@@ -588,7 +572,8 @@ static inline void set_data_vio_packer_callback(struct data_vio *data_vio, vdo_a
  * launch_data_vio_packer_callback() - Set a callback as a packer operation and invoke it
  *				       immediately.
  */
-static inline void launch_data_vio_packer_callback(struct data_vio *data_vio, vdo_action *callback)
+static inline void launch_data_vio_packer_callback(struct data_vio *data_vio,
+						   vdo_action *callback)
 {
 	set_data_vio_packer_callback(data_vio, callback);
 	vdo_launch_completion(&data_vio->vio.completion);
@@ -601,12 +586,12 @@ static inline void assert_data_vio_on_cpu_thread(struct data_vio *data_vio)
 
 	ASSERT_LOG_ONLY((cpu_thread == thread_id),
 			"data_vio for logical block %llu on thread %u, should be on cpu thread %u",
-			(unsigned long long) data_vio->logical.lbn,
-			thread_id,
+			(unsigned long long) data_vio->logical.lbn, thread_id,
 			cpu_thread);
 }
 
-static inline void set_data_vio_cpu_callback(struct data_vio *data_vio, vdo_action *callback)
+static inline void set_data_vio_cpu_callback(struct data_vio *data_vio,
+					     vdo_action *callback)
 {
 	thread_id_t cpu_thread = vdo_from_data_vio(data_vio)->thread_config.cpu_thread;
 
@@ -617,19 +602,18 @@ static inline void set_data_vio_cpu_callback(struct data_vio *data_vio, vdo_acti
  * launch_data_vio_cpu_callback() - Set a callback to run on the CPU queues and invoke it
  *				    immediately.
  */
-static inline void
-launch_data_vio_cpu_callback(struct data_vio *data_vio,
-			     vdo_action *callback,
-			     enum vdo_completion_priority priority)
+static inline void launch_data_vio_cpu_callback(struct data_vio *data_vio,
+						vdo_action *callback,
+						enum vdo_completion_priority priority)
 {
 	set_data_vio_cpu_callback(data_vio, callback);
 	vdo_launch_completion_with_priority(&data_vio->vio.completion, priority);
 }
 
-static inline void set_data_vio_bio_zone_callback(struct data_vio *data_vio, vdo_action *callback)
+static inline void set_data_vio_bio_zone_callback(struct data_vio *data_vio,
+						  vdo_action *callback)
 {
-	vdo_set_completion_callback(&data_vio->vio.completion,
-				    callback,
+	vdo_set_completion_callback(&data_vio->vio.completion, callback,
 				    get_vio_bio_zone_thread_id(&data_vio->vio));
 }
 
@@ -637,11 +621,12 @@ static inline void set_data_vio_bio_zone_callback(struct data_vio *data_vio, vdo
  * launch_data_vio_bio_zone_callback() - Set a callback as a bio zone operation and invoke it
  *					 immediately.
  */
-static inline void
-launch_data_vio_bio_zone_callback(struct data_vio *data_vio, vdo_action *callback)
+static inline void launch_data_vio_bio_zone_callback(struct data_vio *data_vio,
+						     vdo_action *callback)
 {
 	set_data_vio_bio_zone_callback(data_vio, callback);
-	vdo_launch_completion_with_priority(&data_vio->vio.completion, BIO_Q_DATA_PRIORITY);
+	vdo_launch_completion_with_priority(&data_vio->vio.completion,
+					    BIO_Q_DATA_PRIORITY);
 }
 
 /**
@@ -649,8 +634,8 @@ launch_data_vio_bio_zone_callback(struct data_vio *data_vio, vdo_action *callbac
  *					it and invoke it immediately, otherwise, just run the
  *					callback on the current thread.
  */
-static inline void
-launch_data_vio_on_bio_ack_queue(struct data_vio *data_vio, vdo_action *callback)
+static inline void launch_data_vio_on_bio_ack_queue(struct data_vio *data_vio,
+						    vdo_action *callback)
 {
 	struct vdo_completion *completion = &data_vio->vio.completion;
 	struct vdo *vdo = completion->vdo;
@@ -660,14 +645,14 @@ launch_data_vio_on_bio_ack_queue(struct data_vio *data_vio, vdo_action *callback
 		return;
 	}
 
-	vdo_set_completion_callback(completion, callback, vdo->thread_config.bio_ack_thread);
+	vdo_set_completion_callback(completion, callback,
+				    vdo->thread_config.bio_ack_thread);
 	vdo_launch_completion_with_priority(completion, BIO_ACK_Q_ACK_PRIORITY);
 }
 
 void data_vio_allocate_data_block(struct data_vio *data_vio,
 				  enum pbn_lock_type write_lock_type,
-				  vdo_action *callback,
-				  vdo_action *error_handler);
+				  vdo_action *callback, vdo_action *error_handler);
 
 void release_data_vio_allocation_lock(struct data_vio *data_vio, bool reset);
 
@@ -675,7 +660,8 @@ int __must_check uncompress_data_vio(struct data_vio *data_vio,
 				     enum block_mapping_state mapping_state,
 				     char *buffer);
 
-void update_metadata_for_data_vio_write(struct data_vio *data_vio, struct pbn_lock *lock);
+void update_metadata_for_data_vio_write(struct data_vio *data_vio,
+					struct pbn_lock *lock);
 void write_data_vio(struct data_vio *data_vio);
 void launch_compress_data_vio(struct data_vio *data_vio);
 void continue_data_vio_with_block_map_slot(struct vdo_completion *completion);

--- a/drivers/md/dm-vdo/dedupe.c
+++ b/drivers/md/dm-vdo/dedupe.c
@@ -328,8 +328,7 @@ static inline struct hash_zones *as_hash_zones(struct vdo_completion *completion
 static inline void assert_in_hash_zone(struct hash_zone *zone, const char *name)
 {
 	ASSERT_LOG_ONLY((vdo_get_callback_thread_id() == zone->thread_id),
-			"%s called on hash zone thread",
-			name);
+			"%s called on hash zone thread", name);
 }
 
 static inline bool change_context_state(struct dedupe_context *context, int old, int new)
@@ -475,7 +474,8 @@ static void set_hash_lock(struct data_vio *data_vio, struct hash_lock *new_lock)
 }
 
 /* There are loops in the state diagram, so some forward decl's are needed. */
-static void start_deduping(struct hash_lock *lock, struct data_vio *agent, bool agent_is_done);
+static void start_deduping(struct hash_lock *lock, struct data_vio *agent,
+			   bool agent_is_done);
 static void start_locking(struct hash_lock *lock, struct data_vio *agent);
 static void start_writing(struct hash_lock *lock, struct data_vio *agent);
 static void unlock_duplicate_pbn(struct vdo_completion *completion);
@@ -503,7 +503,8 @@ static void exit_hash_lock(struct data_vio *data_vio)
  * @data_vio: The data_vio to modify.
  * @source: The location of the duplicate.
  */
-static void set_duplicate_location(struct data_vio *data_vio, const struct zoned_pbn source)
+static void set_duplicate_location(struct data_vio *data_vio,
+				   const struct zoned_pbn source)
 {
 	data_vio->is_duplicate = (source.pbn != VDO_ZERO_BLOCK);
 	data_vio->duplicate = source;
@@ -684,10 +685,10 @@ static void unlock_duplicate_pbn(struct vdo_completion *completion)
 	struct hash_lock *lock = agent->hash_lock;
 
 	assert_data_vio_in_duplicate_zone(agent);
-	ASSERT_LOG_ONLY(lock->duplicate_lock != NULL, "must have a duplicate lock to release");
+	ASSERT_LOG_ONLY(lock->duplicate_lock != NULL,
+			"must have a duplicate lock to release");
 
-	vdo_release_physical_zone_pbn_lock(agent->duplicate.zone,
-					   agent->duplicate.pbn,
+	vdo_release_physical_zone_pbn_lock(agent->duplicate.zone, agent->duplicate.pbn,
 					   uds_forget(lock->duplicate_lock));
 	if (lock->state == VDO_HASH_LOCK_BYPASSING) {
 		complete_data_vio(completion);
@@ -867,7 +868,8 @@ static int __must_check acquire_lock(struct hash_zone *zone,
 	 * Borrow and prepare a lock from the pool so we don't have to do two pointer_map accesses
 	 * in the common case of no lock contention.
 	 */
-	result = ASSERT(!list_empty(&zone->lock_pool), "never need to wait for a free hash lock");
+	result = ASSERT(!list_empty(&zone->lock_pool),
+			"never need to wait for a free hash lock");
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -880,11 +882,8 @@ static int __must_check acquire_lock(struct hash_zone *zone,
 	 */
 	new_lock->hash = *hash;
 
-	result = vdo_pointer_map_put(zone->hash_lock_map,
-				     &new_lock->hash,
-				     new_lock,
-				     (replace_lock != NULL),
-				     (void **) &lock);
+	result = vdo_pointer_map_put(zone->hash_lock_map, &new_lock->hash, new_lock,
+				     (replace_lock != NULL), (void **) &lock);
 	if (result != VDO_SUCCESS) {
 		return_hash_lock_to_pool(zone, uds_forget(new_lock));
 		return result;
@@ -892,7 +891,8 @@ static int __must_check acquire_lock(struct hash_zone *zone,
 
 	if (replace_lock != NULL) {
 		/* On mismatch put the old lock back and return a severe error */
-		ASSERT_LOG_ONLY(lock == replace_lock, "old lock must have been in the lock map");
+		ASSERT_LOG_ONLY(lock == replace_lock,
+				"old lock must have been in the lock map");
 		/* TODO: Check earlier and bail out? */
 		ASSERT_LOG_ONLY(replace_lock->registered,
 				"old lock must have been marked registered");
@@ -939,7 +939,8 @@ static void fork_hash_lock(struct hash_lock *old_lock, struct data_vio *new_agen
 	struct hash_lock *new_lock;
 	int result;
 
-	result = acquire_lock(new_agent->hash_zone, &new_agent->record_name, old_lock, &new_lock);
+	result = acquire_lock(new_agent->hash_zone, &new_agent->record_name, old_lock,
+			      &new_lock);
 	if (result != VDO_SUCCESS) {
 		continue_data_vio_with_error(new_agent, result);
 		return;
@@ -971,7 +972,8 @@ static void fork_hash_lock(struct hash_lock *old_lock, struct data_vio *new_agen
  * If no increments are available, this will roll over to a new hash lock and launch the data_vio
  * as the writing agent for that lock.
  */
-static void launch_dedupe(struct hash_lock *lock, struct data_vio *data_vio, bool has_claim)
+static void launch_dedupe(struct hash_lock *lock, struct data_vio *data_vio,
+			  bool has_claim)
 {
 	if (!has_claim && !vdo_claim_pbn_lock_increment(lock->duplicate_lock)) {
 		/* Out of increments, so must roll over to a new lock. */
@@ -995,7 +997,8 @@ static void launch_dedupe(struct hash_lock *lock, struct data_vio *data_vio, boo
  * If the agent itself needs to deduplicate, an increment for it must already have been claimed
  * from the duplicate lock, ensuring the hash lock will still have a data_vio holding it.
  */
-static void start_deduping(struct hash_lock *lock, struct data_vio *agent, bool agent_is_done)
+static void start_deduping(struct hash_lock *lock, struct data_vio *agent,
+			   bool agent_is_done)
 {
 	lock->state = VDO_HASH_LOCK_DEDUPING;
 
@@ -1006,7 +1009,8 @@ static void start_deduping(struct hash_lock *lock, struct data_vio *agent, bool 
 	if (lock->duplicate_lock == NULL) {
 		ASSERT_LOG_ONLY(!vdo_is_state_compressed(agent->new_mapped.state),
 				"compression must have shared a lock");
-		ASSERT_LOG_ONLY(agent_is_done, "agent must have written the new duplicate");
+		ASSERT_LOG_ONLY(agent_is_done,
+				"agent must have written the new duplicate");
 		transfer_allocation_lock(agent);
 	}
 
@@ -1137,7 +1141,8 @@ static void uncompress_and_verify(struct vdo_completion *completion)
 	struct data_vio *agent = as_data_vio(completion);
 	int result;
 
-	result = uncompress_data_vio(agent, agent->duplicate.state, agent->scratch_block);
+	result = uncompress_data_vio(agent, agent->duplicate.state,
+				     agent->scratch_block);
 	if (result == VDO_SUCCESS) {
 		verify_callback(completion);
 		return;
@@ -1160,13 +1165,13 @@ static void verify_endio(struct bio *bio)
 	}
 
 	if (vdo_is_state_compressed(agent->duplicate.state)) {
-		launch_data_vio_cpu_callback(agent,
-					     uncompress_and_verify,
+		launch_data_vio_cpu_callback(agent, uncompress_and_verify,
 					     CPU_Q_COMPRESS_BLOCK_PRIORITY);
 		return;
 	}
 
-	launch_data_vio_cpu_callback(agent, verify_callback, CPU_Q_COMPLETE_READ_PRIORITY);
+	launch_data_vio_cpu_callback(agent, verify_callback,
+				     CPU_Q_COMPLETE_READ_PRIORITY);
 }
 
 /**
@@ -1192,7 +1197,8 @@ static void start_verifying(struct hash_lock *lock, struct data_vio *agent)
 	ASSERT_LOG_ONLY(!lock->verified, "hash lock only verifies advice once");
 
 	agent->last_async_operation = VIO_ASYNC_OP_VERIFY_DUPLICATION;
-	result = vio_reset_bio(vio, buffer, verify_endio, REQ_OP_READ, agent->duplicate.pbn);
+	result = vio_reset_bio(vio, buffer, verify_endio, REQ_OP_READ,
+			       agent->duplicate.pbn);
 	if (result != VDO_SUCCESS) {
 		set_data_vio_hash_zone_callback(agent, finish_verifying);
 		continue_data_vio_with_error(agent, result);
@@ -1264,8 +1270,7 @@ static void finish_locking(struct vdo_completion *completion)
 	start_deduping(lock, agent, false);
 }
 
-static bool acquire_provisional_reference(struct data_vio *agent,
-					  struct pbn_lock *lock,
+static bool acquire_provisional_reference(struct data_vio *agent, struct pbn_lock *lock,
 					  struct slab_depot *depot)
 {
 	/* Ensure that the newly-locked block is referenced. */
@@ -1278,7 +1283,8 @@ static bool acquire_provisional_reference(struct data_vio *agent,
 	uds_log_warning_strerror(result,
 				 "Error acquiring provisional reference for dedupe candidate; aborting dedupe");
 	agent->is_duplicate = false;
-	vdo_release_physical_zone_pbn_lock(agent->duplicate.zone, agent->duplicate.pbn, lock);
+	vdo_release_physical_zone_pbn_lock(agent->duplicate.zone,
+					   agent->duplicate.pbn, lock);
 	continue_data_vio_with_error(agent, result);
 	return false;
 }
@@ -1322,10 +1328,8 @@ static void lock_duplicate_pbn(struct vdo_completion *completion)
 		return;
 	}
 
-	result = vdo_attempt_physical_zone_pbn_lock(zone,
-						    agent->duplicate.pbn,
-						    VIO_READ_LOCK,
-						    &lock);
+	result = vdo_attempt_physical_zone_pbn_lock(zone, agent->duplicate.pbn,
+						    VIO_READ_LOCK, &lock);
 	if (result != VDO_SUCCESS) {
 		continue_data_vio_with_error(agent, result);
 		return;
@@ -1615,8 +1619,7 @@ static bool decode_uds_advice(struct dedupe_context *context)
 	/* Don't use advice that's clearly meaningless. */
 	if ((advice->state == VDO_MAPPING_STATE_UNMAPPED) || (advice->pbn == VDO_ZERO_BLOCK)) {
 		uds_log_debug("Invalid advice from deduplication server: pbn %llu, state %u. Giving up on deduplication of logical block %llu",
-			      (unsigned long long) advice->pbn,
-			      advice->state,
+			      (unsigned long long) advice->pbn, advice->state,
 			      (unsigned long long) data_vio->logical.lbn);
 		atomic64_inc(&vdo->stats.invalid_advice_pbn_count);
 		return false;
@@ -1699,7 +1702,8 @@ static void start_querying(struct hash_lock *lock, struct data_vio *data_vio)
 	lock->state = VDO_HASH_LOCK_QUERYING;
 	data_vio->last_async_operation = VIO_ASYNC_OP_CHECK_FOR_DUPLICATION;
 	set_data_vio_hash_zone_callback(data_vio, finish_querying);
-	query_index(data_vio, (data_vio_has_allocation(data_vio) ? UDS_POST : UDS_QUERY));
+	query_index(data_vio,
+		    (data_vio_has_allocation(data_vio) ? UDS_POST : UDS_QUERY));
 }
 
 /**
@@ -1711,8 +1715,7 @@ static void start_querying(struct hash_lock *lock, struct data_vio *data_vio)
  */
 static void report_bogus_lock_state(struct hash_lock *lock, struct data_vio *data_vio)
 {
-	ASSERT_LOG_ONLY(false,
-			"hash lock must not be in unimplemented state %s",
+	ASSERT_LOG_ONLY(false, "hash lock must not be in unimplemented state %s",
 			get_hash_lock_state_name(lock->state));
 	continue_data_vio_with_error(data_vio, VDO_LOCK_ERROR);
 }
@@ -1785,7 +1788,8 @@ static bool is_hash_collision(struct hash_lock *lock, struct data_vio *candidate
 	if (list_empty(&lock->duplicate_ring))
 		return false;
 
-	lock_holder = list_first_entry(&lock->duplicate_ring, struct data_vio, hash_lock_entry);
+	lock_holder = list_first_entry(&lock->duplicate_ring, struct data_vio,
+				       hash_lock_entry);
 	zone = candidate->hash_zone;
 	collides = !blocks_equal(lock_holder->vio.data, candidate->vio.data);
 	if (collides)
@@ -1801,7 +1805,8 @@ static inline int assert_hash_lock_preconditions(const struct data_vio *data_vio
 	int result;
 
 	/* FIXME: BUG_ON() and/or enter read-only mode? */
-	result = ASSERT(data_vio->hash_lock == NULL, "must not already hold a hash lock");
+	result = ASSERT(data_vio->hash_lock == NULL,
+			"must not already hold a hash lock");
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -1916,7 +1921,8 @@ void vdo_release_hash_lock(struct data_vio *data_vio)
 		struct hash_lock *removed;
 
 		removed = vdo_pointer_map_remove(zone->hash_lock_map, &lock->hash);
-		ASSERT_LOG_ONLY(lock == removed, "hash lock being released must have been mapped");
+		ASSERT_LOG_ONLY(lock == removed,
+				"hash lock being released must have been mapped");
 	} else {
 		ASSERT_LOG_ONLY(lock != vdo_pointer_map_get(zone->hash_lock_map, &lock->hash),
 				"unregistered hash lock must not be in the lock map");
@@ -1974,7 +1980,8 @@ static void transfer_allocation_lock(struct data_vio *data_vio)
  * If the lock is still a write lock (as it will be for the first share), it will be converted to a
  * read lock. This also reserves a reference count increment for the data_vio.
  */
-void vdo_share_compressed_write_lock(struct data_vio *data_vio, struct pbn_lock *pbn_lock)
+void vdo_share_compressed_write_lock(struct data_vio *data_vio,
+				     struct pbn_lock *pbn_lock)
 {
 	bool claimed;
 
@@ -2025,10 +2032,12 @@ static void dedupe_kobj_release(struct kobject *directory)
 	uds_free(container_of(directory, struct hash_zones, dedupe_directory));
 }
 
-static ssize_t dedupe_status_show(struct kobject *directory, struct attribute *attr, char *buf)
+static ssize_t dedupe_status_show(struct kobject *directory, struct attribute *attr,
+				  char *buf)
 {
 	struct uds_attribute *ua = container_of(attr, struct uds_attribute, attr);
-	struct hash_zones *zones = container_of(directory, struct hash_zones, dedupe_directory);
+	struct hash_zones *zones = container_of(directory, struct hash_zones,
+						dedupe_directory);
 
 	if (ua->show_string != NULL)
 		return sprintf(buf, "%s\n", ua->show_string(zones));
@@ -2124,8 +2133,7 @@ static void open_index(struct hash_zones *zones)
 	/* Open the index session, while not holding the lock */
 	spin_unlock(&zones->lock);
 	result = uds_open_index(create_flag ? UDS_CREATE : UDS_LOAD,
-				&zones->parameters,
-				zones->index_session);
+				&zones->parameters, zones->index_session);
 	if (result != UDS_SUCCESS)
 		uds_log_error_strerror(result, "Error opening index");
 
@@ -2184,8 +2192,7 @@ static void start_expiration_timer(struct dedupe_context *context)
 	u64 start_time = context->submission_jiffies;
 	u64 end_time;
 
-	if (!change_timer_state(context->zone,
-				DEDUPE_QUERY_TIMER_IDLE,
+	if (!change_timer_state(context->zone, DEDUPE_QUERY_TIMER_IDLE,
 				DEDUPE_QUERY_TIMER_RUNNING))
 		return;
 
@@ -2251,7 +2258,8 @@ static int initialize_index(struct vdo *vdo, struct hash_zones *zones)
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = vdo_make_thread(vdo, vdo->thread_config.dedupe_thread, &uds_queue_type, 1, NULL);
+	result = vdo_make_thread(vdo, vdo->thread_config.dedupe_thread, &uds_queue_type,
+				 1, NULL);
 	if (result != VDO_SUCCESS) {
 		uds_destroy_index_session(uds_forget(zones->index_session));
 		uds_log_error("UDS index queue initialization failed (%d)", result);
@@ -2259,8 +2267,7 @@ static int initialize_index(struct vdo *vdo, struct hash_zones *zones)
 	}
 
 	vdo_initialize_completion(&zones->completion, vdo, VDO_HASH_ZONES_COMPLETION);
-	vdo_set_completion_callback(&zones->completion,
-				    change_dedupe_state,
+	vdo_set_completion_callback(&zones->completion, change_dedupe_state,
 				    vdo->thread_config.dedupe_thread);
 	kobject_init(&zones->dedupe_directory, &dedupe_directory_type);
 	return VDO_SUCCESS;
@@ -2272,9 +2279,11 @@ static int initialize_index(struct vdo *vdo, struct hash_zones *zones)
  */
 static void finish_index_operation(struct uds_request *request)
 {
-	struct dedupe_context *context = container_of(request, struct dedupe_context, request);
+	struct dedupe_context *context = container_of(request, struct dedupe_context,
+						      request);
 
-	if (change_context_state(context, DEDUPE_CONTEXT_PENDING, DEDUPE_CONTEXT_COMPLETE)) {
+	if (change_context_state(context, DEDUPE_CONTEXT_PENDING,
+				 DEDUPE_CONTEXT_COMPLETE)) {
 		/*
 		 * This query has not timed out, so send its data_vio back to its hash zone to
 		 * process the results.
@@ -2287,11 +2296,9 @@ static void finish_index_operation(struct uds_request *request)
 	 * This query has timed out, so try to mark it complete and hence eligible for reuse. Its
 	 * data_vio has already moved on.
 	 */
-	if (!change_context_state(context,
-				  DEDUPE_CONTEXT_TIMED_OUT,
+	if (!change_context_state(context, DEDUPE_CONTEXT_TIMED_OUT,
 				  DEDUPE_CONTEXT_TIMED_OUT_COMPLETE))
-		ASSERT_LOG_ONLY(false,
-				"uds request was timed out (state %d)",
+		ASSERT_LOG_ONLY(false, "uds request was timed out (state %d)",
 				atomic_read(&context->state));
 
 	uds_funnel_queue_put(context->zone->timed_out_complete, &context->queue_entry);
@@ -2309,7 +2316,8 @@ static void check_for_drain_complete(struct hash_zone *zone)
 		return;
 
 	if ((atomic_read(&zone->timer_state) == DEDUPE_QUERY_TIMER_IDLE) ||
-	    change_timer_state(zone, DEDUPE_QUERY_TIMER_RUNNING, DEDUPE_QUERY_TIMER_IDLE)) {
+	    change_timer_state(zone, DEDUPE_QUERY_TIMER_RUNNING,
+			       DEDUPE_QUERY_TIMER_IDLE)) {
 		del_timer_sync(&zone->timer);
 	} else {
 		/*
@@ -2357,8 +2365,7 @@ static void timeout_index_operations_callback(struct vdo_completion *completion)
 			break;
 		}
 
-		if (!change_context_state(context,
-					  DEDUPE_CONTEXT_PENDING,
+		if (!change_context_state(context, DEDUPE_CONTEXT_PENDING,
 					  DEDUPE_CONTEXT_TIMED_OUT)) {
 			/*
 			 * This context completed between the time the timeout fired, and now. We
@@ -2388,22 +2395,20 @@ static void timeout_index_operations(struct timer_list *t)
 {
 	struct hash_zone *zone = from_timer(zone, t, timer);
 
-	if (change_timer_state(zone, DEDUPE_QUERY_TIMER_RUNNING, DEDUPE_QUERY_TIMER_FIRED))
+	if (change_timer_state(zone, DEDUPE_QUERY_TIMER_RUNNING,
+			       DEDUPE_QUERY_TIMER_FIRED))
 		vdo_launch_completion(&zone->completion);
 }
 
-static int __must_check
-initialize_zone(struct vdo *vdo, struct hash_zones *zones, zone_count_t zone_number)
+static int __must_check initialize_zone(struct vdo *vdo, struct hash_zones *zones,
+					zone_count_t zone_number)
 {
 	int result;
 	data_vio_count_t i;
 	struct hash_zone *zone = &zones->zones[zone_number];
 
-	result = vdo_make_pointer_map(VDO_LOCK_MAP_CAPACITY,
-				      0,
-				      compare_keys,
-				      hash_key,
-				      &zone->hash_lock_map);
+	result = vdo_make_pointer_map(VDO_LOCK_MAP_CAPACITY, 0, compare_keys,
+				      hash_key, &zone->hash_lock_map);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -2411,13 +2416,10 @@ initialize_zone(struct vdo *vdo, struct hash_zones *zones, zone_count_t zone_num
 	zone->zone_number = zone_number;
 	zone->thread_id = vdo->thread_config.hash_zone_threads[zone_number];
 	vdo_initialize_completion(&zone->completion, vdo, VDO_HASH_ZONE_COMPLETION);
-	vdo_set_completion_callback(&zone->completion,
-				    timeout_index_operations_callback,
+	vdo_set_completion_callback(&zone->completion, timeout_index_operations_callback,
 				    zone->thread_id);
 	INIT_LIST_HEAD(&zone->lock_pool);
-	result = uds_allocate(LOCK_POOL_CAPACITY,
-			      struct hash_lock,
-			      "hash_lock array",
+	result = uds_allocate(LOCK_POOL_CAPACITY, struct hash_lock, "hash_lock array",
 			      &zone->lock_array);
 	if (result != VDO_SUCCESS)
 		return result;
@@ -2471,11 +2473,8 @@ int vdo_make_hash_zones(struct vdo *vdo, struct hash_zones **zones_ptr)
 	if (zone_count == 0)
 		return VDO_SUCCESS;
 
-	result = uds_allocate_extended(struct hash_zones,
-				       zone_count,
-				       struct hash_zone,
-				       __func__,
-				       &zones);
+	result = uds_allocate_extended(struct hash_zones, zone_count, struct hash_zone,
+				       __func__, &zones);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -2496,13 +2495,9 @@ int vdo_make_hash_zones(struct vdo *vdo, struct hash_zones **zones_ptr)
 		}
 	}
 
-	result = vdo_make_action_manager(zones->zone_count,
-					 get_thread_id_for_zone,
-					 vdo->thread_config.admin_thread,
-					 zones,
-					 NULL,
-					 vdo,
-					 &zones->manager);
+	result = vdo_make_action_manager(zones->zone_count, get_thread_id_for_zone,
+					 vdo->thread_config.admin_thread, zones, NULL,
+					 vdo, &zones->manager);
 	if (result != VDO_SUCCESS) {
 		vdo_free_hash_zones(zones);
 		return result;
@@ -2582,8 +2577,7 @@ static void suspend_index(void *context, struct vdo_completion *completion)
 	struct hash_zones *zones = context;
 
 	vdo_start_draining(&zones->state,
-			   vdo_get_current_manager_operation(zones->manager),
-			   completion,
+			   vdo_get_current_manager_operation(zones->manager), completion,
 			   initiate_suspend_index);
 }
 
@@ -2602,25 +2596,21 @@ static void initiate_drain(struct admin_state *state)
  *
  * Implements vdo_zone_action.
  */
-static void drain_hash_zone(void *context, zone_count_t zone_number, struct vdo_completion *parent)
+static void drain_hash_zone(void *context, zone_count_t zone_number,
+			    struct vdo_completion *parent)
 {
 	struct hash_zones *zones = context;
 
 	vdo_start_draining(&zones->zones[zone_number].state,
-			   vdo_get_current_manager_operation(zones->manager),
-			   parent,
+			   vdo_get_current_manager_operation(zones->manager), parent,
 			   initiate_drain);
 }
 
 /** vdo_drain_hash_zones() - Drain all hash zones. */
 void vdo_drain_hash_zones(struct hash_zones *zones, struct vdo_completion *parent)
 {
-	vdo_schedule_operation(zones->manager,
-			       parent->vdo->suspend_type,
-			       suspend_index,
-			       drain_hash_zone,
-			       NULL,
-			       parent);
+	vdo_schedule_operation(zones->manager, parent->vdo->suspend_type, suspend_index,
+			       drain_hash_zone, NULL, parent);
 }
 
 static void launch_dedupe_state_change(struct hash_zones *zones)
@@ -2676,8 +2666,8 @@ static void resume_index(void *context, struct vdo_completion *parent)
  *
  * Implements vdo_zone_action.
  */
-static void
-resume_hash_zone(void *context, zone_count_t zone_number, struct vdo_completion *parent)
+static void resume_hash_zone(void *context, zone_count_t zone_number,
+			     struct vdo_completion *parent)
 {
 	struct hash_zone *zone = &(((struct hash_zones *) context)->zones[zone_number]);
 
@@ -2696,12 +2686,8 @@ void vdo_resume_hash_zones(struct hash_zones *zones, struct vdo_completion *pare
 		return;
 	}
 
-	vdo_schedule_operation(zones->manager,
-			       VDO_ADMIN_STATE_RESUMING,
-			       resume_index,
-			       resume_hash_zone,
-			       NULL,
-			       parent);
+	vdo_schedule_operation(zones->manager, VDO_ADMIN_STATE_RESUMING, resume_index,
+			       resume_hash_zone, NULL, parent);
 }
 
 /**
@@ -2709,8 +2695,8 @@ void vdo_resume_hash_zones(struct hash_zones *zones, struct vdo_completion *pare
  * @zone: The hash zone to query.
  * @tally: The tally
  */
-static void
-get_hash_zone_statistics(const struct hash_zone *zone, struct hash_lock_statistics *tally)
+static void get_hash_zone_statistics(const struct hash_zone *zone,
+				     struct hash_lock_statistics *tally)
 {
 	const struct hash_lock_statistics *stats = &zone->statistics;
 
@@ -2721,7 +2707,8 @@ get_hash_zone_statistics(const struct hash_zone *zone, struct hash_lock_statisti
 	tally->curr_dedupe_queries += READ_ONCE(zone->active);
 }
 
-static void get_index_statistics(struct hash_zones *zones, struct index_statistics *stats)
+static void get_index_statistics(struct hash_zones *zones,
+				 struct index_statistics *stats)
 {
 	enum index_state state;
 	struct uds_index_stats index_stats;
@@ -2782,8 +2769,8 @@ void vdo_get_dedupe_statistics(struct hash_zones *zones, struct vdo_statistics *
  *
  * Return: The hash zone responsible for the record name.
  */
-struct hash_zone *
-vdo_select_hash_zone(struct hash_zones *zones, const struct uds_record_name *name)
+struct hash_zone *vdo_select_hash_zone(struct hash_zones *zones,
+				       const struct uds_record_name *name)
 {
 	/*
 	 * Use a fragment of the record name as a hash code. Eight bits of hash should suffice
@@ -2828,7 +2815,8 @@ static void dump_hash_lock(const struct hash_lock *lock)
 		     vdo_count_waiters(&lock->waiters), lock->agent);
 }
 
-static const char *index_state_to_string(struct hash_zones *zones, enum index_state state)
+static const char *index_state_to_string(struct hash_zones *zones,
+					 enum index_state state)
 {
 	if (!vdo_is_state_normal(&zones->state))
 		return SUSPENDED;
@@ -2859,8 +2847,7 @@ static void dump_hash_zone(const struct hash_zone *zone)
 	}
 
 	uds_log_info("struct hash_zone %u: mapSize=%zu",
-		     zone->zone_number,
-		     vdo_pointer_map_size(zone->hash_lock_map));
+		     zone->zone_number, vdo_pointer_map_size(zone->hash_lock_map));
 	for (i = 0; i < LOCK_POOL_CAPACITY; i++)
 		dump_hash_lock(&zone->lock_array[i]);
 }
@@ -2940,17 +2927,18 @@ static struct dedupe_context * __must_check acquire_context(struct hash_zone *zo
 
 	if (!list_empty(&zone->available)) {
 		WRITE_ONCE(zone->active, zone->active + 1);
-		context = list_first_entry(&zone->available, struct dedupe_context, list_entry);
+		context = list_first_entry(&zone->available, struct dedupe_context,
+					   list_entry);
 		list_del_init(&context->list_entry);
 		return context;
 	}
 
 	entry = uds_funnel_queue_poll(zone->timed_out_complete);
-	return ((entry == NULL) ? NULL : container_of(entry, struct dedupe_context, queue_entry));
+	return ((entry == NULL) ?
+		NULL : container_of(entry, struct dedupe_context, queue_entry));
 }
 
-static void prepare_uds_request(struct uds_request *request,
-				struct data_vio *data_vio,
+static void prepare_uds_request(struct uds_request *request, struct data_vio *data_vio,
 				enum uds_request_type operation)
 {
 	request->record_name = data_vio->record_name;
@@ -3008,11 +2996,8 @@ static void query_index(struct data_vio *data_vio, enum uds_request_type operati
 	}
 }
 
-static void set_target_state(struct hash_zones *zones,
-			     enum index_state target,
-			     bool change_dedupe,
-			     bool dedupe,
-			     bool set_create)
+static void set_target_state(struct hash_zones *zones, enum index_state target,
+			     bool change_dedupe, bool dedupe, bool set_create)
 {
 	const char *old_state, *new_state;
 
@@ -3067,11 +3052,11 @@ int vdo_message_dedupe_index(struct hash_zones *zones, const char *name)
 int vdo_add_dedupe_index_sysfs(struct hash_zones *zones)
 {
 	int result = kobject_add(&zones->dedupe_directory,
-				 &zones->completion.vdo->vdo_directory,
-				 "dedupe");
+				 &zones->completion.vdo->vdo_directory, "dedupe");
 
 	if (result == 0)
-		vdo_set_admin_state_code(&zones->state, VDO_ADMIN_STATE_NORMAL_OPERATION);
+		vdo_set_admin_state_code(&zones->state,
+					 VDO_ADMIN_STATE_NORMAL_OPERATION);
 
 	return result;
 }

--- a/drivers/md/dm-vdo/dedupe.c
+++ b/drivers/md/dm-vdo/dedupe.c
@@ -920,7 +920,7 @@ static int __must_check acquire_lock(struct hash_zone *zone,
 static void enter_forked_lock(struct waiter *waiter, void *context)
 {
 	struct data_vio *data_vio = waiter_as_data_vio(waiter);
-	struct hash_lock *new_lock = (struct hash_lock *) context;
+	struct hash_lock *new_lock = context;
 
 	set_hash_lock(data_vio, new_lock);
 	wait_on_hash_lock(new_lock, data_vio);
@@ -2822,10 +2822,10 @@ static void dump_hash_lock(const struct hash_lock *lock)
 	 */
 	state = get_hash_lock_state_name(lock->state);
 	uds_log_info("  hl %px: %3.3s %c%llu/%u rc=%u wc=%zu agt=%px",
-		     (const void *) lock, state, (lock->registered ? 'D' : 'U'),
+		     lock, state, (lock->registered ? 'D' : 'U'),
 		     (unsigned long long) lock->duplicate.pbn,
 		     lock->duplicate.state, lock->reference_count,
-		     vdo_count_waiters(&lock->waiters), (void *) lock->agent);
+		     vdo_count_waiters(&lock->waiters), lock->agent);
 }
 
 static const char *index_state_to_string(struct hash_zones *zones, enum index_state state)

--- a/drivers/md/dm-vdo/dedupe.c
+++ b/drivers/md/dm-vdo/dedupe.c
@@ -367,6 +367,7 @@ struct pbn_lock *vdo_get_duplicate_lock(struct data_vio *data_vio)
 {
 	if (data_vio->hash_lock == NULL)
 		return NULL;
+
 	return data_vio->hash_lock->duplicate_lock;
 }
 
@@ -443,7 +444,7 @@ static void set_hash_lock(struct data_vio *data_vio, struct hash_lock *new_lock)
 				"hash lock reference must be counted");
 
 		if ((old_lock->state != VDO_HASH_LOCK_BYPASSING) &&
-		    (old_lock->state != VDO_HASH_LOCK_UNLOCKING))
+		    (old_lock->state != VDO_HASH_LOCK_UNLOCKING)) {
 			/*
 			 * If the reference count goes to zero in a non-terminal state, we're most
 			 * likely leaking this lock.
@@ -451,6 +452,7 @@ static void set_hash_lock(struct data_vio *data_vio, struct hash_lock *new_lock)
 			ASSERT_LOG_ONLY(old_lock->reference_count > 1,
 					"hash locks should only become unreferenced in a terminal state, not state %s",
 					get_hash_lock_state_name(old_lock->state));
+		}
 
 		list_del_init(&data_vio->hash_lock_entry);
 		old_lock->reference_count -= 1;
@@ -820,7 +822,7 @@ static void finish_deduping(struct hash_lock *lock, struct data_vio *data_vio)
 
 	/* The hash lock must have an agent for all other lock states. */
 	lock->agent = agent;
-	if (lock->update_advice)
+	if (lock->update_advice) {
 		/*
 		 * DEDUPING -> UPDATING transition: The location of the duplicate block changed
 		 * since the initial UDS query because of compression, rollover, or because the
@@ -829,13 +831,14 @@ static void finish_deduping(struct hash_lock *lock, struct data_vio *data_vio)
 		 * it's time to update the advice.
 		 */
 		start_updating(lock, agent);
-	else
+	} else {
 		/*
 		 * DEDUPING -> UNLOCKING transition: Release the PBN read lock on the duplicate
 		 * location so the hash lock itself can be released (contingent on no new data_vios
 		 * arriving in the lock before the agent returns).
 		 */
 		start_unlocking(lock, agent);
+	}
 }
 
 /**
@@ -1029,13 +1032,14 @@ static void start_deduping(struct hash_lock *lock, struct data_vio *agent, bool 
 	while (vdo_has_waiters(&lock->waiters))
 		launch_dedupe(lock, dequeue_lock_waiter(lock), false);
 
-	if (agent_is_done)
+	if (agent_is_done) {
 		/*
 		 * In the degenerate case where all the waiters rolled over to a new lock, this
 		 * will continue to use the old agent to clean up this lock, and otherwise it just
 		 * lets the agent exit the lock.
 		 */
 		finish_deduping(lock, agent);
+	}
 }
 
 /**
@@ -1112,9 +1116,10 @@ static bool blocks_equal(char *block1, char *block2)
 	int i;
 
 
-	for (i = 0; i < VDO_BLOCK_SIZE; i += sizeof(u64))
+	for (i = 0; i < VDO_BLOCK_SIZE; i += sizeof(u64)) {
 		if (*((u64 *) &block1[i]) != *((u64 *) &block2[i]))
 			return false;
+	}
 
 	return true;
 }
@@ -1902,9 +1907,10 @@ void vdo_release_hash_lock(struct data_vio *data_vio)
 
 	set_hash_lock(data_vio, NULL);
 
-	if (lock->reference_count > 0)
+	if (lock->reference_count > 0) {
 		/* The lock is still in use by other data_vios. */
 		return;
+	}
 
 	if (lock->registered) {
 		struct hash_lock *removed;
@@ -2303,13 +2309,14 @@ static void check_for_drain_complete(struct hash_zone *zone)
 		return;
 
 	if ((atomic_read(&zone->timer_state) == DEDUPE_QUERY_TIMER_IDLE) ||
-	    change_timer_state(zone, DEDUPE_QUERY_TIMER_RUNNING, DEDUPE_QUERY_TIMER_IDLE))
+	    change_timer_state(zone, DEDUPE_QUERY_TIMER_RUNNING, DEDUPE_QUERY_TIMER_IDLE)) {
 		del_timer_sync(&zone->timer);
-	else
+	} else {
 		/*
 		 * There is an in flight time-out, which must get processed before we can continue.
 		 */
 		return;
+	}
 
 	for (;;) {
 		struct dedupe_context *context;
@@ -2352,13 +2359,14 @@ static void timeout_index_operations_callback(struct vdo_completion *completion)
 
 		if (!change_context_state(context,
 					  DEDUPE_CONTEXT_PENDING,
-					  DEDUPE_CONTEXT_TIMED_OUT))
+					  DEDUPE_CONTEXT_TIMED_OUT)) {
 			/*
 			 * This context completed between the time the timeout fired, and now. We
 			 * can treat it as a a successful query, its requestor is already enqueued
 			 * to process it.
 			 */
 			continue;
+		}
 
 		/*
 		 * Remove this context from the pending list so we won't look at it again on a
@@ -2803,9 +2811,10 @@ static void dump_hash_lock(const struct hash_lock *lock)
 {
 	const char *state;
 
-	if (!list_empty(&lock->pool_node))
+	if (!list_empty(&lock->pool_node)) {
 		/* This lock is on the free list. */
 		return;
+	}
 
 	/*
 	 * Necessarily cryptic since we can log a lot of these. First three chars of state is
@@ -3051,6 +3060,7 @@ int vdo_message_dedupe_index(struct hash_zones *zones, const char *name)
 		set_target_state(zones, IS_OPENED, true, true, false);
 		return 0;
 	}
+
 	return -EINVAL;
 }
 

--- a/drivers/md/dm-vdo/dedupe.c
+++ b/drivers/md/dm-vdo/dedupe.c
@@ -557,7 +557,7 @@ static void wait_on_hash_lock(struct hash_lock *lock, struct data_vio *data_vio)
 }
 
 /**
- * abort_waiter() - waiter_callback function that shunts waiters to write their blocks without
+ * abort_waiter() - waiter_callback_fn function that shunts waiters to write their blocks without
  *                  optimization.
  * @waiter: The data_vio's waiter link.
  * @context: Not used.
@@ -914,8 +914,8 @@ static int __must_check acquire_lock(struct hash_zone *zone,
 /**
  * enter_forked_lock() - Bind the data_vio to a new hash lock.
  *
- * Implements waiter_callback. Binds the data_vio that was waiting to a new hash lock and waits on
- * that lock.
+ * Implements waiter_callback_fn. Binds the data_vio that was waiting to a new hash lock and waits
+ * on that lock.
  */
 static void enter_forked_lock(struct waiter *waiter, void *context)
 {
@@ -2011,14 +2011,14 @@ void vdo_share_compressed_write_lock(struct data_vio *data_vio,
 	ASSERT_LOG_ONLY(claimed, "impossible to fail to claim an initial increment");
 }
 
-/** compare_keys() - Implements pointer_key_comparator. */
+/** compare_keys() - Implements pointer_key_comparator_fn. */
 static bool compare_keys(const void *this_key, const void *that_key)
 {
 	/* Null keys are not supported. */
 	return (memcmp(this_key, that_key, sizeof(struct uds_record_name)) == 0);
 }
 
-/** hash_key() - Implements pointer_key_comparator. */
+/** hash_key() - Implements pointer_key_comparator_fn. */
 static u32 hash_key(const void *key)
 {
 	const struct uds_record_name *name = key;
@@ -2407,8 +2407,8 @@ static int __must_check initialize_zone(struct vdo *vdo, struct hash_zones *zone
 	data_vio_count_t i;
 	struct hash_zone *zone = &zones->zones[zone_number];
 
-	result = vdo_make_pointer_map(VDO_LOCK_MAP_CAPACITY, 0, compare_keys,
-				      hash_key, &zone->hash_lock_map);
+	result = vdo_make_pointer_map(VDO_LOCK_MAP_CAPACITY, 0, compare_keys, hash_key,
+				      &zone->hash_lock_map);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -2447,7 +2447,7 @@ static int __must_check initialize_zone(struct vdo *vdo, struct hash_zones *zone
 	return vdo_make_default_thread(vdo, zone->thread_id);
 }
 
-/** get_thread_id_for_zone() - Implements vdo_zone_thread_getter. */
+/** get_thread_id_for_zone() - Implements vdo_zone_thread_getter_fn. */
 static thread_id_t get_thread_id_for_zone(void *context, zone_count_t zone_number)
 {
 	struct hash_zones *zones = context;
@@ -2570,7 +2570,7 @@ static void initiate_suspend_index(struct admin_state *state)
 /**
  * suspend_index() - Suspend the UDS index prior to draining hash zones.
  *
- * Implements vdo_action_preamble
+ * Implements vdo_action_preamble_fn
  */
 static void suspend_index(void *context, struct vdo_completion *completion)
 {
@@ -2584,7 +2584,7 @@ static void suspend_index(void *context, struct vdo_completion *completion)
 /**
  * initiate_drain() - Initiate a drain.
  *
- * Implements vdo_admin_initiator.
+ * Implements vdo_admin_initiator_fn.
  */
 static void initiate_drain(struct admin_state *state)
 {
@@ -2594,7 +2594,7 @@ static void initiate_drain(struct admin_state *state)
 /**
  * drain_hash_zone() - Drain a hash zone.
  *
- * Implements vdo_zone_action.
+ * Implements vdo_zone_action_fn.
  */
 static void drain_hash_zone(void *context, zone_count_t zone_number,
 			    struct vdo_completion *parent)
@@ -2632,7 +2632,7 @@ static void launch_dedupe_state_change(struct hash_zones *zones)
 /**
  * resume_index() - Resume the UDS index prior to resuming hash zones.
  *
- * Implements vdo_action_preamble
+ * Implements vdo_action_preamble_fn
  */
 static void resume_index(void *context, struct vdo_completion *parent)
 {
@@ -2664,7 +2664,7 @@ static void resume_index(void *context, struct vdo_completion *parent)
 /**
  * resume_hash_zone() - Resume a hash zone.
  *
- * Implements vdo_zone_action.
+ * Implements vdo_zone_action_fn.
  */
 static void resume_hash_zone(void *context, zone_count_t zone_number,
 			     struct vdo_completion *parent)
@@ -2846,8 +2846,8 @@ static void dump_hash_zone(const struct hash_zone *zone)
 		return;
 	}
 
-	uds_log_info("struct hash_zone %u: mapSize=%zu",
-		     zone->zone_number, vdo_pointer_map_size(zone->hash_lock_map));
+	uds_log_info("struct hash_zone %u: mapSize=%zu", zone->zone_number,
+		     vdo_pointer_map_size(zone->hash_lock_map));
 	for (i = 0; i < LOCK_POOL_CAPACITY; i++)
 		dump_hash_lock(&zone->lock_array[i]);
 }

--- a/drivers/md/dm-vdo/dedupe.h
+++ b/drivers/md/dm-vdo/dedupe.h
@@ -75,7 +75,8 @@ void vdo_acquire_hash_lock(struct vdo_completion *completion);
 void vdo_continue_hash_lock(struct vdo_completion *completion);
 void vdo_release_hash_lock(struct data_vio *data_vio);
 void vdo_clean_failed_hash_lock(struct data_vio *data_vio);
-void vdo_share_compressed_write_lock(struct data_vio *data_vio, struct pbn_lock *pbn_lock);
+void vdo_share_compressed_write_lock(struct data_vio *data_vio,
+				     struct pbn_lock *pbn_lock);
 
 int __must_check vdo_make_hash_zones(struct vdo *vdo, struct hash_zones **zones_ptr);
 
@@ -85,8 +86,8 @@ void vdo_drain_hash_zones(struct hash_zones *zones, struct vdo_completion *paren
 
 void vdo_get_dedupe_statistics(struct hash_zones *zones, struct vdo_statistics *stats);
 
-struct hash_zone * __must_check
-vdo_select_hash_zone(struct hash_zones *zones, const struct uds_record_name *name);
+struct hash_zone * __must_check vdo_select_hash_zone(struct hash_zones *zones,
+						     const struct uds_record_name *name);
 
 void vdo_dump_hash_zones(struct hash_zones *zones);
 

--- a/drivers/md/dm-vdo/delta-index.c
+++ b/drivers/md/dm-vdo/delta-index.c
@@ -499,9 +499,10 @@ static bool verify_delta_index_page(u64 nonce,
 		return false;
 
 	/* Verify that the lists are in the correct order. */
-	for (i = 0; i < list_count; i++)
+	for (i = 0; i < list_count; i++) {
 		if (get_immutable_start(memory, i) > get_immutable_start(memory, i + 1))
 			return false;
+	}
 
 	/*
 	 * Verify that the last list ends on the page, and that there is room
@@ -555,12 +556,13 @@ int uds_initialize_delta_index_page(struct delta_index_page *delta_index_page,
 					     list_count,
 					     expected_nonce,
 					     memory,
-					     memory_size))
+					     memory_size)) {
 			/*
 			 * Both attempts failed. Do not log this as an error, because it can happen
 			 * during a rebuild if we haven't written the entire volume at least once.
 			 */
 			return UDS_CORRUPT_DATA;
+		}
 	}
 
 	delta_index_page->delta_index.delta_zones = delta_zone;
@@ -772,11 +774,12 @@ int uds_pack_delta_index_page(const struct delta_index *delta_index,
 	free_bits = memory_size * BITS_PER_BYTE;
 	free_bits -= get_immutable_header_offset(1);
 	free_bits -= GUARD_BITS;
-	if (free_bits < IMMUTABLE_HEADER_SIZE)
+	if (free_bits < IMMUTABLE_HEADER_SIZE) {
 		/* This page is too small to store any delta lists. */
 		return uds_log_error_strerror(UDS_OVERFLOW,
 					      "Chapter Index Page of %zu bytes is too small",
 					      memory_size);
+	}
 
 	while (n_lists < max_lists) {
 		/* Each list requires a delta list offset and the list data. */
@@ -805,12 +808,13 @@ int uds_pack_delta_index_page(const struct delta_index *delta_index,
 	}
 
 	/* Copy the delta list data onto the memory page. */
-	for (i = 0; i < n_lists; i++)
+	for (i = 0; i < n_lists; i++) {
 		move_bits(delta_zone->memory,
 			  delta_lists[i].start,
 			  memory,
 			  get_immutable_start(memory, i),
 			  delta_lists[i].size);
+	}
 
 	/* Set all the bits in the guard bytes. */
 	memset(memory + memory_size - POST_FIELD_GUARD_BYTES, ~0, POST_FIELD_GUARD_BYTES);
@@ -886,9 +890,10 @@ int uds_start_restoring_delta_index(struct delta_index *delta_index,
 		result = uds_read_from_buffered_reader(buffered_readers[z],
 						       buffer,
 						       sizeof(buffer));
-		if (result != UDS_SUCCESS)
+		if (result != UDS_SUCCESS) {
 			return uds_log_warning_strerror(result,
 							"failed to read delta index header");
+		}
 
 		memcpy(&header.magic, buffer, MAGIC_SIZE);
 		offset += MAGIC_SIZE;
@@ -903,52 +908,59 @@ int uds_start_restoring_delta_index(struct delta_index *delta_index,
 				"%zu bytes decoded of %zu expected",
 				offset,
 				sizeof(struct delta_index_header));
-		if (result != UDS_SUCCESS)
+		if (result != UDS_SUCCESS) {
 			return uds_log_warning_strerror(result,
 							"failed to read delta index header");
+		}
 
-		if (memcmp(header.magic, DELTA_INDEX_MAGIC, MAGIC_SIZE) != 0)
+		if (memcmp(header.magic, DELTA_INDEX_MAGIC, MAGIC_SIZE) != 0) {
 			return uds_log_warning_strerror(UDS_CORRUPT_DATA,
 							"delta index file has bad magic number");
+		}
 
-		if (zone_count != header.zone_count)
+		if (zone_count != header.zone_count) {
 			return uds_log_warning_strerror(UDS_CORRUPT_DATA,
 							"delta index files contain mismatched zone counts (%u,%u)",
 							zone_count,
 							header.zone_count);
+		}
 
-		if (header.zone_number != z)
+		if (header.zone_number != z) {
 			return uds_log_warning_strerror(UDS_CORRUPT_DATA,
 							"delta index zone %u found in slot %u",
 							header.zone_number,
 							z);
+		}
 
 		first_list[z] = header.first_list;
 		list_count[z] = header.list_count;
 		record_count += header.record_count;
 		collision_count += header.collision_count;
 
-		if (first_list[z] != list_next)
+		if (first_list[z] != list_next) {
 			return uds_log_warning_strerror(UDS_CORRUPT_DATA,
 							"delta index file for zone %u starts with list %u instead of list %u",
 							z,
 							first_list[z],
 							list_next);
+		}
 
 		list_next += list_count[z];
 	}
 
-	if (list_next != delta_index->list_count)
+	if (list_next != delta_index->list_count) {
 		return uds_log_warning_strerror(UDS_CORRUPT_DATA,
 						"delta index files contain %u delta lists instead of %u delta lists",
 						list_next,
 						delta_index->list_count);
+	}
 
-	if (collision_count > record_count)
+	if (collision_count > record_count) {
 		return uds_log_warning_strerror(UDS_CORRUPT_DATA,
 						"delta index files contain %llu collisions and %llu records",
 						(unsigned long long) collision_count,
 						(unsigned long long) record_count);
+	}
 
 	uds_reset_delta_index(delta_index);
 	delta_index->delta_zones[0].record_count = record_count;
@@ -968,9 +980,10 @@ int uds_start_restoring_delta_index(struct delta_index *delta_index,
 			result = uds_read_from_buffered_reader(buffered_readers[z],
 							       size_data,
 							       sizeof(size_data));
-			if (result != UDS_SUCCESS)
+			if (result != UDS_SUCCESS) {
 				return uds_log_warning_strerror(result,
 								"failed to read delta index size");
+			}
 
 			delta_list_size = get_unaligned_le16(size_data);
 			if (delta_list_size > 0)
@@ -987,6 +1000,7 @@ int uds_start_restoring_delta_index(struct delta_index *delta_index,
 	/* Prepare each zone to start receiving the delta list data. */
 	for (z = 0; z < delta_index->zone_count; z++)
 		rebalance_lists(&delta_index->delta_zones[z]);
+
 	return UDS_SUCCESS;
 }
 
@@ -999,27 +1013,30 @@ static int restore_delta_list_to_zone(struct delta_zone *delta_zone,
 	u16 byte_count;
 	u32 list_number = save_info->index - delta_zone->first_list;
 
-	if (list_number >= delta_zone->list_count)
+	if (list_number >= delta_zone->list_count) {
 		return uds_log_warning_strerror(UDS_CORRUPT_DATA,
 						"invalid delta list number %u not in range [%u,%u)",
 						save_info->index,
 						delta_zone->first_list,
 						delta_zone->first_list +
 						delta_zone->list_count);
+	}
 
 	delta_list = &delta_zone->delta_lists[list_number + 1];
-	if (delta_list->size == 0)
+	if (delta_list->size == 0) {
 		return uds_log_warning_strerror(UDS_CORRUPT_DATA,
 						"unexpected delta list number %u",
 						save_info->index);
+	}
 
 	bit_count = delta_list->size + save_info->bit_offset;
 	byte_count = BITS_TO_BYTES(bit_count);
-	if (save_info->byte_count != byte_count)
+	if (save_info->byte_count != byte_count) {
 		return uds_log_warning_strerror(UDS_CORRUPT_DATA,
 						"unexpected delta list size %u != %u",
 						save_info->byte_count,
 						byte_count);
+	}
 
 	move_bits(data,
 		  save_info->bit_offset,
@@ -1058,16 +1075,18 @@ static int restore_delta_list_data(struct delta_index *delta_index,
 	if (save_info.tag != delta_index->tag)
 		return UDS_CORRUPT_DATA;
 
-	if (save_info.index >= delta_index->list_count)
+	if (save_info.index >= delta_index->list_count) {
 		return uds_log_warning_strerror(UDS_CORRUPT_DATA,
 						"invalid delta list number %u of %u",
 						save_info.index,
 						delta_index->list_count);
+	}
 
 	result = uds_read_from_buffered_reader(buffered_reader, data, save_info.byte_count);
-	if (result != UDS_SUCCESS)
+	if (result != UDS_SUCCESS) {
 		return uds_log_warning_strerror(result,
 						"failed to read delta list data");
+	}
 
 	delta_index->load_lists[load_zone] -= 1;
 	new_zone = save_info.index / delta_index->lists_per_zone;
@@ -1315,7 +1334,7 @@ int uds_start_delta_index_search(const struct delta_index *delta_index,
 	} else {
 		delta_entry->key = 0;
 		delta_entry->offset = 0;
-		if (key == 0)
+		if (key == 0) {
 			/*
 			 * This usually means we're about to walk the entire delta list, so get all
 			 * of it into the CPU cache.
@@ -1323,6 +1342,7 @@ int uds_start_delta_index_search(const struct delta_index *delta_index,
 			uds_prefetch_range(&delta_zone->memory[delta_list->start / BITS_PER_BYTE],
 					   delta_list->size / BITS_PER_BYTE,
 					   false);
+		}
 	}
 
 	delta_entry->at_end = false;
@@ -1751,7 +1771,7 @@ int uds_put_delta_index_entry(struct delta_index_entry *delta_entry,
 	if (result != UDS_SUCCESS)
 		return result;
 
-	if (delta_entry->is_collision)
+	if (delta_entry->is_collision) {
 		/*
 		 * The caller wants us to insert a collision entry onto a collision entry. This
 		 * happens when we find a collision and attempt to add the name again to the index.
@@ -1759,6 +1779,7 @@ int uds_put_delta_index_entry(struct delta_index_entry *delta_entry,
 		 * are rebuilding a volume index.
 		 */
 		return UDS_DUPLICATE_NAME;
+	}
 
 	if (delta_entry->offset < delta_entry->delta_list->save_offset) {
 		/*

--- a/drivers/md/dm-vdo/delta-index.c
+++ b/drivers/md/dm-vdo/delta-index.c
@@ -166,7 +166,8 @@ static inline u16 get_delta_list_byte_size(const struct delta_list *delta_list)
 	return BITS_TO_BYTES(bit_offset + delta_list->size);
 }
 
-static void rebalance_delta_zone(const struct delta_zone *delta_zone, u32 first, u32 last)
+static void rebalance_delta_zone(const struct delta_zone *delta_zone, u32 first,
+				 u32 last)
 {
 	struct delta_list *delta_list;
 	u64 new_start;
@@ -239,13 +240,15 @@ void uds_reset_delta_index(const struct delta_index *delta_index)
 		struct delta_list *delta_lists = zone->delta_lists;
 
 		/* Zeroing the delta list headers initializes the head guard list correctly. */
-		memset(delta_lists, 0, (zone->list_count + 2) * sizeof(struct delta_list));
+		memset(delta_lists, 0,
+		       (zone->list_count + 2) * sizeof(struct delta_list));
 
 		/* Set all the bits in the end guard list. */
 		list_bits = (u64) zone->size * BITS_PER_BYTE - GUARD_BITS;
 		delta_lists[zone->list_count + 1].start = list_bits;
 		delta_lists[zone->list_count + 1].size = GUARD_BITS;
-		memset(zone->memory + (list_bits / BITS_PER_BYTE), ~0, POST_FIELD_GUARD_BYTES);
+		memset(zone->memory + (list_bits / BITS_PER_BYTE), ~0,
+		       POST_FIELD_GUARD_BYTES);
 
 		/* Evenly space out the real delta lists by setting regular offsets. */
 		spacing = list_bits / zone->list_count;
@@ -291,7 +294,8 @@ void uds_reset_delta_index(const struct delta_index *delta_index)
  * - The next INCR values code using MINBITS+2 bits.
  * - (and so on).
  */
-static void compute_coding_constants(u32 mean_delta, u16 *min_bits, u32 *min_keys, u32 *incr_keys)
+static void compute_coding_constants(u32 mean_delta, u16 *min_bits, u32 *min_keys,
+				     u32 *incr_keys)
 {
 	/*
 	 * We want to compute the rounded value of log(2) * mean_delta. Since we cannot always use
@@ -319,13 +323,9 @@ void uds_uninitialize_delta_index(struct delta_index *delta_index)
 	memset(delta_index, 0, sizeof(struct delta_index));
 }
 
-static int initialize_delta_zone(struct delta_zone *delta_zone,
-				 size_t size,
-				 u32 first_list,
-				 u32 list_count,
-				 u32 mean_delta,
-				 u32 payload_bits,
-				 u8 tag)
+static int initialize_delta_zone(struct delta_zone *delta_zone, size_t size,
+				 u32 first_list, u32 list_count, u32 mean_delta,
+				 u32 payload_bits, u8 tag)
 {
 	int result;
 
@@ -333,22 +333,19 @@ static int initialize_delta_zone(struct delta_zone *delta_zone,
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = uds_allocate(list_count + 2, u64, "delta list temp", &delta_zone->new_offsets);
+	result = uds_allocate(list_count + 2, u64, "delta list temp",
+			      &delta_zone->new_offsets);
 	if (result != UDS_SUCCESS)
 		return result;
 
 	/* Allocate the delta lists. */
-	result = uds_allocate(list_count + 2,
-			      struct delta_list,
-			      "delta lists",
+	result = uds_allocate(list_count + 2, struct delta_list, "delta lists",
 			      &delta_zone->delta_lists);
 	if (result != UDS_SUCCESS)
 		return result;
 
-	compute_coding_constants(mean_delta,
-				 &delta_zone->min_bits,
-				 &delta_zone->min_keys,
-				 &delta_zone->incr_keys);
+	compute_coding_constants(mean_delta, &delta_zone->min_bits,
+				 &delta_zone->min_keys, &delta_zone->incr_keys);
 	delta_zone->value_bits = payload_bits;
 	delta_zone->buffered_writer = NULL;
 	delta_zone->size = size;
@@ -365,21 +362,15 @@ static int initialize_delta_zone(struct delta_zone *delta_zone,
 	return UDS_SUCCESS;
 }
 
-int uds_initialize_delta_index(struct delta_index *delta_index,
-			       unsigned int zone_count,
-			       u32 list_count,
-			       u32 mean_delta,
-			       u32 payload_bits,
-			       size_t memory_size,
-			       u8 tag)
+int uds_initialize_delta_index(struct delta_index *delta_index, unsigned int zone_count,
+			       u32 list_count, u32 mean_delta, u32 payload_bits,
+			       size_t memory_size, u8 tag)
 {
 	int result;
 	unsigned int z;
 	size_t zone_memory;
 
-	result = uds_allocate(zone_count,
-			      struct delta_zone,
-			      "Delta Index Zones",
+	result = uds_allocate(zone_count, struct delta_zone, "Delta Index Zones",
 			      &delta_index->delta_zones);
 	if (result != UDS_SUCCESS)
 		return result;
@@ -404,20 +395,15 @@ int uds_initialize_delta_index(struct delta_index *delta_index,
 				uds_uninitialize_delta_index(delta_index);
 				return uds_log_error_strerror(UDS_INVALID_ARGUMENT,
 							      "%u delta lists not enough for %u zones",
-							      list_count,
-							      zone_count);
+							      list_count, zone_count);
 			}
 			lists_in_zone = delta_index->list_count - first_list_in_zone;
 		}
 
 		zone_memory = get_zone_memory_size(zone_count, memory_size);
-		result = initialize_delta_zone(&delta_index->delta_zones[z],
-					       zone_memory,
-					       first_list_in_zone,
-					       lists_in_zone,
-					       mean_delta,
-					       payload_bits,
-					       tag);
+		result = initialize_delta_zone(&delta_index->delta_zones[z], zone_memory,
+					       first_list_in_zone, lists_in_zone,
+					       mean_delta, payload_bits, tag);
 		if (result != UDS_SUCCESS) {
 			uds_uninitialize_delta_index(delta_index);
 			return result;
@@ -462,20 +448,19 @@ static inline u32 get_immutable_header_offset(u32 list_number)
 /* Get the bit offset to the start of the immutable delta list bit stream. */
 static inline u32 get_immutable_start(const u8 *memory, u32 list_number)
 {
-	return get_field(memory, get_immutable_header_offset(list_number), IMMUTABLE_HEADER_SIZE);
+	return get_field(memory, get_immutable_header_offset(list_number),
+			 IMMUTABLE_HEADER_SIZE);
 }
 
 /* Set the bit offset to the start of the immutable delta list bit stream. */
 static inline void set_immutable_start(u8 *memory, u32 list_number, u32 start)
 {
-	set_field(start, memory, get_immutable_header_offset(list_number), IMMUTABLE_HEADER_SIZE);
+	set_field(start, memory, get_immutable_header_offset(list_number),
+		  IMMUTABLE_HEADER_SIZE);
 }
 
-static bool verify_delta_index_page(u64 nonce,
-				    u16 list_count,
-				    u64 expected_nonce,
-				    u8 *memory,
-				    size_t memory_size)
+static bool verify_delta_index_page(u64 nonce, u16 list_count, u64 expected_nonce,
+				    u8 *memory, size_t memory_size)
 {
 	unsigned int i;
 
@@ -524,11 +509,8 @@ static bool verify_delta_index_page(u64 nonce,
 
 /* Initialize a delta index page to refer to a supplied page. */
 int uds_initialize_delta_index_page(struct delta_index_page *delta_index_page,
-				    u64 expected_nonce,
-				    u32 mean_delta,
-				    u32 payload_bits,
-				    u8 *memory,
-				    size_t memory_size)
+				    u64 expected_nonce, u32 mean_delta, u32 payload_bits,
+				    u8 *memory, size_t memory_size)
 {
 	u64 nonce;
 	u64 vcn;
@@ -546,16 +528,14 @@ int uds_initialize_delta_index_page(struct delta_index_page *delta_index_page,
 	vcn = get_unaligned_le64(vcn_addr);
 	first_list = get_unaligned_le16(first_list_addr);
 	list_count = get_unaligned_le16(list_count_addr);
-	if (!verify_delta_index_page(nonce, list_count, expected_nonce, memory, memory_size)) {
+	if (!verify_delta_index_page(nonce, list_count, expected_nonce, memory,
+				     memory_size)) {
 		/* If that fails, try big endian. */
 		nonce = get_unaligned_be64(nonce_addr);
 		vcn = get_unaligned_be64(vcn_addr);
 		first_list = get_unaligned_be16(first_list_addr);
 		list_count = get_unaligned_be16(list_count_addr);
-		if (!verify_delta_index_page(nonce,
-					     list_count,
-					     expected_nonce,
-					     memory,
+		if (!verify_delta_index_page(nonce, list_count, expected_nonce, memory,
 					     memory_size)) {
 			/*
 			 * Both attempts failed. Do not log this as an error, because it can happen
@@ -575,10 +555,8 @@ int uds_initialize_delta_index_page(struct delta_index_page *delta_index_page,
 	delta_index_page->lowest_list_number = first_list;
 	delta_index_page->highest_list_number = first_list + list_count - 1;
 
-	compute_coding_constants(mean_delta,
-				 &delta_zone->min_bits,
-				 &delta_zone->min_keys,
-				 &delta_zone->incr_keys);
+	compute_coding_constants(mean_delta, &delta_zone->min_bits,
+				 &delta_zone->min_keys, &delta_zone->incr_keys);
 	delta_zone->value_bits = payload_bits;
 	delta_zone->memory = memory;
 	delta_zone->delta_lists = NULL;
@@ -639,7 +617,8 @@ static inline void set_zero(u8 *memory, u64 offset, u32 size)
  * Move several bits from a higher to a lower address, moving the lower addressed bits first. The
  * size and memory offsets are measured in bits.
  */
-static void move_bits_down(const u8 *from, u64 from_offset, u8 *to, u64 to_offset, u32 size)
+static void move_bits_down(const u8 *from, u64 from_offset, u8 *to, u64 to_offset,
+			   u32 size)
 {
 	const u8 *source;
 	u8 *destination;
@@ -679,7 +658,8 @@ static void move_bits_down(const u8 *from, u64 from_offset, u8 *to, u64 to_offse
  * Move several bits from a lower to a higher address, moving the higher addressed bits first. The
  * size and memory offsets are measured in bits.
  */
-static void move_bits_up(const u8 *from, u64 from_offset, u8 *to, u64 to_offset, u32 size)
+static void move_bits_up(const u8 *from, u64 from_offset, u8 *to, u64 to_offset,
+			 u32 size)
 {
 	const u8 *source;
 	u8 *destination;
@@ -744,13 +724,9 @@ static void move_bits(const u8 *from, u64 from_offset, u8 *to, u64 to_offset, u3
  * memory page used in the immutable index. The number of lists copied onto the page is returned in
  * list_count.
  */
-int uds_pack_delta_index_page(const struct delta_index *delta_index,
-			      u64 header_nonce,
-			      u8 *memory,
-			      size_t memory_size,
-			      u64 virtual_chapter_number,
-			      u32 first_list,
-			      u32 *list_count)
+int uds_pack_delta_index_page(const struct delta_index *delta_index, u64 header_nonce,
+			      u8 *memory, size_t memory_size, u64 virtual_chapter_number,
+			      u32 first_list, u32 *list_count)
 {
 	const struct delta_zone *delta_zone;
 	struct delta_list *delta_lists;
@@ -795,7 +771,8 @@ int uds_pack_delta_index_page(const struct delta_index *delta_index,
 
 	header = (struct delta_page_header *) memory;
 	put_unaligned_le64(header_nonce, (u8 *) &header->nonce);
-	put_unaligned_le64(virtual_chapter_number, (u8 *) &header->virtual_chapter_number);
+	put_unaligned_le64(virtual_chapter_number,
+			   (u8 *) &header->virtual_chapter_number);
 	put_unaligned_le16(first_list, (u8 *) &header->first_list);
 	put_unaligned_le16(n_lists, (u8 *) &header->list_count);
 
@@ -809,23 +786,19 @@ int uds_pack_delta_index_page(const struct delta_index *delta_index,
 
 	/* Copy the delta list data onto the memory page. */
 	for (i = 0; i < n_lists; i++) {
-		move_bits(delta_zone->memory,
-			  delta_lists[i].start,
-			  memory,
-			  get_immutable_start(memory, i),
-			  delta_lists[i].size);
+		move_bits(delta_zone->memory, delta_lists[i].start, memory,
+			  get_immutable_start(memory, i), delta_lists[i].size);
 	}
 
 	/* Set all the bits in the guard bytes. */
-	memset(memory + memory_size - POST_FIELD_GUARD_BYTES, ~0, POST_FIELD_GUARD_BYTES);
+	memset(memory + memory_size - POST_FIELD_GUARD_BYTES, ~0,
+	       POST_FIELD_GUARD_BYTES);
 	return UDS_SUCCESS;
 }
 
 /* Compute the new offsets of the delta lists. */
-static void compute_new_list_offsets(struct delta_zone *delta_zone,
-				     u32 growing_index,
-				     size_t growing_size,
-				     size_t used_space)
+static void compute_new_list_offsets(struct delta_zone *delta_zone, u32 growing_index,
+				     size_t growing_size, size_t used_space)
 {
 	size_t spacing;
 	u32 i;
@@ -887,8 +860,7 @@ int uds_start_restoring_delta_index(struct delta_index *delta_index,
 		u8 buffer[sizeof(struct delta_index_header)];
 		size_t offset = 0;
 
-		result = uds_read_from_buffered_reader(buffered_readers[z],
-						       buffer,
+		result = uds_read_from_buffered_reader(buffered_readers[z], buffer,
 						       sizeof(buffer));
 		if (result != UDS_SUCCESS) {
 			return uds_log_warning_strerror(result,
@@ -905,8 +877,7 @@ int uds_start_restoring_delta_index(struct delta_index *delta_index,
 		decode_u64_le(buffer, &offset, &header.collision_count);
 
 		result = ASSERT(offset == sizeof(struct delta_index_header),
-				"%zu bytes decoded of %zu expected",
-				offset,
+				"%zu bytes decoded of %zu expected", offset,
 				sizeof(struct delta_index_header));
 		if (result != UDS_SUCCESS) {
 			return uds_log_warning_strerror(result,
@@ -921,15 +892,13 @@ int uds_start_restoring_delta_index(struct delta_index *delta_index,
 		if (zone_count != header.zone_count) {
 			return uds_log_warning_strerror(UDS_CORRUPT_DATA,
 							"delta index files contain mismatched zone counts (%u,%u)",
-							zone_count,
-							header.zone_count);
+							zone_count, header.zone_count);
 		}
 
 		if (header.zone_number != z) {
 			return uds_log_warning_strerror(UDS_CORRUPT_DATA,
 							"delta index zone %u found in slot %u",
-							header.zone_number,
-							z);
+							header.zone_number, z);
 		}
 
 		first_list[z] = header.first_list;
@@ -940,9 +909,7 @@ int uds_start_restoring_delta_index(struct delta_index *delta_index,
 		if (first_list[z] != list_next) {
 			return uds_log_warning_strerror(UDS_CORRUPT_DATA,
 							"delta index file for zone %u starts with list %u instead of list %u",
-							z,
-							first_list[z],
-							list_next);
+							z, first_list[z], list_next);
 		}
 
 		list_next += list_count[z];
@@ -951,8 +918,7 @@ int uds_start_restoring_delta_index(struct delta_index *delta_index,
 	if (list_next != delta_index->list_count) {
 		return uds_log_warning_strerror(UDS_CORRUPT_DATA,
 						"delta index files contain %u delta lists instead of %u delta lists",
-						list_next,
-						delta_index->list_count);
+						list_next, delta_index->list_count);
 	}
 
 	if (collision_count > record_count) {
@@ -1016,10 +982,8 @@ static int restore_delta_list_to_zone(struct delta_zone *delta_zone,
 	if (list_number >= delta_zone->list_count) {
 		return uds_log_warning_strerror(UDS_CORRUPT_DATA,
 						"invalid delta list number %u not in range [%u,%u)",
-						save_info->index,
-						delta_zone->first_list,
-						delta_zone->first_list +
-						delta_zone->list_count);
+						save_info->index, delta_zone->first_list,
+						delta_zone->first_list + delta_zone->list_count);
 	}
 
 	delta_list = &delta_zone->delta_lists[list_number + 1];
@@ -1034,22 +998,17 @@ static int restore_delta_list_to_zone(struct delta_zone *delta_zone,
 	if (save_info->byte_count != byte_count) {
 		return uds_log_warning_strerror(UDS_CORRUPT_DATA,
 						"unexpected delta list size %u != %u",
-						save_info->byte_count,
-						byte_count);
+						save_info->byte_count, byte_count);
 	}
 
-	move_bits(data,
-		  save_info->bit_offset,
-		  delta_zone->memory,
-		  delta_list->start,
+	move_bits(data, save_info->bit_offset, delta_zone->memory, delta_list->start,
 		  delta_list->size);
 	return UDS_SUCCESS;
 }
 
 static int restore_delta_list_data(struct delta_index *delta_index,
 				   unsigned int load_zone,
-				   struct buffered_reader *buffered_reader,
-				   u8 *data)
+				   struct buffered_reader *buffered_reader, u8 *data)
 {
 	int result;
 	struct delta_list_save_info save_info;
@@ -1058,7 +1017,8 @@ static int restore_delta_list_data(struct delta_index *delta_index,
 
 	result = uds_read_from_buffered_reader(buffered_reader, buffer, sizeof(buffer));
 	if (result != UDS_SUCCESS)
-		return uds_log_warning_strerror(result, "failed to read delta list data");
+		return uds_log_warning_strerror(result,
+						"failed to read delta list data");
 
 	save_info = (struct delta_list_save_info) {
 		.tag = buffer[0],
@@ -1069,7 +1029,8 @@ static int restore_delta_list_data(struct delta_index *delta_index,
 
 	if ((save_info.bit_offset >= BITS_PER_BYTE) ||
 	    (save_info.byte_count > DELTA_LIST_MAX_BYTE_COUNT))
-		return uds_log_warning_strerror(UDS_CORRUPT_DATA, "corrupt delta list data");
+		return uds_log_warning_strerror(UDS_CORRUPT_DATA,
+						"corrupt delta list data");
 
 	/* Make sure the data is intended for this delta index. */
 	if (save_info.tag != delta_index->tag)
@@ -1082,7 +1043,8 @@ static int restore_delta_list_data(struct delta_index *delta_index,
 						delta_index->list_count);
 	}
 
-	result = uds_read_from_buffered_reader(buffered_reader, data, save_info.byte_count);
+	result = uds_read_from_buffered_reader(buffered_reader, data,
+					       save_info.byte_count);
 	if (result != UDS_SUCCESS) {
 		return uds_log_warning_strerror(result,
 						"failed to read delta list data");
@@ -1090,7 +1052,8 @@ static int restore_delta_list_data(struct delta_index *delta_index,
 
 	delta_index->load_lists[load_zone] -= 1;
 	new_zone = save_info.index / delta_index->lists_per_zone;
-	return restore_delta_list_to_zone(&delta_index->delta_zones[new_zone], &save_info, data);
+	return restore_delta_list_to_zone(&delta_index->delta_zones[new_zone],
+					  &save_info, data);
 }
 
 /* Restore delta lists from saved data. */
@@ -1109,10 +1072,8 @@ int uds_finish_restoring_delta_index(struct delta_index *delta_index,
 
 	for (z = 0; z < reader_count; z++) {
 		while (delta_index->load_lists[z] > 0) {
-			result = restore_delta_list_data(delta_index,
-							 z,
-							 buffered_readers[z],
-							 data);
+			result = restore_delta_list_data(delta_index, z,
+							 buffered_readers[z], data);
 			if (result != UDS_SUCCESS) {
 				saved_result = result;
 				break;
@@ -1132,8 +1093,7 @@ int uds_check_guard_delta_lists(struct buffered_reader **buffered_readers,
 	u8 buffer[sizeof(struct delta_list_save_info)];
 
 	for (z = 0; z < reader_count; z++) {
-		result = uds_read_from_buffered_reader(buffered_readers[z],
-						       buffer,
+		result = uds_read_from_buffered_reader(buffered_readers[z], buffer,
 						       sizeof(buffer));
 		if (result != UDS_SUCCESS)
 			return result;
@@ -1158,7 +1118,8 @@ static int flush_delta_list(struct delta_zone *zone, u32 flush_index)
 	put_unaligned_le16(get_delta_list_byte_size(delta_list), &buffer[2]);
 	put_unaligned_le32(zone->first_list + flush_index, &buffer[4]);
 
-	result = uds_write_to_buffered_writer(zone->buffered_writer, buffer, sizeof(buffer));
+	result = uds_write_to_buffered_writer(zone->buffered_writer, buffer,
+					      sizeof(buffer));
 	if (result != UDS_SUCCESS) {
 		uds_log_warning_strerror(result, "failed to write delta list memory");
 		return result;
@@ -1195,15 +1156,15 @@ int uds_start_saving_delta_index(const struct delta_index *delta_index,
 	encode_u64_le(buffer, &offset, delta_zone->collision_count);
 
 	result = ASSERT(offset == sizeof(struct delta_index_header),
-			"%zu bytes encoded of %zu expected",
-			offset,
+			"%zu bytes encoded of %zu expected", offset,
 			sizeof(struct delta_index_header));
 	if (result != UDS_SUCCESS)
 		return result;
 
 	result = uds_write_to_buffered_writer(buffered_writer, buffer, offset);
 	if (result != UDS_SUCCESS)
-		return uds_log_warning_strerror(result, "failed to write delta index header");
+		return uds_log_warning_strerror(result,
+						"failed to write delta index header");
 
 	for (i = 0; i < delta_zone->list_count; i++) {
 		u8 data[sizeof(u16)];
@@ -1211,16 +1172,19 @@ int uds_start_saving_delta_index(const struct delta_index *delta_index,
 
 		delta_list = &delta_zone->delta_lists[i + 1];
 		put_unaligned_le16(delta_list->size, data);
-		result = uds_write_to_buffered_writer(buffered_writer, data, sizeof(data));
+		result = uds_write_to_buffered_writer(buffered_writer, data,
+						      sizeof(data));
 		if (result != UDS_SUCCESS)
-			return uds_log_warning_strerror(result, "failed to write delta list size");
+			return uds_log_warning_strerror(result,
+							"failed to write delta list size");
 	}
 
 	delta_zone->buffered_writer = buffered_writer;
 	return UDS_SUCCESS;
 }
 
-int uds_finish_saving_delta_index(const struct delta_index *delta_index, unsigned int zone_number)
+int uds_finish_saving_delta_index(const struct delta_index *delta_index,
+				  unsigned int zone_number)
 {
 	int result;
 	int first_error = UDS_SUCCESS;
@@ -1283,10 +1247,8 @@ static int assert_not_at_end(const struct delta_index_entry *delta_entry)
  * fields of the delta_index_entry argument will be set up for iteration, but will not contain an
  * entry from the list.
  */
-int uds_start_delta_index_search(const struct delta_index *delta_index,
-				 u32 list_number,
-				 u32 key,
-				 struct delta_index_entry *delta_entry)
+int uds_start_delta_index_search(const struct delta_index *delta_index, u32 list_number,
+				 u32 key, struct delta_index_entry *delta_entry)
 {
 	int result;
 	unsigned int zone_number;
@@ -1294,8 +1256,7 @@ int uds_start_delta_index_search(const struct delta_index *delta_index,
 	struct delta_list *delta_list;
 
 	result = ASSERT((list_number < delta_index->list_count),
-			"Delta list number (%u) is out of range (%u)",
-			list_number,
+			"Delta list number (%u) is out of range (%u)", list_number,
 			delta_index->list_count);
 	if (result != UDS_SUCCESS)
 		return UDS_CORRUPT_DATA;
@@ -1305,9 +1266,7 @@ int uds_start_delta_index_search(const struct delta_index *delta_index,
 	list_number -= delta_zone->first_list;
 	result = ASSERT((list_number < delta_zone->list_count),
 			"Delta list number (%u) is out of range (%u) for zone (%u)",
-			list_number,
-			delta_zone->list_count,
-			zone_number);
+			list_number, delta_zone->list_count, zone_number);
 	if (result != UDS_SUCCESS)
 		return UDS_CORRUPT_DATA;
 
@@ -1340,8 +1299,7 @@ int uds_start_delta_index_search(const struct delta_index *delta_index,
 			 * of it into the CPU cache.
 			 */
 			uds_prefetch_range(&delta_zone->memory[delta_list->start / BITS_PER_BYTE],
-					   delta_list->size / BITS_PER_BYTE,
-					   false);
+					   delta_list->size / BITS_PER_BYTE, false);
 		}
 	}
 
@@ -1498,15 +1456,14 @@ static void set_collision_name(const struct delta_index_entry *entry, const u8 *
 	}
 }
 
-int uds_get_delta_index_entry(const struct delta_index *delta_index,
-			      u32 list_number,
-			      u32 key,
-			      const u8 *name,
+int uds_get_delta_index_entry(const struct delta_index *delta_index, u32 list_number,
+			      u32 key, const u8 *name,
 			      struct delta_index_entry *delta_entry)
 {
 	int result;
 
-	result = uds_start_delta_index_search(delta_index, list_number, key, delta_entry);
+	result = uds_start_delta_index_search(delta_index, list_number, key,
+					      delta_entry);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -1564,8 +1521,7 @@ int uds_get_delta_entry_collision(const struct delta_index_entry *delta_entry, u
 u32 uds_get_delta_entry_value(const struct delta_index_entry *delta_entry)
 {
 	return get_field(delta_entry->delta_zone->memory,
-			 get_delta_entry_offset(delta_entry),
-			 delta_entry->value_bits);
+			 get_delta_entry_offset(delta_entry), delta_entry->value_bits);
 }
 
 static int assert_mutable_entry(const struct delta_index_entry *delta_entry)
@@ -1593,15 +1549,12 @@ int uds_set_delta_entry_value(const struct delta_index_entry *delta_entry, u32 v
 
 	result = ASSERT((value & value_mask) == value,
 			"Value (%u) being set in a delta index is too large (must fit in %u bits)",
-			value,
-			delta_entry->value_bits);
+			value, delta_entry->value_bits);
 	if (result != UDS_SUCCESS)
 		return UDS_INVALID_ARGUMENT;
 
-	set_field(value,
-		  delta_entry->delta_zone->memory,
-		  get_delta_entry_offset(delta_entry),
-		  delta_entry->value_bits);
+	set_field(value, delta_entry->delta_zone->memory,
+		  get_delta_entry_offset(delta_entry), delta_entry->value_bits);
 	return UDS_SUCCESS;
 }
 
@@ -1609,8 +1562,8 @@ int uds_set_delta_entry_value(const struct delta_index_entry *delta_entry, u32 v
  * Extend the memory used by the delta lists by adding growing_size bytes before the list indicated
  * by growing_index, then rebalancing the lists in the new chunk.
  */
-static int
-extend_delta_zone(struct delta_zone *delta_zone, u32 growing_index, size_t growing_size)
+static int extend_delta_zone(struct delta_zone *delta_zone, u32 growing_index,
+			     size_t growing_size)
 {
 	ktime_t start_time;
 	ktime_t end_time;
@@ -1699,7 +1652,8 @@ static int insert_bits(struct delta_index_entry *delta_entry, u16 size)
 		before_flag = before_size < after_size;
 		if (!before_flag)
 			growing_index++;
-		result = extend_delta_zone(delta_zone, growing_index, BITS_TO_BYTES(size));
+		result = extend_delta_zone(delta_zone, growing_index,
+					   BITS_TO_BYTES(size));
 		if (result != UDS_SUCCESS)
 			return result;
 	}
@@ -1744,7 +1698,8 @@ static void encode_delta(const struct delta_index_entry *delta_entry)
 	set_field(1, memory, offset + delta_zone->min_bits + t2, 1);
 }
 
-static void encode_entry(const struct delta_index_entry *delta_entry, u32 value, const u8 *name)
+static void encode_entry(const struct delta_index_entry *delta_entry, u32 value,
+			 const u8 *name)
 {
 	u8 *memory = delta_entry->delta_zone->memory;
 	u64 offset = get_delta_entry_offset(delta_entry);
@@ -1759,9 +1714,7 @@ static void encode_entry(const struct delta_index_entry *delta_entry, u32 value,
  * Create a new entry in the delta index. If the entry is a collision, the full 256 bit name must
  * be provided.
  */
-int uds_put_delta_index_entry(struct delta_index_entry *delta_entry,
-			      u32 key,
-			      u32 value,
+int uds_put_delta_index_entry(struct delta_index_entry *delta_entry, u32 key, u32 value,
 			      const u8 *name)
 {
 	int result;
@@ -1797,7 +1750,8 @@ int uds_put_delta_index_entry(struct delta_index_entry *delta_entry,
 		if (result != UDS_SUCCESS)
 			return result;
 
-		result = ASSERT((key == delta_entry->key), "incorrect key for collision entry");
+		result = ASSERT((key == delta_entry->key),
+				"incorrect key for collision entry");
 		if (result != UDS_SUCCESS)
 			return result;
 
@@ -1826,7 +1780,8 @@ int uds_put_delta_index_entry(struct delta_index_entry *delta_entry,
 		 * Insert a new entry which requires the delta in the following entry to be
 		 * updated.
 		 */
-		result = ASSERT((key < delta_entry->key), "key precedes following entry");
+		result = ASSERT((key < delta_entry->key),
+				"key precedes following entry");
 		if (result != UDS_SUCCESS)
 			return result;
 
@@ -1997,18 +1952,16 @@ size_t uds_compute_delta_index_size(u32 entry_count, u32 mean_delta, u32 payload
 	return entry_count * (payload_bits + min_bits + 1) + entry_count / 2;
 }
 
-u32 uds_get_delta_index_page_count(u32 entry_count,
-				   u32 list_count,
-				   u32 mean_delta,
-				   u32 payload_bits,
-				   size_t bytes_per_page)
+u32 uds_get_delta_index_page_count(u32 entry_count, u32 list_count, u32 mean_delta,
+				   u32 payload_bits, size_t bytes_per_page)
 {
 	unsigned int bits_per_delta_list;
 	unsigned int bits_per_page;
 	size_t bits_per_index;
 
 	/* Compute the expected number of bits needed for all the entries. */
-	bits_per_index = uds_compute_delta_index_size(entry_count, mean_delta, payload_bits);
+	bits_per_index = uds_compute_delta_index_size(entry_count, mean_delta,
+						      payload_bits);
 	bits_per_delta_list = bits_per_index / list_count;
 
 	/* Add in the immutable delta list headers. */
@@ -2028,10 +1981,8 @@ void uds_log_delta_index_entry(struct delta_index_entry *delta_entry)
 {
 	uds_log_ratelimit(uds_log_info,
 			  "List 0x%X Key 0x%X Offset 0x%X%s%s List_size 0x%X%s",
-			  delta_entry->list_number,
-			  delta_entry->key,
-			  delta_entry->offset,
-			  delta_entry->at_end ? " end" : "",
+			  delta_entry->list_number, delta_entry->key,
+			  delta_entry->offset, delta_entry->at_end ? " end" : "",
 			  delta_entry->is_collision ? " collision" : "",
 			  delta_entry->delta_list->size,
 			  delta_entry->list_overflow ? " overflow" : "");

--- a/drivers/md/dm-vdo/delta-index.h
+++ b/drivers/md/dm-vdo/delta-index.h
@@ -198,18 +198,13 @@ struct delta_index_stats {
 };
 
 int __must_check uds_initialize_delta_index(struct delta_index *delta_index,
-					    unsigned int zone_count,
-					    u32 list_count,
-					    u32 mean_delta,
-					    u32 payload_bits,
-					    size_t memory_size,
-					    u8 tag);
+					    unsigned int zone_count, u32 list_count,
+					    u32 mean_delta, u32 payload_bits,
+					    size_t memory_size, u8 tag);
 
 int __must_check uds_initialize_delta_index_page(struct delta_index_page *delta_index_page,
-						 u64 expected_nonce,
-						 u32 mean_delta,
-						 u32 payload_bits,
-						 u8 *memory,
+						 u64 expected_nonce, u32 mean_delta,
+						 u32 payload_bits, u8 *memory,
 						 size_t memory_size);
 
 void uds_uninitialize_delta_index(struct delta_index *delta_index);
@@ -217,11 +212,9 @@ void uds_uninitialize_delta_index(struct delta_index *delta_index);
 void uds_reset_delta_index(const struct delta_index *delta_index);
 
 int __must_check uds_pack_delta_index_page(const struct delta_index *delta_index,
-					   u64 header_nonce,
-					   u8 *memory,
+					   u64 header_nonce, u8 *memory,
 					   size_t memory_size,
-					   u64 virtual_chapter_number,
-					   u32 first_list,
+					   u64 virtual_chapter_number, u32 first_list,
 					   u32 *list_count);
 
 int __must_check uds_start_restoring_delta_index(struct delta_index *delta_index,
@@ -232,23 +225,23 @@ int __must_check uds_finish_restoring_delta_index(struct delta_index *delta_inde
 						  struct buffered_reader **buffered_readers,
 						  unsigned int reader_count);
 
-int __must_check
-uds_check_guard_delta_lists(struct buffered_reader **buffered_readers, unsigned int reader_count);
+int __must_check uds_check_guard_delta_lists(struct buffered_reader **buffered_readers,
+					     unsigned int reader_count);
 
 int __must_check uds_start_saving_delta_index(const struct delta_index *delta_index,
 					      unsigned int zone_number,
 					      struct buffered_writer *buffered_writer);
 
-int __must_check
-uds_finish_saving_delta_index(const struct delta_index *delta_index, unsigned int zone_number);
+int __must_check uds_finish_saving_delta_index(const struct delta_index *delta_index,
+					       unsigned int zone_number);
 
 int __must_check uds_write_guard_delta_list(struct buffered_writer *buffered_writer);
 
-size_t __must_check uds_compute_delta_index_save_bytes(u32 list_count, size_t memory_size);
+size_t __must_check uds_compute_delta_index_save_bytes(u32 list_count,
+						       size_t memory_size);
 
 int __must_check uds_start_delta_index_search(const struct delta_index *delta_index,
-					      u32 list_number,
-					      u32 key,
+					      u32 list_number, u32 key,
 					      struct delta_index_entry *iterator);
 
 int __must_check uds_next_delta_index_entry(struct delta_index_entry *delta_entry);
@@ -256,36 +249,29 @@ int __must_check uds_next_delta_index_entry(struct delta_index_entry *delta_entr
 int __must_check uds_remember_delta_index_offset(const struct delta_index_entry *delta_entry);
 
 int __must_check uds_get_delta_index_entry(const struct delta_index *delta_index,
-					   u32 list_number,
-					   u32 key,
-					   const u8 *name,
+					   u32 list_number, u32 key, const u8 *name,
 					   struct delta_index_entry *delta_entry);
 
-int __must_check
-uds_get_delta_entry_collision(const struct delta_index_entry *delta_entry, u8 *name);
+int __must_check uds_get_delta_entry_collision(const struct delta_index_entry *delta_entry,
+					       u8 *name);
 
 u32 __must_check uds_get_delta_entry_value(const struct delta_index_entry *delta_entry);
 
 int __must_check uds_set_delta_entry_value(const struct delta_index_entry *delta_entry, u32 value);
 
-int __must_check uds_put_delta_index_entry(struct delta_index_entry *delta_entry,
-					   u32 key,
-					   u32 value,
-					   const u8 *name);
+int __must_check uds_put_delta_index_entry(struct delta_index_entry *delta_entry, u32 key,
+					   u32 value, const u8 *name);
 
 int __must_check uds_remove_delta_index_entry(struct delta_index_entry *delta_entry);
 
 void uds_get_delta_index_stats(const struct delta_index *delta_index,
 			       struct delta_index_stats *stats);
 
-size_t __must_check
-uds_compute_delta_index_size(u32 entry_count, u32 mean_delta, u32 payload_bits);
+size_t __must_check uds_compute_delta_index_size(u32 entry_count, u32 mean_delta,
+						 u32 payload_bits);
 
-u32 uds_get_delta_index_page_count(u32 entry_count,
-				   u32 list_count,
-				   u32 mean_delta,
-				   u32 payload_bits,
-				   size_t bytes_per_page);
+u32 uds_get_delta_index_page_count(u32 entry_count, u32 list_count, u32 mean_delta,
+				   u32 payload_bits, size_t bytes_per_page);
 
 void uds_log_delta_index_entry(struct delta_index_entry *delta_entry);
 

--- a/drivers/md/dm-vdo/dump.c
+++ b/drivers/md/dm-vdo/dump.c
@@ -208,9 +208,10 @@ static void encode_vio_dump_flags(struct data_vio *data_vio, char buffer[8])
 		*p_flag++ = 'z';
 	if (data_vio->remaining_discard > 0)
 		*p_flag++ = 'd';
-	if (p_flag == &buffer[1])
+	if (p_flag == &buffer[1]) {
 		/* No flags, so remove the blank space. */
 		p_flag = buffer;
+	}
 	*p_flag = '\0';
 }
 
@@ -241,32 +242,34 @@ void dump_data_vio(void *data)
 	vdo_dump_completion_to_buffer(&data_vio->vio.completion,
 				      vio_completion_dump_buffer,
 				      sizeof(vio_completion_dump_buffer));
-	if (data_vio->is_duplicate)
+	if (data_vio->is_duplicate) {
 		snprintf(vio_block_number_dump_buffer,
 			 sizeof(vio_block_number_dump_buffer),
 			 "P%llu L%llu D%llu",
 			 data_vio->allocation.pbn,
 			 data_vio->logical.lbn,
 			 data_vio->duplicate.pbn);
-	else if (data_vio_has_allocation(data_vio))
+	} else if (data_vio_has_allocation(data_vio)) {
 		snprintf(vio_block_number_dump_buffer,
 			 sizeof(vio_block_number_dump_buffer),
 			 "P%llu L%llu",
 			 data_vio->allocation.pbn,
 			 data_vio->logical.lbn);
-	else
+	} else {
 		snprintf(vio_block_number_dump_buffer,
 			 sizeof(vio_block_number_dump_buffer),
 			 "L%llu",
 			 data_vio->logical.lbn);
+	}
 
-	if (data_vio->flush_generation != 0)
+	if (data_vio->flush_generation != 0) {
 		snprintf(vio_flush_generation_buffer,
 			 sizeof(vio_flush_generation_buffer),
 			 " FG%llu",
 			 data_vio->flush_generation);
-	else
+	} else {
 		vio_flush_generation_buffer[0] = 0;
+	}
 
 	encode_vio_dump_flags(data_vio, flags_dump_buffer);
 

--- a/drivers/md/dm-vdo/dump.c
+++ b/drivers/md/dm-vdo/dump.c
@@ -218,7 +218,7 @@ static void encode_vio_dump_flags(struct data_vio *data_vio, char buffer[8])
 /* Implements buffer_dump_function. */
 void dump_data_vio(void *data)
 {
-	struct data_vio *data_vio = (struct data_vio *) data;
+	struct data_vio *data_vio = data;
 
 	/*
 	 * This just needs to be big enough to hold a queue (thread) name and a function name (plus

--- a/drivers/md/dm-vdo/dump.c
+++ b/drivers/md/dm-vdo/dump.c
@@ -52,7 +52,8 @@ static inline bool is_arg_string(const char *arg, const char *this_option)
 	return strncasecmp(arg, this_option, strlen(this_option)) == 0;
 }
 
-static void do_dump(struct vdo *vdo, unsigned int dump_options_requested, const char *why)
+static void do_dump(struct vdo *vdo, unsigned int dump_options_requested,
+		    const char *why)
 {
 	u32 active, maximum;
 	s64 outstanding;
@@ -63,9 +64,7 @@ static void do_dump(struct vdo *vdo, unsigned int dump_options_requested, const 
 	outstanding = (atomic64_read(&vdo->stats.bios_submitted) -
 		       atomic64_read(&vdo->stats.bios_completed));
 	uds_log_info("%u device requests outstanding (max %u), %lld bio requests outstanding, device '%s'",
-		     active,
-		     maximum,
-		     outstanding,
+		     active, maximum, outstanding,
 		     vdo_get_device_name(vdo->device_config->owning_target));
 	if (((dump_options_requested & FLAG_SHOW_QUEUES) != 0) && (vdo->threads != NULL)) {
 		thread_id_t id;
@@ -75,7 +74,8 @@ static void do_dump(struct vdo *vdo, unsigned int dump_options_requested, const 
 	}
 
 	vdo_dump_hash_zones(vdo->hash_zones);
-	dump_data_vio_pool(vdo->data_vio_pool, (dump_options_requested & FLAG_SHOW_VIO_POOL) != 0);
+	dump_data_vio_pool(vdo->data_vio_pool,
+			   (dump_options_requested & FLAG_SHOW_VIO_POOL) != 0);
 	if ((dump_options_requested & FLAG_SHOW_VDO_STATUS) != 0)
 		vdo_dump_status(vdo);
 
@@ -83,8 +83,8 @@ static void do_dump(struct vdo *vdo, unsigned int dump_options_requested, const 
 	uds_log_info("end of %s dump", UDS_LOGGING_MODULE_NAME);
 }
 
-static int
-parse_dump_options(unsigned int argc, char *const *argv, unsigned int *dump_options_requested_ptr)
+static int parse_dump_options(unsigned int argc, char *const *argv,
+			      unsigned int *dump_options_requested_ptr)
 {
 	unsigned int dump_options_requested = 0;
 
@@ -160,19 +160,13 @@ static void dump_vio_waiters(struct wait_queue *queue, char *wait_on)
 	data_vio = waiter_as_data_vio(first);
 
 	uds_log_info("      %s is locked. Waited on by: vio %px pbn %llu lbn %llu d-pbn %llu lastOp %s",
-		     wait_on,
-		     data_vio,
-		     data_vio->allocation.pbn,
-		     data_vio->logical.lbn,
-		     data_vio->duplicate.pbn,
-		     get_data_vio_operation_name(data_vio));
+		     wait_on, data_vio, data_vio->allocation.pbn, data_vio->logical.lbn,
+		     data_vio->duplicate.pbn, get_data_vio_operation_name(data_vio));
 
 	for (waiter = first->next_waiter; waiter != first; waiter = waiter->next_waiter) {
 		data_vio = waiter_as_data_vio(waiter);
 		uds_log_info("     ... and : vio %px pbn %llu lbn %llu d-pbn %llu lastOp %s",
-			     data_vio,
-			     data_vio->allocation.pbn,
-			     data_vio->logical.lbn,
+			     data_vio, data_vio->allocation.pbn, data_vio->logical.lbn,
 			     data_vio->duplicate.pbn,
 			     get_data_vio_operation_name(data_vio));
 	}
@@ -244,28 +238,22 @@ void dump_data_vio(void *data)
 				      sizeof(vio_completion_dump_buffer));
 	if (data_vio->is_duplicate) {
 		snprintf(vio_block_number_dump_buffer,
-			 sizeof(vio_block_number_dump_buffer),
-			 "P%llu L%llu D%llu",
-			 data_vio->allocation.pbn,
-			 data_vio->logical.lbn,
+			 sizeof(vio_block_number_dump_buffer), "P%llu L%llu D%llu",
+			 data_vio->allocation.pbn, data_vio->logical.lbn,
 			 data_vio->duplicate.pbn);
 	} else if (data_vio_has_allocation(data_vio)) {
 		snprintf(vio_block_number_dump_buffer,
-			 sizeof(vio_block_number_dump_buffer),
-			 "P%llu L%llu",
-			 data_vio->allocation.pbn,
-			 data_vio->logical.lbn);
+			 sizeof(vio_block_number_dump_buffer), "P%llu L%llu",
+			 data_vio->allocation.pbn, data_vio->logical.lbn);
 	} else {
 		snprintf(vio_block_number_dump_buffer,
-			 sizeof(vio_block_number_dump_buffer),
-			 "L%llu",
+			 sizeof(vio_block_number_dump_buffer), "L%llu",
 			 data_vio->logical.lbn);
 	}
 
 	if (data_vio->flush_generation != 0) {
 		snprintf(vio_flush_generation_buffer,
-			 sizeof(vio_flush_generation_buffer),
-			 " FG%llu",
+			 sizeof(vio_flush_generation_buffer), " FG%llu",
 			 data_vio->flush_generation);
 	} else {
 		vio_flush_generation_buffer[0] = 0;
@@ -273,8 +261,7 @@ void dump_data_vio(void *data)
 
 	encode_vio_dump_flags(data_vio, flags_dump_buffer);
 
-	uds_log_info("	vio %px %s%s %s %s%s",
-		     data_vio,
+	uds_log_info("	vio %px %s%s %s %s%s", data_vio,
 		     vio_block_number_dump_buffer,
 		     vio_flush_generation_buffer,
 		     get_data_vio_operation_name(data_vio),

--- a/drivers/md/dm-vdo/encodings.c
+++ b/drivers/md/dm-vdo/encodings.c
@@ -169,8 +169,7 @@ static int __must_check validate_version(struct version_number expected_version,
  *         VDO_UNSUPPORTED_VERSION if the versions or sizes don't match.
  */
 int vdo_validate_header(const struct header *expected_header,
-			const struct header *actual_header,
-			bool exact_size,
+			const struct header *actual_header, bool exact_size,
 			const char *name)
 {
 	int result;
@@ -178,12 +177,12 @@ int vdo_validate_header(const struct header *expected_header,
 	if (expected_header->id != actual_header->id) {
 		return uds_log_error_strerror(VDO_INCORRECT_COMPONENT,
 					      "%s ID mismatch, expected %d, got %d",
-					      name,
-					      expected_header->id,
+					      name, expected_header->id,
 					      actual_header->id);
 	}
 
-	result = validate_version(expected_header->version, actual_header->version, name);
+	result = validate_version(expected_header->version, actual_header->version,
+				  name);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -191,15 +190,15 @@ int vdo_validate_header(const struct header *expected_header,
 	    (exact_size && (expected_header->size < actual_header->size))) {
 		return uds_log_error_strerror(VDO_UNSUPPORTED_VERSION,
 					      "%s size mismatch, expected %zu, got %zu",
-					      name,
-					      expected_header->size,
+					      name, expected_header->size,
 					      actual_header->size);
 	}
 
 	return VDO_SUCCESS;
 }
 
-static void encode_version_number(u8 *buffer, size_t *offset, struct version_number version)
+static void encode_version_number(u8 *buffer, size_t *offset,
+				  struct version_number version)
 {
 	struct packed_version_number packed = vdo_pack_version_number(version);
 
@@ -215,7 +214,8 @@ void vdo_encode_header(u8 *buffer, size_t *offset, const struct header *header)
 	*offset += sizeof(packed);
 }
 
-static void decode_version_number(u8 *buffer, size_t *offset, struct version_number *version)
+static void decode_version_number(u8 *buffer, size_t *offset,
+				  struct version_number *version)
 {
 	struct packed_version_number packed;
 
@@ -241,8 +241,8 @@ void vdo_decode_header(u8 *buffer, size_t *offset, struct header *header)
  * @geometry: The structure to receive the decoded fields.
  * @version: The geometry block version to decode.
  */
-static void
-decode_volume_geometry(u8 *buffer, size_t *offset, struct volume_geometry *geometry, u32 version)
+static void decode_volume_geometry(u8 *buffer, size_t *offset,
+				   struct volume_geometry *geometry, u32 version)
 {
 	u32 unused, mem;
 	enum volume_region_id id;
@@ -304,10 +304,13 @@ int __must_check vdo_parse_geometry_block(u8 *block, struct volume_geometry *geo
 	offset += VDO_GEOMETRY_MAGIC_NUMBER_SIZE;
 
 	vdo_decode_header(block, &offset, &header);
-	if (header.version.major_version <= 4)
-		result = vdo_validate_header(&GEOMETRY_BLOCK_HEADER_4_0, &header, true, __func__);
-	else
-		result = vdo_validate_header(&GEOMETRY_BLOCK_HEADER_5_0, &header, true, __func__);
+	if (header.version.major_version <= 4) {
+		result = vdo_validate_header(&GEOMETRY_BLOCK_HEADER_4_0, &header,
+					     true, __func__);
+	} else {
+		result = vdo_validate_header(&GEOMETRY_BLOCK_HEADER_5_0, &header,
+					     true, __func__);
+	}
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -325,8 +328,7 @@ int __must_check vdo_parse_geometry_block(u8 *block, struct volume_geometry *geo
 	return ((checksum == saved_checksum) ? VDO_SUCCESS : VDO_CHECKSUM_MISMATCH);
 }
 
-struct block_map_page *vdo_format_block_map_page(void *buffer,
-						 nonce_t nonce,
+struct block_map_page *vdo_format_block_map_page(void *buffer, nonce_t nonce,
 						 physical_block_number_t pbn,
 						 bool initialized)
 {
@@ -340,16 +342,15 @@ struct block_map_page *vdo_format_block_map_page(void *buffer,
 	return page;
 }
 
-enum block_map_page_validity
-vdo_validate_block_map_page(struct block_map_page *page,
-			    nonce_t nonce,
-			    physical_block_number_t pbn)
+enum block_map_page_validity vdo_validate_block_map_page(struct block_map_page *page,
+							 nonce_t nonce,
+							 physical_block_number_t pbn)
 {
 	BUILD_BUG_ON(sizeof(struct block_map_page_header) != PAGE_HEADER_4_1_SIZE);
 
-	if (!vdo_are_same_version(BLOCK_MAP_4_1, vdo_unpack_version_number(page->version)) ||
-	    !page->header.initialized ||
-	    (nonce != __le64_to_cpu(page->header.nonce)))
+	if (!vdo_are_same_version(BLOCK_MAP_4_1,
+				  vdo_unpack_version_number(page->version)) ||
+	    !page->header.initialized || (nonce != __le64_to_cpu(page->header.nonce)))
 		return VDO_BLOCK_MAP_PAGE_INVALID;
 
 	if (pbn != vdo_get_block_map_page_pbn(page))
@@ -358,8 +359,8 @@ vdo_validate_block_map_page(struct block_map_page *page,
 	return VDO_BLOCK_MAP_PAGE_VALID;
 }
 
-static int
-decode_block_map_state_2_0(u8 *buffer, size_t *offset, struct block_map_state_2_0 *state)
+static int decode_block_map_state_2_0(u8 *buffer, size_t *offset,
+				      struct block_map_state_2_0 *state)
 {
 	size_t initial_offset;
 	block_count_t flat_page_count, root_count;
@@ -407,8 +408,8 @@ decode_block_map_state_2_0(u8 *buffer, size_t *offset, struct block_map_state_2_
 	return VDO_SUCCESS;
 }
 
-static void
-encode_block_map_state_2_0(u8 *buffer, size_t *offset, struct block_map_state_2_0 state)
+static void encode_block_map_state_2_0(u8 *buffer, size_t *offset,
+				       struct block_map_state_2_0 state)
 {
 	size_t initial_offset;
 
@@ -460,10 +461,8 @@ block_count_t vdo_compute_new_forest_pages(root_count_t root_count,
  *
  * Return: VDO_SUCCESS or an error code.
  */
-static void
-encode_recovery_journal_state_7_0(u8 *buffer,
-				  size_t *offset,
-				  struct recovery_journal_state_7_0 state)
+static void encode_recovery_journal_state_7_0(u8 *buffer, size_t *offset,
+					      struct recovery_journal_state_7_0 state)
 {
 	size_t initial_offset;
 
@@ -485,10 +484,8 @@ encode_recovery_journal_state_7_0(u8 *buffer,
  *
  * Return: VDO_SUCCESS or an error code.
  */
-static int __must_check
-decode_recovery_journal_state_7_0(u8 *buffer,
-				  size_t *offset,
-				  struct recovery_journal_state_7_0 *state)
+static int __must_check decode_recovery_journal_state_7_0(u8 *buffer, size_t *offset,
+							  struct recovery_journal_state_7_0 *state)
 {
 	struct header header;
 	int result;
@@ -497,7 +494,8 @@ decode_recovery_journal_state_7_0(u8 *buffer,
 	block_count_t logical_blocks_used, block_map_data_blocks;
 
 	vdo_decode_header(buffer, offset, &header);
-	result = vdo_validate_header(&VDO_RECOVERY_JOURNAL_HEADER_7_0, &header, true, __func__);
+	result = vdo_validate_header(&VDO_RECOVERY_JOURNAL_HEADER_7_0, &header, true,
+				     __func__);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -545,8 +543,8 @@ const char *vdo_get_journal_operation_name(enum journal_operation operation)
  *
  * Return: UDS_SUCCESS or an error.
  */
-static void
-encode_slab_depot_state_2_0(u8 *buffer, size_t *offset, struct slab_depot_state_2_0 state)
+static void encode_slab_depot_state_2_0(u8 *buffer, size_t *offset,
+					struct slab_depot_state_2_0 state)
 {
 	size_t initial_offset;
 
@@ -573,8 +571,8 @@ encode_slab_depot_state_2_0(u8 *buffer, size_t *offset, struct slab_depot_state_
  *
  * Return: UDS_SUCCESS or an error code.
  */
-static int
-decode_slab_depot_state_2_0(u8 *buffer, size_t *offset, struct slab_depot_state_2_0 *state)
+static int decode_slab_depot_state_2_0(u8 *buffer, size_t *offset,
+				       struct slab_depot_state_2_0 *state)
 {
 	struct header header;
 	int result;
@@ -585,7 +583,8 @@ decode_slab_depot_state_2_0(u8 *buffer, size_t *offset, struct slab_depot_state_
 	zone_count_t zone_count;
 
 	vdo_decode_header(buffer, offset, &header);
-	result = vdo_validate_header(&VDO_SLAB_DEPOT_HEADER_2_0, &header, true, __func__);
+	result = vdo_validate_header(&VDO_SLAB_DEPOT_HEADER_2_0, &header, true,
+				     __func__);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -644,8 +643,7 @@ decode_slab_depot_state_2_0(u8 *buffer, size_t *offset, struct slab_depot_state_
  * Return: VDO_SUCCESS or an error code.
  */
 int vdo_configure_slab_depot(const struct partition *partition,
-			     struct slab_config slab_config,
-			     zone_count_t zone_count,
+			     struct slab_config slab_config, zone_count_t zone_count,
 			     struct slab_depot_state_2_0 *state)
 {
 	block_count_t total_slab_blocks, total_data_blocks;
@@ -654,11 +652,9 @@ int vdo_configure_slab_depot(const struct partition *partition,
 	block_count_t slab_size = slab_config.slab_blocks;
 
 	uds_log_debug("slabDepot %s(block_count=%llu, first_block=%llu, slab_size=%llu, zone_count=%u)",
-		      __func__,
-		      (unsigned long long) partition->count,
+		      __func__, (unsigned long long) partition->count,
 		      (unsigned long long) partition->offset,
-		      (unsigned long long) slab_size,
-		      zone_count);
+		      (unsigned long long) slab_size, zone_count);
 
 	/* We do not allow runt slabs, so we waste up to a slab's worth. */
 	slab_count = (partition->count / slab_size);
@@ -681,8 +677,7 @@ int vdo_configure_slab_depot(const struct partition *partition,
 
 	uds_log_debug("slab_depot last_block=%llu, total_data_blocks=%llu, slab_count=%zu, left_over=%llu",
 		      (unsigned long long) last_block,
-		      (unsigned long long) total_data_blocks,
-		      slab_count,
+		      (unsigned long long) total_data_blocks, slab_count,
 		      (unsigned long long) (partition->count - (last_block - partition->offset)));
 
 	return VDO_SUCCESS;
@@ -696,8 +691,7 @@ int vdo_configure_slab_depot(const struct partition *partition,
  *
  * Return: VDO_SUCCESS or an error code.
  */
-int vdo_configure_slab(block_count_t slab_size,
-		       block_count_t slab_journal_blocks,
+int vdo_configure_slab(block_count_t slab_size, block_count_t slab_journal_blocks,
 		       struct slab_config *slab_config)
 {
 	block_count_t ref_blocks, meta_blocks, data_blocks;
@@ -772,9 +766,8 @@ int vdo_configure_slab(block_count_t slab_size,
  *
  * Return: The decoded entry.
  */
-struct slab_journal_entry
-vdo_decode_slab_journal_entry(struct packed_slab_journal_block *block,
-			      journal_entry_count_t entry_count)
+struct slab_journal_entry vdo_decode_slab_journal_entry(struct packed_slab_journal_block *block,
+							journal_entry_count_t entry_count)
 {
 	struct slab_journal_entry entry =
 		vdo_unpack_slab_journal_entry(&block->payload.entries[entry_count]);
@@ -796,10 +789,8 @@ vdo_decode_slab_journal_entry(struct packed_slab_journal_block *block,
  *
  * Return: VDO_SUCCESS or an error.
  */
-static int allocate_partition(struct layout *layout,
-			      u8 id,
-			      physical_block_number_t offset,
-			      block_count_t size)
+static int allocate_partition(struct layout *layout, u8 id,
+			      physical_block_number_t offset, block_count_t size)
 {
 	struct partition *partition;
 	int result;
@@ -828,11 +819,8 @@ static int allocate_partition(struct layout *layout,
  * Return: A success or error code, particularly VDO_NO_SPACE if there are fewer than size blocks
  *         remaining.
  */
-static int __must_check
-make_partition(struct layout *layout,
-	       enum partition_id id,
-	       block_count_t size,
-	       bool beginning)
+static int __must_check make_partition(struct layout *layout, enum partition_id id,
+				       block_count_t size, bool beginning)
 {
 	int result;
 	physical_block_number_t offset;
@@ -876,19 +864,17 @@ make_partition(struct layout *layout,
  *
  * Return: VDO_SUCCESS or an error.
  */
-int vdo_initialize_layout(block_count_t size,
-			  physical_block_number_t offset,
-			  block_count_t block_map_blocks,
-			  block_count_t journal_blocks,
-			  block_count_t summary_blocks,
-			  struct layout *layout)
+int vdo_initialize_layout(block_count_t size, physical_block_number_t offset,
+			  block_count_t block_map_blocks, block_count_t journal_blocks,
+			  block_count_t summary_blocks, struct layout *layout)
 {
 	int result;
 	block_count_t necessary_size =
 		(offset + block_map_blocks + journal_blocks + summary_blocks);
 
 	if (necessary_size > size)
-		return uds_log_error_strerror(VDO_NO_SPACE, "Not enough space to make a VDO");
+		return uds_log_error_strerror(VDO_NO_SPACE,
+					      "Not enough space to make a VDO");
 
 	*layout = (struct layout) {
 		.start = offset,
@@ -905,13 +891,15 @@ int vdo_initialize_layout(block_count_t size,
 		return result;
 	}
 
-	result = make_partition(layout, VDO_SLAB_SUMMARY_PARTITION, summary_blocks, false);
+	result = make_partition(layout, VDO_SLAB_SUMMARY_PARTITION, summary_blocks,
+				false);
 	if (result != VDO_SUCCESS) {
 		vdo_uninitialize_layout(layout);
 		return result;
 	}
 
-	result = make_partition(layout, VDO_RECOVERY_JOURNAL_PARTITION, journal_blocks, false);
+	result = make_partition(layout, VDO_RECOVERY_JOURNAL_PARTITION, journal_blocks,
+				false);
 	if (result != VDO_SUCCESS) {
 		vdo_uninitialize_layout(layout);
 		return result;
@@ -950,8 +938,7 @@ void vdo_uninitialize_layout(struct layout *layout)
  *
  * Return: VDO_SUCCESS or an error.
  */
-int vdo_get_partition(struct layout *layout,
-		      enum partition_id id,
+int vdo_get_partition(struct layout *layout, enum partition_id id,
 		      struct partition **partition_ptr)
 {
 	struct partition *partition;
@@ -1016,12 +1003,8 @@ static void encode_layout(u8 *buffer, size_t *offset, const struct layout *layou
 			"encoded size of a layout must match header size");
 }
 
-static int
-decode_layout(u8 *buffer,
-	      size_t *offset,
-	      physical_block_number_t start,
-	      block_count_t size,
-	      struct layout *layout)
+static int decode_layout(u8 *buffer, size_t *offset, physical_block_number_t start,
+			 block_count_t size, struct layout *layout)
 {
 	struct header header;
 	struct layout_3_0 layout_header;
@@ -1095,7 +1078,8 @@ decode_layout(u8 *buffer,
 
 	if (start != size) {
 		vdo_uninitialize_layout(layout);
-		return uds_log_error_strerror(UDS_BAD_STATE, "partitions do not cover the layout");
+		return uds_log_error_strerror(UDS_BAD_STATE,
+					      "partitions do not cover the layout");
 	}
 
 	return VDO_SUCCESS;
@@ -1135,7 +1119,8 @@ static struct packed_vdo_component_41_0 pack_vdo_component(const struct vdo_comp
 	};
 }
 
-static void encode_vdo_component(u8 *buffer, size_t *offset, struct vdo_component component)
+static void encode_vdo_component(u8 *buffer, size_t *offset,
+				 struct vdo_component component)
 {
 	struct packed_vdo_component_41_0 packed;
 
@@ -1169,8 +1154,7 @@ static struct vdo_config unpack_vdo_config(struct packed_vdo_config config)
  *
  * Return: The native in-memory representation of the component.
  */
-static struct vdo_component
-unpack_vdo_component_41_0(struct packed_vdo_component_41_0 component)
+static struct vdo_component unpack_vdo_component_41_0(struct packed_vdo_component_41_0 component)
 {
 	return (struct vdo_component) {
 		.state = __le32_to_cpu(component.state),
@@ -1193,7 +1177,8 @@ static int decode_vdo_component(u8 *buffer, size_t *offset, struct vdo_component
 	int result;
 
 	decode_version_number(buffer, offset, &version);
-	result = validate_version(version, VDO_COMPONENT_DATA_41_0, "VDO component data");
+	result = validate_version(version, VDO_COMPONENT_DATA_41_0,
+				  "VDO component data");
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -1223,7 +1208,8 @@ int vdo_validate_config(const struct vdo_config *config,
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = ASSERT(is_power_of_2(config->slab_size), "slab size must be a power of two");
+	result = ASSERT(is_power_of_2(config->slab_size),
+			"slab size must be a power of two");
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -1243,7 +1229,8 @@ int vdo_validate_config(const struct vdo_config *config,
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = vdo_configure_slab(config->slab_size, config->slab_journal_blocks, &slab_config);
+	result = vdo_configure_slab(config->slab_size, config->slab_journal_blocks,
+				    &slab_config);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -1271,7 +1258,8 @@ int vdo_validate_config(const struct vdo_config *config,
 	}
 
 	if (logical_block_count > 0) {
-		result = ASSERT((config->logical_blocks > 0), "logical blocks unspecified");
+		result = ASSERT((config->logical_blocks > 0),
+				"logical blocks unspecified");
 		if (result != UDS_SUCCESS)
 			return result;
 
@@ -1288,7 +1276,8 @@ int vdo_validate_config(const struct vdo_config *config,
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = ASSERT(config->recovery_journal_size > 0, "recovery journal size unspecified");
+	result = ASSERT(config->recovery_journal_size > 0,
+			"recovery journal size unspecified");
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -1322,8 +1311,7 @@ void vdo_destroy_component_states(struct vdo_component_states *states)
  *
  * Return: VDO_SUCCESS or an error.
  */
-static int __must_check decode_components(u8 *buffer,
-					  size_t *offset,
+static int __must_check decode_components(u8 *buffer, size_t *offset,
 					  struct volume_geometry *geometry,
 					  struct vdo_component_states *states)
 {
@@ -1331,15 +1319,13 @@ static int __must_check decode_components(u8 *buffer,
 
 	decode_vdo_component(buffer, offset, &states->vdo);
 
-	result = decode_layout(buffer,
-			       offset,
-			       vdo_get_data_region_start(*geometry) + 1,
-			       states->vdo.config.physical_blocks,
-			       &states->layout);
+	result = decode_layout(buffer, offset, vdo_get_data_region_start(*geometry) + 1,
+			       states->vdo.config.physical_blocks, &states->layout);
 	if (result != VDO_SUCCESS)
 		return result;
 
-	result = decode_recovery_journal_state_7_0(buffer, offset, &states->recovery_journal);
+	result = decode_recovery_journal_state_7_0(buffer, offset,
+						   &states->recovery_journal);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -1364,8 +1350,7 @@ static int __must_check decode_components(u8 *buffer,
  *
  * Return: VDO_SUCCESS or an error.
  */
-int vdo_decode_component_states(u8 *buffer,
-				struct volume_geometry *geometry,
+int vdo_decode_component_states(u8 *buffer, struct volume_geometry *geometry,
 				struct vdo_component_states *states)
 {
 	int result;
@@ -1376,7 +1361,8 @@ int vdo_decode_component_states(u8 *buffer,
 
 	/* Check the VDO volume version */
 	decode_version_number(buffer, &offset, &states->volume_version);
-	result = validate_version(VDO_VOLUME_VERSION_67_0, states->volume_version, "volume");
+	result = validate_version(VDO_VOLUME_VERSION_67_0, states->volume_version,
+				  "volume");
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -1398,8 +1384,7 @@ int vdo_decode_component_states(u8 *buffer,
  * Return: VDO_SUCCESS or an error if the configuration is invalid.
  */
 int vdo_validate_component_states(struct vdo_component_states *states,
-				  nonce_t geometry_nonce,
-				  block_count_t physical_size,
+				  nonce_t geometry_nonce, block_count_t physical_size,
 				  block_count_t logical_size)
 {
 	if (geometry_nonce != states->vdo.nonce) {
@@ -1415,8 +1400,8 @@ int vdo_validate_component_states(struct vdo_component_states *states,
 /**
  * vdo_encode_component_states() - Encode the state of all vdo components in the super block.
  */
-static void
-vdo_encode_component_states(u8 *buffer, size_t *offset, const struct vdo_component_states *states)
+static void vdo_encode_component_states(u8 *buffer, size_t *offset,
+					const struct vdo_component_states *states)
 {
 	/* This is for backwards compatibility. */
 	encode_u32_le(buffer, offset, states->unused);
@@ -1451,7 +1436,8 @@ void vdo_encode_super_block(u8 *buffer, struct vdo_component_states *states)
 	 * Even though the buffer is a full block, to avoid the potential corruption from a torn
 	 * write, the entire encoding must fit in the first sector.
 	 */
-	ASSERT_LOG_ONLY(offset <= VDO_SECTOR_SIZE, "entire superblock must fit in one sector");
+	ASSERT_LOG_ONLY(offset <= VDO_SECTOR_SIZE,
+			"entire superblock must fit in one sector");
 }
 
 /**

--- a/drivers/md/dm-vdo/encodings.c
+++ b/drivers/md/dm-vdo/encodings.c
@@ -330,7 +330,7 @@ struct block_map_page *vdo_format_block_map_page(void *buffer,
 						 physical_block_number_t pbn,
 						 bool initialized)
 {
-	struct block_map_page *page = (struct block_map_page *) buffer;
+	struct block_map_page *page = buffer;
 
 	memset(buffer, 0, VDO_BLOCK_SIZE);
 	page->version = vdo_pack_version_number(BLOCK_MAP_4_1);
@@ -781,7 +781,7 @@ vdo_decode_slab_journal_entry(struct packed_slab_journal_block *block,
 
 	if (block->header.has_block_map_increments &&
 	    ((block->payload.full_entries.entry_types[entry_count / 8] &
-	      ((u8)1 << (entry_count % 8))) != 0))
+	      ((u8) 1 << (entry_count % 8))) != 0))
 		entry.operation = VDO_JOURNAL_BLOCK_MAP_REMAPPING;
 
 	return entry;

--- a/drivers/md/dm-vdo/encodings.c
+++ b/drivers/md/dm-vdo/encodings.c
@@ -141,7 +141,7 @@ static int __must_check validate_version(struct version_number expected_version,
 					 struct version_number actual_version,
 					 const char *component_name)
 {
-	if (!vdo_are_same_version(expected_version, actual_version))
+	if (!vdo_are_same_version(expected_version, actual_version)) {
 		return uds_log_error_strerror(VDO_UNSUPPORTED_VERSION,
 					      "%s version mismatch, expected %d.%d, got %d.%d",
 					      component_name,
@@ -149,6 +149,8 @@ static int __must_check validate_version(struct version_number expected_version,
 					      expected_version.minor_version,
 					      actual_version.major_version,
 					      actual_version.minor_version);
+	}
+
 	return VDO_SUCCESS;
 }
 
@@ -173,24 +175,26 @@ int vdo_validate_header(const struct header *expected_header,
 {
 	int result;
 
-	if (expected_header->id != actual_header->id)
+	if (expected_header->id != actual_header->id) {
 		return uds_log_error_strerror(VDO_INCORRECT_COMPONENT,
 					      "%s ID mismatch, expected %d, got %d",
 					      name,
 					      expected_header->id,
 					      actual_header->id);
+	}
 
 	result = validate_version(expected_header->version, actual_header->version, name);
 	if (result != VDO_SUCCESS)
 		return result;
 
 	if ((expected_header->size > actual_header->size) ||
-	    (exact_size && (expected_header->size < actual_header->size)))
+	    (exact_size && (expected_header->size < actual_header->size))) {
 		return uds_log_error_strerror(VDO_UNSUPPORTED_VERSION,
 					      "%s size mismatch, expected %zu, got %zu",
 					      name,
 					      expected_header->size,
 					      actual_header->size);
+	}
 
 	return VDO_SUCCESS;
 }
@@ -1055,9 +1059,10 @@ decode_layout(u8 *buffer,
 	layout->last_free = layout_header.last_free;
 	layout->num_partitions = layout_header.partition_count;
 
-	if (layout->num_partitions > VDO_PARTITION_COUNT)
+	if (layout->num_partitions > VDO_PARTITION_COUNT) {
 		return uds_log_error_strerror(VDO_UNKNOWN_PARTITION,
 					      "layout has extra partitions");
+	}
 
 	for (i = 0; i < layout->num_partitions; i++) {
 		u8 id;
@@ -1397,11 +1402,12 @@ int vdo_validate_component_states(struct vdo_component_states *states,
 				  block_count_t physical_size,
 				  block_count_t logical_size)
 {
-	if (geometry_nonce != states->vdo.nonce)
+	if (geometry_nonce != states->vdo.nonce) {
 		return uds_log_error_strerror(VDO_BAD_NONCE,
 					      "Geometry nonce %llu does not match superblock nonce %llu",
 					      (unsigned long long) geometry_nonce,
 					      (unsigned long long) states->vdo.nonce);
+	}
 
 	return vdo_validate_config(&states->vdo.config, physical_size, logical_size);
 }
@@ -1464,7 +1470,7 @@ int vdo_decode_super_block(u8 *buffer)
 	if (result != VDO_SUCCESS)
 		return result;
 
-	if (header.size > VDO_COMPONENT_DATA_SIZE + sizeof(u32))
+	if (header.size > VDO_COMPONENT_DATA_SIZE + sizeof(u32)) {
 		/*
 		 * We can't check release version or checksum until we know the content size, so we
 		 * have to assume a version mismatch on unexpected values.
@@ -1472,6 +1478,7 @@ int vdo_decode_super_block(u8 *buffer)
 		return uds_log_error_strerror(VDO_UNSUPPORTED_VERSION,
 					      "super block contents too large: %zu",
 					      header.size);
+	}
 
 	/* Skip past the component data for now, to verify the checksum. */
 	offset += VDO_COMPONENT_DATA_SIZE;

--- a/drivers/md/dm-vdo/encodings.h
+++ b/drivers/md/dm-vdo/encodings.h
@@ -701,8 +701,8 @@ struct vdo_component_states {
  *
  * Return: true if the two versions are the same.
  */
-static inline bool
-vdo_are_same_version(struct version_number version_a, struct version_number version_b)
+static inline bool vdo_are_same_version(struct version_number version_a,
+					struct version_number version_b)
 {
 	return ((version_a.major_version == version_b.major_version) &&
 		(version_a.minor_version == version_b.minor_version));
@@ -727,8 +727,7 @@ static inline bool vdo_is_upgradable_version(struct version_number expected_vers
 }
 
 int __must_check vdo_validate_header(const struct header *expected_header,
-				     const struct header *actual_header,
-				     bool exact_size,
+				     const struct header *actual_header, bool exact_size,
 				     const char *component_name);
 
 void vdo_encode_header(u8 *buffer, size_t *offset, const struct header *header);
@@ -830,7 +829,8 @@ vdo_get_index_region_size(struct volume_geometry geometry)
 		vdo_get_index_region_start(geometry);
 }
 
-int __must_check vdo_parse_geometry_block(unsigned char *block, struct volume_geometry *geometry);
+int __must_check vdo_parse_geometry_block(unsigned char *block,
+					  struct volume_geometry *geometry);
 
 static inline bool vdo_is_state_compressed(const enum block_mapping_state mapping_state)
 {
@@ -877,26 +877,23 @@ vdo_get_block_map_page_pbn(const struct block_map_page *page)
 	return __le64_to_cpu(page->header.pbn);
 }
 
-struct block_map_page *vdo_format_block_map_page(void *buffer,
-						 nonce_t nonce,
+struct block_map_page *vdo_format_block_map_page(void *buffer, nonce_t nonce,
 						 physical_block_number_t pbn,
 						 bool initialized);
 
-enum block_map_page_validity __must_check
-vdo_validate_block_map_page(struct block_map_page *page,
-			    nonce_t nonce,
-			    physical_block_number_t pbn);
+enum block_map_page_validity __must_check vdo_validate_block_map_page(struct block_map_page *page,
+								      nonce_t nonce,
+								      physical_block_number_t pbn);
 
 static inline page_count_t vdo_compute_block_map_page_count(block_count_t entries)
 {
 	return DIV_ROUND_UP(entries, VDO_BLOCK_MAP_ENTRIES_PER_PAGE);
 }
 
-block_count_t __must_check
-vdo_compute_new_forest_pages(root_count_t root_count,
-			     struct boundary *old_sizes,
-			     block_count_t entries,
-			     struct boundary *new_sizes);
+block_count_t __must_check vdo_compute_new_forest_pages(root_count_t root_count,
+							struct boundary *old_sizes,
+							block_count_t entries,
+							struct boundary *new_sizes);
 
 /**
  * vdo_pack_recovery_journal_entry() - Return the packed, on-disk representation of a recovery
@@ -914,7 +911,8 @@ vdo_pack_recovery_journal_entry(const struct recovery_journal_entry *entry)
 		.slot_high = (entry->slot.slot >> 6) & 0x0F,
 		.pbn_high_nibble = (entry->slot.pbn >> 32) & 0x0F,
 		.pbn_low_word = __cpu_to_le32(entry->slot.pbn & UINT_MAX),
-		.mapping = vdo_pack_block_map_entry(entry->mapping.pbn, entry->mapping.state),
+		.mapping = vdo_pack_block_map_entry(entry->mapping.pbn,
+						    entry->mapping.state),
 		.unmapping = vdo_pack_block_map_entry(entry->unmapping.pbn,
 						      entry->unmapping.state),
 	};
@@ -1065,10 +1063,9 @@ vdo_unpack_recovery_block_header(const struct packed_journal_header *packed)
  *
  * Return: The number of slabs.
  */
-static inline slab_count_t
-vdo_compute_slab_count(physical_block_number_t first_block,
-		       physical_block_number_t last_block,
-		       unsigned int slab_size_shift)
+static inline slab_count_t vdo_compute_slab_count(physical_block_number_t first_block,
+						  physical_block_number_t last_block,
+						  unsigned int slab_size_shift)
 {
 	return (slab_count_t) ((last_block - first_block) >> slab_size_shift);
 }
@@ -1090,8 +1087,7 @@ int __must_check vdo_configure_slab(block_count_t slab_size,
  *
  * Return: The number of blocks required to save reference counts with the given block count.
  */
-static inline block_count_t
-vdo_get_saved_reference_count_size(block_count_t block_count)
+static inline block_count_t vdo_get_saved_reference_count_size(block_count_t block_count)
 {
 	return DIV_ROUND_UP(block_count, COUNTS_PER_BLOCK);
 }
@@ -1114,8 +1110,8 @@ vdo_get_slab_journal_start_block(const struct slab_config *slab_config,
  * @point: The journal point to adjust.
  * @entries_per_block: The number of entries in one full block.
  */
-static inline void
-vdo_advance_journal_point(struct journal_point *point, journal_entry_count_t entries_per_block)
+static inline void vdo_advance_journal_point(struct journal_point *point,
+					     journal_entry_count_t entries_per_block)
 {
 	point->entry_count++;
 	if (point->entry_count == entries_per_block) {
@@ -1131,8 +1127,8 @@ vdo_advance_journal_point(struct journal_point *point, journal_entry_count_t ent
  *
  * Return: true if the first point precedes the second point.
  */
-static inline bool
-vdo_before_journal_point(const struct journal_point *first, const struct journal_point *second)
+static inline bool vdo_before_journal_point(const struct journal_point *first,
+					    const struct journal_point *second)
 {
 	return ((first->sequence_number < second->sequence_number) ||
 		((first->sequence_number == second->sequence_number) &&
@@ -1145,8 +1141,8 @@ vdo_before_journal_point(const struct journal_point *first, const struct journal
  * @unpacked: The unpacked input point.
  * @packed: The packed output point.
  */
-static inline void
-vdo_pack_journal_point(const struct journal_point *unpacked, struct packed_journal_point *packed)
+static inline void vdo_pack_journal_point(const struct journal_point *unpacked,
+					  struct packed_journal_point *packed)
 {
 	packed->encoded_point =
 		__cpu_to_le64((unpacked->sequence_number << 16) | unpacked->entry_count);
@@ -1158,8 +1154,8 @@ vdo_pack_journal_point(const struct journal_point *unpacked, struct packed_journ
  * @packed: The packed input point.
  * @unpacked: The unpacked output point.
  */
-static inline void
-vdo_unpack_journal_point(const struct packed_journal_point *packed, struct journal_point *unpacked)
+static inline void vdo_unpack_journal_point(const struct packed_journal_point *packed,
+					    struct journal_point *unpacked)
 {
 	u64 native = __le64_to_cpu(packed->encoded_point);
 
@@ -1215,8 +1211,7 @@ vdo_unpack_slab_journal_block_header(const struct packed_slab_journal_block_head
  * @is_increment: The increment flag.
  */
 static inline void vdo_pack_slab_journal_entry(packed_slab_journal_entry *packed,
-					       slab_block_number sbn,
-					       bool is_increment)
+					       slab_block_number sbn, bool is_increment)
 {
 	packed->offset_low8 = (sbn & 0x0000FF);
 	packed->offset_mid8 = (sbn & 0x00FF00) >> 8;
@@ -1271,12 +1266,11 @@ int __must_check vdo_initialize_layout(block_count_t size,
 
 void vdo_uninitialize_layout(struct layout *layout);
 
-int __must_check vdo_get_partition(struct layout *layout,
-				   enum partition_id id,
+int __must_check vdo_get_partition(struct layout *layout, enum partition_id id,
 				   struct partition **partition_ptr);
 
-struct partition * __must_check
-vdo_get_known_partition(struct layout *layout, enum partition_id id);
+struct partition * __must_check vdo_get_known_partition(struct layout *layout,
+							enum partition_id id);
 
 int vdo_validate_config(const struct vdo_config *config,
 			block_count_t physical_block_count,
@@ -1284,16 +1278,14 @@ int vdo_validate_config(const struct vdo_config *config,
 
 void vdo_destroy_component_states(struct vdo_component_states *states);
 
-int __must_check
-vdo_decode_component_states(u8 *buffer,
-			    struct volume_geometry *geometry,
-			    struct vdo_component_states *states);
+int __must_check vdo_decode_component_states(u8 *buffer,
+					     struct volume_geometry *geometry,
+					     struct vdo_component_states *states);
 
-int __must_check
-vdo_validate_component_states(struct vdo_component_states *states,
-			      nonce_t geometry_nonce,
-			      block_count_t physical_size,
-			      block_count_t logical_size);
+int __must_check vdo_validate_component_states(struct vdo_component_states *states,
+					       nonce_t geometry_nonce,
+					       block_count_t physical_size,
+					       block_count_t logical_size);
 
 void vdo_encode_super_block(u8 *buffer, struct vdo_component_states *states);
 int __must_check vdo_decode_super_block(u8 *buffer);

--- a/drivers/md/dm-vdo/errors.c
+++ b/drivers/md/dm-vdo/errors.c
@@ -159,18 +159,19 @@ const char *uds_string_error(int errnum, char *buf, size_t buflen)
 
 	block_name = get_error_info(errnum, &info);
 	if (block_name != NULL) {
-		if (info != NULL)
+		if (info != NULL) {
 			buffer = uds_append_to_buffer(buffer,
 						      buf_end,
 						      "%s: %s",
 						      block_name,
 						      info->message);
-		else
+		} else {
 			buffer = uds_append_to_buffer(buffer,
 						      buf_end,
 						      "Unknown %s %d",
 						      block_name,
 						      errnum);
+		}
 	} else if (info != NULL) {
 		buffer = uds_append_to_buffer(buffer, buf_end, "%s", info->message);
 	} else {
@@ -181,6 +182,7 @@ const char *uds_string_error(int errnum, char *buf, size_t buflen)
 		else
 			buffer += strlen(tmp);
 	}
+
 	return buf;
 }
 
@@ -197,14 +199,15 @@ const char *uds_string_error_name(int errnum, char *buf, size_t buflen)
 
 	block_name = get_error_info(errnum, &info);
 	if (block_name != NULL) {
-		if (info != NULL)
+		if (info != NULL) {
 			buffer = uds_append_to_buffer(buffer, buf_end, "%s", info->name);
-		else
+		} else {
 			buffer = uds_append_to_buffer(buffer,
 						      buf_end,
 						      "%s %d",
 						      block_name,
 						      errnum);
+		}
 	} else if (info != NULL) {
 		buffer = uds_append_to_buffer(buffer, buf_end, "%s", info->name);
 	} else {
@@ -216,6 +219,7 @@ const char *uds_string_error_name(int errnum, char *buf, size_t buflen)
 		else
 			buffer += strlen(tmp);
 	}
+
 	return buf;
 }
 
@@ -233,9 +237,10 @@ int uds_map_to_system_error(int error)
 	if (likely(error <= 0))
 		return error;
 
-	if (error < 1024)
+	if (error < 1024) {
 		/* This is probably an errno from userspace. */
 		return -error;
+	}
 
 	/* Internal UDS errors */
 	switch (error) {
@@ -296,9 +301,10 @@ int uds_register_error_block(const char *block_name,
 	if (result != UDS_SUCCESS)
 		return result;
 
-	if (registered_errors.count == registered_errors.allocated)
+	if (registered_errors.count == registered_errors.allocated) {
 		/* This should never happen. */
 		return UDS_OVERFLOW;
+	}
 
 	for (block = registered_errors.blocks;
 	     block < registered_errors.blocks + registered_errors.count;

--- a/drivers/md/dm-vdo/errors.c
+++ b/drivers/md/dm-vdo/errors.c
@@ -160,17 +160,11 @@ const char *uds_string_error(int errnum, char *buf, size_t buflen)
 	block_name = get_error_info(errnum, &info);
 	if (block_name != NULL) {
 		if (info != NULL) {
-			buffer = uds_append_to_buffer(buffer,
-						      buf_end,
-						      "%s: %s",
-						      block_name,
-						      info->message);
+			buffer = uds_append_to_buffer(buffer, buf_end, "%s: %s",
+						      block_name, info->message);
 		} else {
-			buffer = uds_append_to_buffer(buffer,
-						      buf_end,
-						      "Unknown %s %d",
-						      block_name,
-						      errnum);
+			buffer = uds_append_to_buffer(buffer, buf_end, "Unknown %s %d",
+						      block_name, errnum);
 		}
 	} else if (info != NULL) {
 		buffer = uds_append_to_buffer(buffer, buf_end, "%s", info->message);
@@ -202,11 +196,8 @@ const char *uds_string_error_name(int errnum, char *buf, size_t buflen)
 		if (info != NULL) {
 			buffer = uds_append_to_buffer(buffer, buf_end, "%s", info->name);
 		} else {
-			buffer = uds_append_to_buffer(buffer,
-						      buf_end,
-						      "%s %d",
-						      block_name,
-						      errnum);
+			buffer = uds_append_to_buffer(buffer, buf_end, "%s %d",
+						      block_name, errnum);
 		}
 	} else if (info != NULL) {
 		buffer = uds_append_to_buffer(buffer, buf_end, "%s", info->name);
@@ -264,10 +255,11 @@ int uds_map_to_system_error(int error)
 	default:
 		/* Translate an unexpected error into something generic. */
 		uds_log_info("%s: mapping status code %d (%s: %s) to -EIO",
-			     __func__,
-			     error,
-			     uds_string_error_name(error, error_name, sizeof(error_name)),
-			     uds_string_error(error, error_message, sizeof(error_message)));
+			     __func__, error,
+			     uds_string_error_name(error, error_name,
+						   sizeof(error_name)),
+			     uds_string_error(error, error_message,
+					      sizeof(error_message)));
 		return -EIO;
 	}
 }
@@ -281,10 +273,8 @@ int uds_map_to_system_error(int error)
  * @infos: a pointer to the error info array for the block
  * @info_size: the size of the error info array
  */
-int uds_register_error_block(const char *block_name,
-			     int first_error,
-			     int next_free_error,
-			     const struct error_info *infos,
+int uds_register_error_block(const char *block_name, int first_error,
+			     int next_free_error, const struct error_info *infos,
 			     size_t info_size)
 {
 	int result;

--- a/drivers/md/dm-vdo/errors.c
+++ b/drivers/md/dm-vdo/errors.c
@@ -111,7 +111,7 @@ static const char *get_error_info(int errnum, const struct error_info **info_ptr
 
 	for (block = registered_errors.blocks;
 	     block < registered_errors.blocks + registered_errors.count;
-	     ++block) {
+	     block++) {
 		if ((errnum >= block->base) && (errnum < block->last)) {
 			*info_ptr = block->infos + (errnum - block->base);
 			return block->name;
@@ -302,7 +302,7 @@ int uds_register_error_block(const char *block_name,
 
 	for (block = registered_errors.blocks;
 	     block < registered_errors.blocks + registered_errors.count;
-	     ++block) {
+	     block++) {
 		if (strcmp(block_name, block->name) == 0)
 			return UDS_DUPLICATE_NAME;
 

--- a/drivers/md/dm-vdo/errors.h
+++ b/drivers/md/dm-vdo/errors.h
@@ -74,10 +74,8 @@ const char *uds_string_error_name(int errnum, char *buf, size_t buflen);
 
 int uds_map_to_system_error(int error);
 
-int uds_register_error_block(const char *block_name,
-			     int first_error,
-			     int last_reserved_error,
-			     const struct error_info *infos,
+int uds_register_error_block(const char *block_name, int first_error,
+			     int last_reserved_error, const struct error_info *infos,
 			     size_t info_size);
 
 #endif /* UDS_ERRORS_H */

--- a/drivers/md/dm-vdo/flush.c
+++ b/drivers/md/dm-vdo/flush.c
@@ -60,8 +60,7 @@ struct flusher {
 static inline void assert_on_flusher_thread(struct flusher *flusher, const char *caller)
 {
 	ASSERT_LOG_ONLY((vdo_get_callback_thread_id() == flusher->thread_id),
-			"%s() called from flusher thread",
-			caller);
+			"%s() called from flusher thread", caller);
 }
 
 /**
@@ -115,7 +114,8 @@ static void *allocate_flush(gfp_t gfp_mask, void *pool_data)
 	if (flush != NULL) {
 		struct flusher *flusher = pool_data;
 
-		vdo_initialize_completion(&flush->completion, flusher->vdo, VDO_FLUSH_COMPLETION);
+		vdo_initialize_completion(&flush->completion, flusher->vdo,
+					  VDO_FLUSH_COMPLETION);
 	}
 
 	return flush;
@@ -147,7 +147,8 @@ int vdo_make_flusher(struct vdo *vdo)
 
 	spin_lock_init(&vdo->flusher->lock);
 	bio_list_init(&vdo->flusher->waiting_flush_bios);
-	vdo->flusher->flush_pool = mempool_create(1, allocate_flush, free_flush, vdo->flusher);
+	vdo->flusher->flush_pool = mempool_create(1, allocate_flush, free_flush,
+						  vdo->flusher);
 	return ((vdo->flusher->flush_pool == NULL) ? -ENOMEM : VDO_SUCCESS);
 }
 
@@ -213,7 +214,8 @@ static void flush_packer_callback(struct vdo_completion *completion)
 	struct flusher *flusher = as_flusher(completion);
 
 	vdo_increment_packer_flush_generation(flusher->vdo->packer);
-	vdo_launch_completion_callback(completion, finish_notification, flusher->thread_id);
+	vdo_launch_completion_callback(completion, finish_notification,
+				       flusher->thread_id);
 }
 
 /**
@@ -230,15 +232,13 @@ static void increment_generation(struct vdo_completion *completion)
 
 	vdo_increment_logical_zone_flush_generation(zone, flusher->notify_generation);
 	if (zone->next == NULL) {
-		vdo_launch_completion_callback(completion,
-					       flush_packer_callback,
+		vdo_launch_completion_callback(completion, flush_packer_callback,
 					       flusher->thread_id);
 		return;
 	}
 
 	flusher->logical_zone_to_notify = zone->next;
-	vdo_launch_completion_callback(completion,
-				       increment_generation,
+	vdo_launch_completion_callback(completion, increment_generation,
 				       flusher->logical_zone_to_notify->thread_id);
 }
 
@@ -253,8 +253,7 @@ static void notify_flush(struct flusher *flusher)
 	flusher->notify_generation = flush->flush_generation;
 	flusher->logical_zone_to_notify = &flusher->vdo->logical_zones->zones[0];
 	flusher->completion.requeue = true;
-	vdo_launch_completion_callback(&flusher->completion,
-				       increment_generation,
+	vdo_launch_completion_callback(&flusher->completion, increment_generation,
 				       flusher->logical_zone_to_notify->thread_id);
 }
 
@@ -272,7 +271,8 @@ static void flush_vdo(struct vdo_completion *completion)
 	int result;
 
 	assert_on_flusher_thread(flusher, __func__);
-	result = ASSERT(vdo_is_state_normal(&flusher->state), "flusher is in normal operation");
+	result = ASSERT(vdo_is_state_normal(&flusher->state),
+			"flusher is in normal operation");
 	if (result != VDO_SUCCESS) {
 		vdo_enter_read_only_mode(flusher->vdo, result);
 		vdo_complete_flush(flush);
@@ -318,7 +318,8 @@ void vdo_complete_flushes(struct flusher *flusher)
 
 	for (zone = &flusher->vdo->logical_zones->zones[0]; zone != NULL; zone = zone->next)
 		oldest_active_generation =
-			min(oldest_active_generation, READ_ONCE(zone->oldest_active_generation));
+			min(oldest_active_generation,
+			    READ_ONCE(zone->oldest_active_generation));
 
 	while (vdo_has_waiters(&flusher->pending_flushes)) {
 		struct vdo_flush *flush =
@@ -374,11 +375,8 @@ static void launch_flush(struct vdo_flush *flush)
 {
 	struct vdo_completion *completion = &flush->completion;
 
-	vdo_prepare_completion(completion,
-			       flush_vdo,
-			       flush_vdo,
-			       completion->vdo->thread_config.packer_thread,
-			       NULL);
+	vdo_prepare_completion(completion, flush_vdo, flush_vdo,
+			       completion->vdo->thread_config.packer_thread, NULL);
 	vdo_enqueue_completion(completion, VDO_DEFAULT_Q_FLUSH_PRIORITY);
 }
 
@@ -400,7 +398,8 @@ void vdo_launch_flush(struct vdo *vdo, struct bio *bio)
 	struct flusher *flusher = vdo->flusher;
 	const struct admin_state_code *code = vdo_get_admin_state_code(&flusher->state);
 
-	ASSERT_LOG_ONLY(!code->quiescent, "Flushing not allowed in state %s", code->name);
+	ASSERT_LOG_ONLY(!code->quiescent, "Flushing not allowed in state %s",
+			code->name);
 
 	spin_lock(&flusher->lock);
 
@@ -516,11 +515,9 @@ static void vdo_complete_flush(struct vdo_flush *flush)
 {
 	struct vdo_completion *completion = &flush->completion;
 
-	vdo_prepare_completion(completion,
+	vdo_prepare_completion(completion, vdo_complete_flush_callback,
 			       vdo_complete_flush_callback,
-			       vdo_complete_flush_callback,
-			       select_bio_queue(completion->vdo->flusher),
-			       NULL);
+			       select_bio_queue(completion->vdo->flusher), NULL);
 	vdo_enqueue_completion(completion, BIO_Q_FLUSH_PRIORITY);
 }
 
@@ -545,9 +542,7 @@ static void initiate_drain(struct admin_state *state)
 void vdo_drain_flusher(struct flusher *flusher, struct vdo_completion *completion)
 {
 	assert_on_flusher_thread(flusher, __func__);
-	vdo_start_draining(&flusher->state,
-			   VDO_ADMIN_STATE_SUSPENDING,
-			   completion,
+	vdo_start_draining(&flusher->state, VDO_ADMIN_STATE_SUSPENDING, completion,
 			   initiate_drain);
 }
 

--- a/drivers/md/dm-vdo/flush.c
+++ b/drivers/md/dm-vdo/flush.c
@@ -524,7 +524,7 @@ static void vdo_complete_flush(struct vdo_flush *flush)
 /**
  * initiate_drain() - Initiate a drain.
  *
- * Implements vdo_admin_initiator.
+ * Implements vdo_admin_initiator_fn.
  */
 static void initiate_drain(struct admin_state *state)
 {

--- a/drivers/md/dm-vdo/funnel-queue.c
+++ b/drivers/md/dm-vdo/funnel-queue.c
@@ -69,12 +69,13 @@ static struct funnel_queue_entry *get_oldest(struct funnel_queue *queue)
 	if (next == NULL) {
 		struct funnel_queue_entry *newest = READ_ONCE(queue->newest);
 
-		if (oldest != newest)
+		if (oldest != newest) {
 			/*
 			 * Another thread has already swung queue->newest atomically, but not yet
 			 * assigned previous->next. The queue is really still empty.
 			 */
 			return NULL;
+		}
 
 		/*
 		 * Put the stub entry back on the queue, ensuring a successor will eventually be
@@ -84,12 +85,13 @@ static struct funnel_queue_entry *get_oldest(struct funnel_queue *queue)
 
 		/* Check again for a successor. */
 		next = READ_ONCE(oldest->next);
-		if (next == NULL)
+		if (next == NULL) {
 			/*
 			 * We lost a race with a producer who swapped queue->newest before we did,
 			 * but who hasn't yet updated previous->next. Try again later.
 			 */
 			return NULL;
+		}
 	}
 
 	return oldest;

--- a/drivers/md/dm-vdo/funnel-queue.h
+++ b/drivers/md/dm-vdo/funnel-queue.h
@@ -79,8 +79,8 @@ void uds_free_funnel_queue(struct funnel_queue *queue);
  * from the pointer that passed in here, so every entry in the queue must have the struct
  * funnel_queue_entry at the same offset within the client's structure.
  */
-static inline void
-uds_funnel_queue_put(struct funnel_queue *queue, struct funnel_queue_entry *entry)
+static inline void uds_funnel_queue_put(struct funnel_queue *queue,
+					struct funnel_queue_entry *entry)
 {
 	struct funnel_queue_entry *previous;
 

--- a/drivers/md/dm-vdo/funnel-requestqueue.c
+++ b/drivers/md/dm-vdo/funnel-requestqueue.c
@@ -50,7 +50,7 @@ struct uds_request_queue {
 	/* Wait queue for synchronizing producers and consumer */
 	struct wait_queue_head wait_head;
 	/* Function to process a request */
-	uds_request_queue_processor_t *processor;
+	uds_request_queue_processor_fn processor;
 	/* Queue of new incoming requests */
 	struct funnel_queue *main_queue;
 	/* Queue of old requests to retry */
@@ -192,7 +192,7 @@ static void request_queue_worker(void *arg)
 }
 
 int uds_make_request_queue(const char *queue_name,
-			   uds_request_queue_processor_t *processor,
+			   uds_request_queue_processor_fn processor,
 			   struct uds_request_queue **queue_ptr)
 {
 	int result;

--- a/drivers/md/dm-vdo/funnel-requestqueue.c
+++ b/drivers/md/dm-vdo/funnel-requestqueue.c
@@ -133,7 +133,7 @@ static void wait_for_request(struct uds_request_queue *queue,
 
 static void request_queue_worker(void *arg)
 {
-	struct uds_request_queue *queue = (struct uds_request_queue *) arg;
+	struct uds_request_queue *queue = arg;
 	struct uds_request *request = NULL;
 	unsigned long time_batch = DEFAULT_WAIT_TIME;
 	bool dormant = atomic_read(&queue->dormant);

--- a/drivers/md/dm-vdo/funnel-requestqueue.c
+++ b/drivers/md/dm-vdo/funnel-requestqueue.c
@@ -92,8 +92,7 @@ static inline bool are_queues_idle(struct uds_request_queue *queue)
  * the thread did sleep before returning a new request.
  */
 static inline bool dequeue_request(struct uds_request_queue *queue,
-				   struct uds_request **request_ptr,
-				   bool *waited_ptr)
+				   struct uds_request **request_ptr, bool *waited_ptr)
 {
 	struct uds_request *request = poll_queues(queue);
 
@@ -113,10 +112,8 @@ static inline bool dequeue_request(struct uds_request_queue *queue,
 	return false;
 }
 
-static void wait_for_request(struct uds_request_queue *queue,
-			     bool dormant,
-			     unsigned long timeout,
-			     struct uds_request **request,
+static void wait_for_request(struct uds_request_queue *queue, bool dormant,
+			     unsigned long timeout, struct uds_request **request,
 			     bool *waited)
 {
 	if (dormant) {
@@ -222,7 +219,8 @@ int uds_make_request_queue(const char *queue_name,
 		return result;
 	}
 
-	result = uds_create_thread(request_queue_worker, queue, queue_name, &queue->thread);
+	result = uds_create_thread(request_queue_worker, queue, queue_name,
+				   &queue->thread);
 	if (result != UDS_SUCCESS) {
 		uds_request_queue_finish(queue);
 		return result;
@@ -239,7 +237,8 @@ static inline void wake_up_worker(struct uds_request_queue *queue)
 		wake_up(&queue->wait_head);
 }
 
-void uds_request_queue_enqueue(struct uds_request_queue *queue, struct uds_request *request)
+void uds_request_queue_enqueue(struct uds_request_queue *queue,
+			       struct uds_request *request)
 {
 	struct funnel_queue *sub_queue;
 	bool unbatched = request->unbatched;

--- a/drivers/md/dm-vdo/funnel-requestqueue.h
+++ b/drivers/md/dm-vdo/funnel-requestqueue.h
@@ -23,7 +23,8 @@ int __must_check uds_make_request_queue(const char *queue_name,
 					uds_request_queue_processor_t *processor,
 					struct uds_request_queue **queue_ptr);
 
-void uds_request_queue_enqueue(struct uds_request_queue *queue, struct uds_request *request);
+void uds_request_queue_enqueue(struct uds_request_queue *queue,
+			       struct uds_request *request);
 
 void uds_request_queue_finish(struct uds_request_queue *queue);
 

--- a/drivers/md/dm-vdo/funnel-requestqueue.h
+++ b/drivers/md/dm-vdo/funnel-requestqueue.h
@@ -17,10 +17,10 @@
 
 struct uds_request_queue;
 
-typedef void uds_request_queue_processor_t(struct uds_request *);
+typedef void (*uds_request_queue_processor_fn)(struct uds_request *);
 
 int __must_check uds_make_request_queue(const char *queue_name,
-					uds_request_queue_processor_t *processor,
+					uds_request_queue_processor_fn processor,
 					struct uds_request_queue **queue_ptr);
 
 void uds_request_queue_enqueue(struct uds_request_queue *queue,

--- a/drivers/md/dm-vdo/funnel-workqueue.c
+++ b/drivers/md/dm-vdo/funnel-workqueue.c
@@ -72,11 +72,11 @@ struct round_robin_work_queue {
 
 static inline struct simple_work_queue *as_simple_work_queue(struct vdo_work_queue *queue)
 {
-	return ((queue == NULL) ? NULL : container_of(queue, struct simple_work_queue, common));
+	return ((queue == NULL) ?
+		NULL : container_of(queue, struct simple_work_queue, common));
 }
 
-static inline struct round_robin_work_queue *
-as_round_robin_work_queue(struct vdo_work_queue *queue)
+static inline struct round_robin_work_queue *as_round_robin_work_queue(struct vdo_work_queue *queue)
 {
 	return ((queue == NULL) ?
 		 NULL :
@@ -107,15 +107,12 @@ static struct vdo_completion *poll_for_completion(struct simple_work_queue *queu
 	return NULL;
 }
 
-static void
-enqueue_work_queue_completion(struct simple_work_queue *queue, struct vdo_completion *completion)
+static void enqueue_work_queue_completion(struct simple_work_queue *queue,
+					  struct vdo_completion *completion)
 {
 	ASSERT_LOG_ONLY(completion->my_queue == NULL,
 			"completion %px (fn %px) to enqueue (%px) is not already queued (%px)",
-			completion,
-			completion->callback,
-			queue,
-			completion->my_queue);
+			completion, completion->callback, queue, completion->my_queue);
 	if (completion->priority == VDO_WORK_Q_DEFAULT_PRIORITY)
 		completion->priority = queue->common.type->default_priority;
 
@@ -180,7 +177,8 @@ static struct vdo_completion *wait_for_next_completion(struct simple_work_queue 
 	DEFINE_WAIT(wait);
 
 	while (true) {
-		prepare_to_wait(&queue->waiting_worker_threads, &wait, TASK_INTERRUPTIBLE);
+		prepare_to_wait(&queue->waiting_worker_threads, &wait,
+				TASK_INTERRUPTIBLE);
 		/*
 		 * Don't set the idle flag until a wakeup will not be lost.
 		 *
@@ -221,13 +219,12 @@ static struct vdo_completion *wait_for_next_completion(struct simple_work_queue 
 	return completion;
 }
 
-static void process_completion(struct simple_work_queue *queue, struct vdo_completion *completion)
+static void process_completion(struct simple_work_queue *queue,
+			       struct vdo_completion *completion)
 {
 	if (ASSERT(completion->my_queue == &queue->common,
 		   "completion %px from queue %px marked as being in this queue (%px)",
-		   completion,
-		   queue,
-		   completion->my_queue) == UDS_SUCCESS)
+		   completion, queue, completion->my_queue) == UDS_SUCCESS)
 		completion->my_queue = NULL;
 
 	vdo_run_completion(completion);
@@ -311,10 +308,8 @@ void vdo_free_work_queue(struct vdo_work_queue *queue)
 		free_simple_work_queue(as_simple_work_queue(queue));
 }
 
-static int make_simple_work_queue(const char *thread_name_prefix,
-				  const char *name,
-				  struct vdo_thread *owner,
-				  void *private,
+static int make_simple_work_queue(const char *thread_name_prefix, const char *name,
+				  struct vdo_thread *owner, void *private,
 				  const struct vdo_work_queue_type *type,
 				  struct simple_work_queue **queue_ptr)
 {
@@ -325,8 +320,7 @@ static int make_simple_work_queue(const char *thread_name_prefix,
 	int result;
 
 	ASSERT_LOG_ONLY((type->max_priority <= VDO_WORK_Q_MAX_PRIORITY),
-			"queue priority count %u within limit %u",
-			type->max_priority,
+			"queue priority count %u within limit %u", type->max_priority,
 			VDO_WORK_Q_MAX_PRIORITY);
 
 	result = uds_allocate(1, struct simple_work_queue, "simple work queue", &queue);
@@ -353,10 +347,7 @@ static int make_simple_work_queue(const char *thread_name_prefix,
 		}
 	}
 
-	thread = kthread_run(work_queue_runner,
-			     queue,
-			     "%s:%s",
-			     thread_name_prefix,
+	thread = kthread_run(work_queue_runner, queue, "%s:%s", thread_name_prefix,
 			     queue->common.name);
 	if (IS_ERR(thread)) {
 		free_simple_work_queue(queue);
@@ -387,12 +378,9 @@ static int make_simple_work_queue(const char *thread_name_prefix,
  * of the actual number of queues and threads allocated here, code outside of the queue
  * implementation will treat this as a single zone.
  */
-int vdo_make_work_queue(const char *thread_name_prefix,
-			const char *name,
-			struct vdo_thread *owner,
-			const struct vdo_work_queue_type *type,
-			unsigned int thread_count,
-			void *thread_privates[],
+int vdo_make_work_queue(const char *thread_name_prefix, const char *name,
+			struct vdo_thread *owner, const struct vdo_work_queue_type *type,
+			unsigned int thread_count, void *thread_privates[],
 			struct vdo_work_queue **queue_ptr)
 {
 	struct round_robin_work_queue *queue;
@@ -404,25 +392,20 @@ int vdo_make_work_queue(const char *thread_name_prefix,
 		struct simple_work_queue *simple_queue;
 		void *context = ((thread_privates != NULL) ? thread_privates[0] : NULL);
 
-		result = make_simple_work_queue(thread_name_prefix,
-						name,
-						owner,
-						context,
-						type,
-						&simple_queue);
+		result = make_simple_work_queue(thread_name_prefix, name, owner, context,
+						type, &simple_queue);
 		if (result == VDO_SUCCESS)
 			*queue_ptr = &simple_queue->common;
 		return result;
 	}
 
-	result = uds_allocate(1, struct round_robin_work_queue, "round-robin work queue", &queue);
+	result = uds_allocate(1, struct round_robin_work_queue, "round-robin work queue",
+			      &queue);
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = uds_allocate(thread_count,
-			      struct simple_work_queue *,
-			      "subordinate work queues",
-			      &queue->service_queues);
+	result = uds_allocate(thread_count, struct simple_work_queue *,
+			      "subordinate work queues", &queue->service_queues);
 	if (result != UDS_SUCCESS) {
 		uds_free(queue);
 		return result;
@@ -445,12 +428,8 @@ int vdo_make_work_queue(const char *thread_name_prefix,
 		void *context = ((thread_privates != NULL) ? thread_privates[i] : NULL);
 
 		snprintf(thread_name, sizeof(thread_name), "%s%u", name, i);
-		result = make_simple_work_queue(thread_name_prefix,
-						thread_name,
-						owner,
-						context,
-						type,
-						&queue->service_queues[i]);
+		result = make_simple_work_queue(thread_name_prefix, thread_name, owner,
+						context, type, &queue->service_queues[i]);
 		if (result != VDO_SUCCESS) {
 			queue->num_service_queues = i;
 			/* Destroy previously created subordinates. */
@@ -506,11 +485,8 @@ static void dump_simple_work_queue(struct simple_work_queue *queue)
 		thread_status = atomic_read(&queue->idle) ? "idle" : "running";
 	}
 
-	uds_log_info("workQ %px (%s) %s (%c)",
-		     &queue->common,
-		     queue->common.name,
-		     thread_status,
-		     task_state_report);
+	uds_log_info("workQ %px (%s) %s (%c)", &queue->common, queue->common.name,
+		     thread_status, task_state_report);
 
 	/* ->waiting_worker_threads wait queue status? anyone waiting? */
 }
@@ -559,19 +535,17 @@ static void get_function_name(void *pointer, char *buffer, size_t buffer_length)
 	}
 }
 
-void vdo_dump_completion_to_buffer(struct vdo_completion *completion, char *buffer, size_t length)
+void vdo_dump_completion_to_buffer(struct vdo_completion *completion, char *buffer,
+				   size_t length)
 {
 	size_t current_length =
-		scnprintf(buffer,
-			  length,
-			  "%.*s/",
-			  TASK_COMM_LEN,
+		scnprintf(buffer, length, "%.*s/", TASK_COMM_LEN,
 			  (completion->my_queue == NULL ? "-" : completion->my_queue->name));
 
-	if (current_length < length - 1)
-		get_function_name((void *) completion->callback,
-				  buffer + current_length,
+	if (current_length < length - 1) {
+		get_function_name((void *) completion->callback, buffer + current_length,
 				  length - current_length);
+	}
 }
 
 /* Completion submission */
@@ -579,7 +553,8 @@ void vdo_dump_completion_to_buffer(struct vdo_completion *completion, char *buff
  * If the completion has a timeout that has already passed, the timeout handler function may be
  * invoked by this function.
  */
-void vdo_enqueue_work_queue(struct vdo_work_queue *queue, struct vdo_completion *completion)
+void vdo_enqueue_work_queue(struct vdo_work_queue *queue,
+			    struct vdo_completion *completion)
 {
 	/*
 	 * Convert the provided generic vdo_work_queue to the simple_work_queue to actually queue
@@ -656,7 +631,8 @@ void *vdo_get_work_queue_private_data(void)
 	return (queue != NULL) ? queue->private : NULL;
 }
 
-bool vdo_work_queue_type_is(struct vdo_work_queue *queue, const struct vdo_work_queue_type *type)
+bool vdo_work_queue_type_is(struct vdo_work_queue *queue,
+			    const struct vdo_work_queue_type *type)
 {
 	return (queue->type == type);
 }

--- a/drivers/md/dm-vdo/funnel-workqueue.c
+++ b/drivers/md/dm-vdo/funnel-workqueue.c
@@ -243,9 +243,10 @@ static void service_work_queue(struct simple_work_queue *queue)
 		if (completion == NULL)
 			completion = wait_for_next_completion(queue);
 
-		if (completion == NULL)
+		if (completion == NULL) {
 			/* No completions but kthread_should_stop() was triggered. */
 			break;
+		}
 
 		process_completion(queue, completion);
 
@@ -623,9 +624,11 @@ static struct simple_work_queue *get_current_thread_work_queue(void)
 	 */
 	if (in_interrupt())
 		return NULL;
+
 	if (kthread_func(current) != work_queue_runner)
 		/* Not a VDO work queue thread. */
 		return NULL;
+
 	return kthread_data(current);
 }
 

--- a/drivers/md/dm-vdo/funnel-workqueue.h
+++ b/drivers/md/dm-vdo/funnel-workqueue.h
@@ -25,12 +25,9 @@ struct vdo_completion;
 struct vdo_thread;
 struct vdo_work_queue;
 
-int vdo_make_work_queue(const char *thread_name_prefix,
-			const char *name,
-			struct vdo_thread *owner,
-			const struct vdo_work_queue_type *type,
-			unsigned int thread_count,
-			void *thread_privates[],
+int vdo_make_work_queue(const char *thread_name_prefix, const char *name,
+			struct vdo_thread *owner, const struct vdo_work_queue_type *type,
+			unsigned int thread_count, void *thread_privates[],
 			struct vdo_work_queue **queue_ptr);
 
 void vdo_enqueue_work_queue(struct vdo_work_queue *queue, struct vdo_completion *completion);
@@ -41,13 +38,14 @@ void vdo_free_work_queue(struct vdo_work_queue *queue);
 
 void vdo_dump_work_queue(struct vdo_work_queue *queue);
 
-void vdo_dump_completion_to_buffer(struct vdo_completion *completion, char *buffer, size_t length);
+void vdo_dump_completion_to_buffer(struct vdo_completion *completion, char *buffer,
+				   size_t length);
 
 void *vdo_get_work_queue_private_data(void);
 struct vdo_work_queue *vdo_get_current_work_queue(void);
 struct vdo_thread *vdo_get_work_queue_owner(struct vdo_work_queue *queue);
 
-bool __must_check
-vdo_work_queue_type_is(struct vdo_work_queue *queue, const struct vdo_work_queue_type *type);
+bool __must_check vdo_work_queue_type_is(struct vdo_work_queue *queue,
+					 const struct vdo_work_queue_type *type);
 
 #endif /* VDO_WORK_QUEUE_H */

--- a/drivers/md/dm-vdo/geometry.c
+++ b/drivers/md/dm-vdo/geometry.c
@@ -116,8 +116,7 @@ int uds_copy_geometry(struct geometry *source, struct geometry **geometry_ptr)
 				 source->record_pages_per_chapter,
 				 source->chapters_per_volume,
 				 source->sparse_chapters_per_volume,
-				 source->remapped_virtual,
-				 source->remapped_physical,
+				 source->remapped_virtual, source->remapped_physical,
 				 geometry_ptr);
 }
 
@@ -126,7 +125,8 @@ void uds_free_geometry(struct geometry *geometry)
 	uds_free(geometry);
 }
 
-u32 __must_check uds_map_to_physical_chapter(const struct geometry *geometry, u64 virtual_chapter)
+u32 __must_check uds_map_to_physical_chapter(const struct geometry *geometry,
+					     u64 virtual_chapter)
 {
 	u64 delta;
 
@@ -153,8 +153,7 @@ u32 __must_check uds_map_to_physical_chapter(const struct geometry *geometry, u6
 }
 
 /* Check whether any sparse chapters are in use. */
-bool uds_has_sparse_chapters(const struct geometry *geometry,
-			     u64 oldest_virtual_chapter,
+bool uds_has_sparse_chapters(const struct geometry *geometry, u64 oldest_virtual_chapter,
 			     u64 newest_virtual_chapter)
 {
 	return uds_is_sparse_geometry(geometry) &&
@@ -162,13 +161,10 @@ bool uds_has_sparse_chapters(const struct geometry *geometry,
 		geometry->dense_chapters_per_volume);
 }
 
-bool uds_is_chapter_sparse(const struct geometry *geometry,
-			   u64 oldest_virtual_chapter,
-			   u64 newest_virtual_chapter,
-			   u64 virtual_chapter_number)
+bool uds_is_chapter_sparse(const struct geometry *geometry, u64 oldest_virtual_chapter,
+			   u64 newest_virtual_chapter, u64 virtual_chapter_number)
 {
-	return uds_has_sparse_chapters(geometry,
-				       oldest_virtual_chapter,
+	return uds_has_sparse_chapters(geometry, oldest_virtual_chapter,
 				       newest_virtual_chapter) &&
 	       ((virtual_chapter_number + geometry->dense_chapters_per_volume) <=
 		newest_virtual_chapter);

--- a/drivers/md/dm-vdo/geometry.h
+++ b/drivers/md/dm-vdo/geometry.h
@@ -95,19 +95,19 @@ enum {
 	HEADER_PAGES_PER_VOLUME = 1,
 };
 
-int __must_check uds_make_geometry(size_t bytes_per_page,
-				   u32 record_pages_per_chapter,
+int __must_check uds_make_geometry(size_t bytes_per_page, u32 record_pages_per_chapter,
 				   u32 chapters_per_volume,
-				   u32 sparse_chapters_per_volume,
-				   u64 remapped_virtual,
+				   u32 sparse_chapters_per_volume, u64 remapped_virtual,
 				   u64 remapped_physical,
 				   struct geometry **geometry_ptr);
 
-int __must_check uds_copy_geometry(struct geometry *source, struct geometry **geometry_ptr);
+int __must_check uds_copy_geometry(struct geometry *source,
+				   struct geometry **geometry_ptr);
 
 void uds_free_geometry(struct geometry *geometry);
 
-u32 __must_check uds_map_to_physical_chapter(const struct geometry *geometry, u64 virtual_chapter);
+u32 __must_check uds_map_to_physical_chapter(const struct geometry *geometry,
+					     u64 virtual_chapter);
 
 /*
  * Check whether this geometry is reduced by a chapter. This will only be true if the volume was
@@ -132,6 +132,7 @@ bool __must_check uds_is_chapter_sparse(const struct geometry *geometry,
 					u64 newest_virtual_chapter,
 					u64 virtual_chapter_number);
 
-u32 __must_check uds_chapters_to_expire(const struct geometry *geometry, u64 newest_chapter);
+u32 __must_check uds_chapters_to_expire(const struct geometry *geometry,
+					u64 newest_chapter);
 
 #endif /* UDS_GEOMETRY_H */

--- a/drivers/md/dm-vdo/hash-utils.h
+++ b/drivers/md/dm-vdo/hash-utils.h
@@ -22,7 +22,7 @@ enum {
 	SAMPLE_BYTES_COUNT = 2,
 };
 
-static inline u64 uds_extract_chapter_index_bytes(const struct  uds_record_name *name)
+static inline u64 uds_extract_chapter_index_bytes(const struct uds_record_name *name)
 {
 	const u8 *chapter_bits = &name->name[CHAPTER_INDEX_BYTES_OFFSET];
 	u64 bytes = (u64) get_unaligned_be16(chapter_bits) << 32;
@@ -42,23 +42,22 @@ static inline u32 uds_extract_sampling_bytes(const struct uds_record_name *name)
 }
 
 /* Compute the chapter delta list for a given name. */
-static inline u32
-uds_hash_to_chapter_delta_list(const struct uds_record_name *name, const struct geometry *geometry)
+static inline u32 uds_hash_to_chapter_delta_list(const struct uds_record_name *name,
+						 const struct geometry *geometry)
 {
 	return ((uds_extract_chapter_index_bytes(name) >> geometry->chapter_address_bits) &
 		((1 << geometry->chapter_delta_list_bits) - 1));
 }
 
 /* Compute the chapter delta address for a given name. */
-static inline u32
-uds_hash_to_chapter_delta_address(const struct uds_record_name *name,
-				  const struct geometry *geometry)
+static inline u32 uds_hash_to_chapter_delta_address(const struct uds_record_name *name,
+						    const struct geometry *geometry)
 {
 	return uds_extract_chapter_index_bytes(name) & ((1 << geometry->chapter_address_bits) - 1);
 }
 
-static inline unsigned int
-uds_name_to_hash_slot(const struct uds_record_name *name, unsigned int slot_count)
+static inline unsigned int uds_name_to_hash_slot(const struct uds_record_name *name,
+						 unsigned int slot_count)
 {
 	return (unsigned int) (uds_extract_chapter_index_bytes(name) % slot_count);
 }

--- a/drivers/md/dm-vdo/index-layout.c
+++ b/drivers/md/dm-vdo/index-layout.c
@@ -693,12 +693,13 @@ make_layout_region_table(struct index_layout *layout, struct region_table **tabl
 
 	*lr++ = layout->seal;
 
-	if (is_converted_super_block(&layout->super))
+	if (is_converted_super_block(&layout->super)) {
 		payload = sizeof(struct super_block_data);
-	else
+	} else {
 		payload = (sizeof(struct super_block_data) -
 			   sizeof(layout->super.volume_offset) -
 			   sizeof(layout->super.start_offset));
+	}
 
 	table->header = (struct region_header) {
 		.magic = REGION_MAGIC,
@@ -1170,10 +1171,11 @@ load_region_table(struct buffered_reader *reader, struct region_table **table_pt
 	if (header.magic != REGION_MAGIC)
 		return UDS_NO_INDEX;
 
-	if (header.version != 1)
+	if (header.version != 1) {
 		return uds_log_error_strerror(UDS_UNSUPPORTED_VERSION,
 					      "unknown region table version %hu",
 					      header.version);
+	}
 
 	result = uds_allocate_extended(struct region_table,
 				       header.region_count,
@@ -1257,26 +1259,30 @@ static int __must_check read_super_block_data(struct buffered_reader *reader,
 	    (super->version == 4) ||
 	    (super->version == 5) ||
 	    (super->version == 6) ||
-	    (super->version > SUPER_VERSION_MAXIMUM))
+	    (super->version > SUPER_VERSION_MAXIMUM)) {
 		return uds_log_error_strerror(UDS_UNSUPPORTED_VERSION,
 					      "unknown superblock version number %u",
 					      super->version);
+	}
 
-	if (super->volume_offset < super->start_offset)
+	if (super->volume_offset < super->start_offset) {
 		return uds_log_error_strerror(UDS_CORRUPT_DATA,
 					      "inconsistent offsets (start %llu, volume %llu)",
 					      (unsigned long long) super->start_offset,
 					      (unsigned long long) super->volume_offset);
+	}
 
 	/* Sub-indexes are no longer used but the layout retains this field. */
-	if (super->index_count != 1)
+	if (super->index_count != 1) {
 		return uds_log_error_strerror(UDS_CORRUPT_DATA,
 					      "invalid subindex count %u",
 					      super->index_count);
+	}
 
-	if (generate_primary_nonce(super->nonce_info, sizeof(super->nonce_info)) != super->nonce)
+	if (generate_primary_nonce(super->nonce_info, sizeof(super->nonce_info)) != super->nonce) {
 		return uds_log_error_strerror(UDS_CORRUPT_DATA,
 					      "inconsistent superblock nonce");
+	}
 
 	return UDS_SUCCESS;
 }
@@ -1292,9 +1298,10 @@ static int __must_check verify_region(struct layout_region *lr,
 	if (lr->kind != kind)
 		return uds_log_error_strerror(UDS_CORRUPT_DATA, "incorrect layout region kind");
 
-	if (lr->instance != instance)
+	if (lr->instance != instance) {
 		return uds_log_error_strerror(UDS_CORRUPT_DATA,
 					      "incorrect layout region instance");
+	}
 
 	return UDS_SUCCESS;
 }
@@ -1331,9 +1338,10 @@ verify_sub_index(struct index_layout *layout, u64 start_block, struct region_tab
 	}
 
 	next_block -= layout->super.volume_offset;
-	if (next_block != start_block + sil->sub_index.block_count)
+	if (next_block != start_block + sil->sub_index.block_count) {
 		return uds_log_error_strerror(UDS_CORRUPT_DATA,
 					      "sub index region does not span all saves");
+	}
 
 	return UDS_SUCCESS;
 }
@@ -1377,9 +1385,10 @@ reconstitute_layout(struct index_layout *layout, struct region_table *table, u64
 	if (result != UDS_SUCCESS)
 		return result;
 
-	if (++next_block != (first_block + layout->total_blocks))
+	if (++next_block != (first_block + layout->total_blocks)) {
 		return uds_log_error_strerror(UDS_CORRUPT_DATA,
 					      "layout table does not span total blocks");
+	}
 
 	return UDS_SUCCESS;
 }
@@ -1431,10 +1440,11 @@ static int __must_check read_index_save_data(struct buffered_reader *reader,
 	u8 buffer[sizeof(struct index_save_data) + sizeof(struct index_state_data301)];
 	size_t offset = 0;
 
-	if (saved_size != sizeof(buffer))
+	if (saved_size != sizeof(buffer)) {
 		return uds_log_error_strerror(UDS_CORRUPT_DATA,
 					      "unexpected index save data size %zu",
 					      saved_size);
+	}
 
 	result = uds_read_from_buffered_reader(reader, buffer, sizeof(buffer));
 	if (result != UDS_SUCCESS)
@@ -1445,20 +1455,22 @@ static int __must_check read_index_save_data(struct buffered_reader *reader,
 	decode_u32_le(buffer, &offset, &isl->save_data.version);
 	offset += sizeof(u32);
 
-	if (isl->save_data.version > 1)
+	if (isl->save_data.version > 1) {
 		return uds_log_error_strerror(UDS_UNSUPPORTED_VERSION,
 					      "unknown index save version number %u",
 					      isl->save_data.version);
+	}
 
 	decode_s32_le(buffer, &offset, &file_version.signature);
 	decode_s32_le(buffer, &offset, &file_version.version_id);
 
 	if ((file_version.signature != INDEX_STATE_VERSION_301.signature) ||
-	    (file_version.version_id != INDEX_STATE_VERSION_301.version_id))
+	    (file_version.version_id != INDEX_STATE_VERSION_301.version_id)) {
 		return uds_log_error_strerror(UDS_UNSUPPORTED_VERSION,
 					      "index state version %d,%d is unsupported",
 					      file_version.signature,
 					      file_version.version_id);
+	}
 
 	decode_u64_le(buffer, &offset, &isl->state_data.newest_chapter);
 	decode_u64_le(buffer, &offset, &isl->state_data.oldest_chapter);
@@ -1534,9 +1546,10 @@ reconstruct_index_save(struct index_save_layout *isl, struct region_table *table
 		return result;
 
 	next_block += isl->free_space.block_count;
-	if (next_block != last_block)
+	if (next_block != last_block) {
 		return uds_log_error_strerror(UDS_CORRUPT_DATA,
 					      "index save layout table incomplete");
+	}
 
 	return UDS_SUCCESS;
 }
@@ -1549,10 +1562,11 @@ static int __must_check load_index_save(struct index_save_layout *isl,
 	struct region_table *table = NULL;
 
 	result = load_region_table(reader, &table);
-	if (result != UDS_SUCCESS)
+	if (result != UDS_SUCCESS) {
 		return uds_log_error_strerror(result,
 					      "cannot read index save %u header",
 					      instance);
+	}
 
 	if (table->header.region_blocks != isl->index_save.block_count) {
 		u64 region_blocks = table->header.region_blocks;
@@ -1589,10 +1603,11 @@ static int __must_check load_index_save(struct index_save_layout *isl,
 
 	result = reconstruct_index_save(isl, table);
 	uds_free(table);
-	if (result != UDS_SUCCESS)
+	if (result != UDS_SUCCESS) {
 		return uds_log_error_strerror(result,
 					      "cannot reconstruct index save %u",
 					      instance);
+	}
 
 	return UDS_SUCCESS;
 }

--- a/drivers/md/dm-vdo/index-layout.c
+++ b/drivers/md/dm-vdo/index-layout.c
@@ -1604,7 +1604,7 @@ static int __must_check load_sub_index_regions(struct index_layout *layout)
 	struct index_save_layout *isl;
 	struct buffered_reader *reader;
 
-	for (j = 0; j < layout->super.max_saves; ++j) {
+	for (j = 0; j < layout->super.max_saves; j++) {
 		isl = &layout->index.saves[j];
 		result = open_region_reader(layout, &isl->index_save, &reader);
 

--- a/drivers/md/dm-vdo/index-layout.c
+++ b/drivers/md/dm-vdo/index-layout.c
@@ -233,16 +233,17 @@ static int __must_check compute_sizes(const struct configuration *config,
 	sls->block_size = UDS_BLOCK_SIZE;
 	sls->volume_blocks = geometry->bytes_per_volume / sls->block_size;
 
-	result = uds_compute_volume_index_save_blocks(config,
-						      sls->block_size,
+	result = uds_compute_volume_index_save_blocks(config, sls->block_size,
 						      &sls->volume_index_blocks);
 	if (result != UDS_SUCCESS)
 		return uds_log_error_strerror(result, "cannot compute index save size");
 
 	sls->page_map_blocks =
-		DIV_ROUND_UP(uds_compute_index_page_map_save_size(geometry), sls->block_size);
+		DIV_ROUND_UP(uds_compute_index_page_map_save_size(geometry),
+			     sls->block_size);
 	sls->open_chapter_blocks =
-		DIV_ROUND_UP(uds_compute_saved_open_chapter_size(geometry), sls->block_size);
+		DIV_ROUND_UP(uds_compute_saved_open_chapter_size(geometry),
+			     sls->block_size);
 	sls->save_blocks =
 		1 + (sls->volume_index_blocks + sls->page_map_blocks + sls->open_chapter_blocks);
 	sls->sub_index_blocks = sls->volume_blocks + (sls->save_count * sls->save_blocks);
@@ -323,49 +324,44 @@ static u64 generate_secondary_nonce(u64 nonce, const void *data, size_t len)
 }
 
 static int __must_check open_layout_reader(struct index_layout *layout,
-					   struct layout_region *lr,
-					   off_t offset,
+					   struct layout_region *lr, off_t offset,
 					   struct buffered_reader **reader_ptr)
 {
-	return uds_make_buffered_reader(layout->factory,
-					lr->start_block + offset,
-					lr->block_count,
-					reader_ptr);
+	return uds_make_buffered_reader(layout->factory, lr->start_block + offset,
+					lr->block_count, reader_ptr);
 }
 
-static int open_region_reader(struct index_layout *layout,
-			      struct layout_region *region,
+static int open_region_reader(struct index_layout *layout, struct layout_region *region,
 			      struct buffered_reader **reader_ptr)
 {
-	return open_layout_reader(layout, region, -layout->super.start_offset, reader_ptr);
+	return open_layout_reader(layout, region, -layout->super.start_offset,
+				  reader_ptr);
 }
 
 static int __must_check open_layout_writer(struct index_layout *layout,
-					   struct layout_region *lr,
-					   off_t offset,
+					   struct layout_region *lr, off_t offset,
 					   struct buffered_writer **writer_ptr)
 {
-	return uds_make_buffered_writer(layout->factory,
-					lr->start_block + offset,
-					lr->block_count,
-					writer_ptr);
+	return uds_make_buffered_writer(layout->factory, lr->start_block + offset,
+					lr->block_count, writer_ptr);
 }
 
-static int open_region_writer(struct index_layout *layout,
-			      struct layout_region *region,
+static int open_region_writer(struct index_layout *layout, struct layout_region *region,
 			      struct buffered_writer **writer_ptr)
 {
-	return open_layout_writer(layout, region, -layout->super.start_offset, writer_ptr);
+	return open_layout_writer(layout, region, -layout->super.start_offset,
+				  writer_ptr);
 }
 
-static void
-generate_super_block_data(struct save_layout_sizes *sls, struct super_block_data *super)
+static void generate_super_block_data(struct save_layout_sizes *sls,
+				      struct super_block_data *super)
 {
 	memset(super, 0, sizeof(*super));
 	memcpy(super->magic_label, LAYOUT_MAGIC, MAGIC_SIZE);
 	create_unique_nonce_data(super->nonce_info);
 
-	super->nonce = generate_primary_nonce(super->nonce_info, sizeof(super->nonce_info));
+	super->nonce = generate_primary_nonce(super->nonce_info,
+					      sizeof(super->nonce_info));
 	super->version = SUPER_VERSION_CURRENT;
 	super->block_size = sls->block_size;
 	super->index_count = 1;
@@ -391,11 +387,12 @@ static void define_sub_index_nonce(struct index_layout *layout)
 	encode_u16_le(buffer, &offset, 0);
 	sil->nonce = generate_secondary_nonce(primary_nonce, buffer, sizeof(buffer));
 	if (sil->nonce == 0)
-		sil->nonce = generate_secondary_nonce(~primary_nonce + 1, buffer, sizeof(buffer));
+		sil->nonce = generate_secondary_nonce(~primary_nonce + 1, buffer,
+						      sizeof(buffer));
 }
 
-static void
-setup_sub_index(struct index_layout *layout, u64 start_block, struct save_layout_sizes *sls)
+static void setup_sub_index(struct index_layout *layout, u64 start_block,
+			    struct save_layout_sizes *sls)
 {
 	struct sub_index_layout *sil = &layout->index;
 	u64 next_block = start_block;
@@ -462,8 +459,8 @@ static void initialize_layout(struct index_layout *layout, struct save_layout_si
 	};
 }
 
-static int __must_check
-make_index_save_region_table(struct index_save_layout *isl, struct region_table **table_ptr)
+static int __must_check make_index_save_region_table(struct index_save_layout *isl,
+						     struct region_table **table_ptr)
 {
 	int result;
 	unsigned int z;
@@ -491,11 +488,9 @@ make_index_save_region_table(struct index_save_layout *isl, struct region_table 
 		type = RH_TYPE_UNSAVED;
 	}
 
-	result = uds_allocate_extended(struct region_table,
-				       region_count,
+	result = uds_allocate_extended(struct region_table, region_count,
 				       struct layout_region,
-				       "layout region table for ISL",
-				       &table);
+				       "layout region table for ISL", &table);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -580,7 +575,8 @@ static int __must_check write_index_save_header(struct index_save_layout *isl,
 	return uds_flush_buffered_writer(writer);
 }
 
-static int write_index_save_layout(struct index_layout *layout, struct index_save_layout *isl)
+static int write_index_save_layout(struct index_layout *layout,
+				   struct index_save_layout *isl)
 {
 	int result;
 	struct region_table *table;
@@ -636,8 +632,8 @@ static void reset_index_save_layout(struct index_save_layout *isl, u64 page_map_
 	};
 }
 
-static int __must_check
-invalidate_old_save(struct index_layout *layout, struct index_save_layout *isl)
+static int __must_check invalidate_old_save(struct index_layout *layout,
+					    struct index_save_layout *isl)
 {
 	reset_index_save_layout(isl, layout->super.page_map_blocks);
 	return write_index_save_layout(layout, isl);
@@ -663,8 +659,8 @@ static int discard_index_state_data(struct index_layout *layout)
 	return UDS_SUCCESS;
 }
 
-static int __must_check
-make_layout_region_table(struct index_layout *layout, struct region_table **table_ptr)
+static int __must_check make_layout_region_table(struct index_layout *layout,
+						 struct region_table **table_ptr)
 {
 	int result;
 	unsigned int i;
@@ -674,10 +670,8 @@ make_layout_region_table(struct index_layout *layout, struct region_table **tabl
 	struct region_table *table;
 	struct layout_region *lr;
 
-	result = uds_allocate_extended(struct region_table,
-				       region_count,
-				       struct layout_region,
-				       "layout region table",
+	result = uds_allocate_extended(struct region_table, region_count,
+				       struct layout_region, "layout region table",
 				       &table);
 	if (result != UDS_SUCCESS)
 		return result;
@@ -814,9 +808,7 @@ static int create_index_layout(struct index_layout *layout, struct configuration
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = uds_allocate(sizes.save_count,
-			      struct index_save_layout,
-			      __func__,
+	result = uds_allocate(sizes.save_count, struct index_save_layout, __func__,
 			      &layout->index.saves);
 	if (result != UDS_SUCCESS)
 		return result;
@@ -849,9 +841,7 @@ static u64 generate_index_save_nonce(u64 volume_nonce, struct index_save_layout 
 	encode_u32_le(buffer, &offset, 0U);
 	encode_u64_le(buffer, &offset, isl->index_save.start_block);
 	ASSERT_LOG_ONLY(offset == sizeof(nonce_data),
-			"%zu bytes encoded of %zu expected",
-			offset,
-			sizeof(nonce_data));
+			"%zu bytes encoded of %zu expected", offset, sizeof(nonce_data));
 	return generate_secondary_nonce(volume_nonce, buffer, sizeof(buffer));
 }
 
@@ -866,8 +856,8 @@ static u64 validate_index_save_layout(struct index_save_layout *isl, u64 volume_
 	return isl->save_data.timestamp;
 }
 
-static int
-find_latest_uds_index_save_slot(struct index_layout *layout, struct index_save_layout **isl_ptr)
+static int find_latest_uds_index_save_slot(struct index_layout *layout,
+					   struct index_save_layout **isl_ptr)
 {
 	struct index_save_layout *latest = NULL;
 	struct index_save_layout *isl;
@@ -943,8 +933,7 @@ int uds_load_index_state(struct index_layout *layout, struct uds_index *index)
 		return result;
 
 	for (zone = 0; zone < isl->zone_count; zone++) {
-		result = open_region_reader(layout,
-					    &isl->volume_index_zones[zone],
+		result = open_region_reader(layout, &isl->volume_index_zones[zone],
 					    &readers[zone]);
 		if (result != UDS_SUCCESS) {
 			for (; zone > 0; zone--)
@@ -992,8 +981,7 @@ static struct index_save_layout *select_oldest_index_save_layout(struct index_la
 
 static void instantiate_index_save_layout(struct index_save_layout *isl,
 					  struct super_block_data *super,
-					  u64 volume_nonce,
-					  unsigned int zone_count)
+					  u64 volume_nonce, unsigned int zone_count)
 {
 	unsigned int z;
 	u64 next_block;
@@ -1067,7 +1055,8 @@ static int setup_uds_index_save_slot(struct index_layout *layout,
 	if (result != UDS_SUCCESS)
 		return result;
 
-	instantiate_index_save_layout(isl, &layout->super, layout->index.nonce, zone_count);
+	instantiate_index_save_layout(isl, &layout->super, layout->index.nonce,
+				      zone_count);
 
 	*isl_ptr = isl;
 	return UDS_SUCCESS;
@@ -1111,8 +1100,7 @@ int uds_save_index_state(struct index_layout *layout, struct uds_index *index)
 	}
 
 	for (zone = 0; zone < index->zone_count; zone++) {
-		result = open_region_writer(layout,
-					    &isl->volume_index_zones[zone],
+		result = open_region_writer(layout, &isl->volume_index_zones[zone],
 					    &writers[zone]);
 		if (result != UDS_SUCCESS) {
 			for (; zone > 0; zone--)
@@ -1147,8 +1135,8 @@ int uds_save_index_state(struct index_layout *layout, struct uds_index *index)
 	return write_index_save_layout(layout, isl);
 }
 
-static int __must_check
-load_region_table(struct buffered_reader *reader, struct region_table **table_ptr)
+static int __must_check load_region_table(struct buffered_reader *reader,
+					  struct region_table **table_ptr)
 {
 	int result;
 	unsigned int i;
@@ -1177,11 +1165,9 @@ load_region_table(struct buffered_reader *reader, struct region_table **table_pt
 					      header.version);
 	}
 
-	result = uds_allocate_extended(struct region_table,
-				       header.region_count,
+	result = uds_allocate_extended(struct region_table, header.region_count,
 				       struct layout_region,
-				       "single file layout region table",
-				       &table);
+				       "single file layout region table", &table);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -1190,8 +1176,7 @@ load_region_table(struct buffered_reader *reader, struct region_table **table_pt
 		u8 region_buffer[sizeof(struct layout_region)];
 
 		offset = 0;
-		result = uds_read_from_buffered_reader(reader,
-						       region_buffer,
+		result = uds_read_from_buffered_reader(reader, region_buffer,
 						       sizeof(region_buffer));
 		if (result != UDS_SUCCESS) {
 			uds_free(table);
@@ -1253,7 +1238,8 @@ static int __must_check read_super_block_data(struct buffered_reader *reader,
 	uds_free(buffer);
 
 	if (memcmp(super->magic_label, LAYOUT_MAGIC, MAGIC_SIZE) != 0)
-		return uds_log_error_strerror(UDS_CORRUPT_DATA, "unknown superblock magic label");
+		return uds_log_error_strerror(UDS_CORRUPT_DATA,
+					      "unknown superblock magic label");
 
 	if ((super->version < SUPER_VERSION_MINIMUM) ||
 	    (super->version == 4) ||
@@ -1287,16 +1273,16 @@ static int __must_check read_super_block_data(struct buffered_reader *reader,
 	return UDS_SUCCESS;
 }
 
-static int __must_check verify_region(struct layout_region *lr,
-				      u64 start_block,
-				      enum region_kind kind,
-				      unsigned int instance)
+static int __must_check verify_region(struct layout_region *lr, u64 start_block,
+				      enum region_kind kind, unsigned int instance)
 {
 	if (lr->start_block != start_block)
-		return uds_log_error_strerror(UDS_CORRUPT_DATA, "incorrect layout region offset");
+		return uds_log_error_strerror(UDS_CORRUPT_DATA,
+					      "incorrect layout region offset");
 
 	if (lr->kind != kind)
-		return uds_log_error_strerror(UDS_CORRUPT_DATA, "incorrect layout region kind");
+		return uds_log_error_strerror(UDS_CORRUPT_DATA,
+					      "incorrect layout region kind");
 
 	if (lr->instance != instance) {
 		return uds_log_error_strerror(UDS_CORRUPT_DATA,
@@ -1306,8 +1292,8 @@ static int __must_check verify_region(struct layout_region *lr,
 	return UDS_SUCCESS;
 }
 
-static int __must_check
-verify_sub_index(struct index_layout *layout, u64 start_block, struct region_table *table)
+static int __must_check verify_sub_index(struct index_layout *layout, u64 start_block,
+					 struct region_table *table)
 {
 	int result;
 	unsigned int i;
@@ -1322,7 +1308,8 @@ verify_sub_index(struct index_layout *layout, u64 start_block, struct region_tab
 	define_sub_index_nonce(layout);
 
 	sil->volume = table->regions[3];
-	result = verify_region(&sil->volume, next_block, RL_KIND_VOLUME, RL_SOLE_INSTANCE);
+	result = verify_region(&sil->volume, next_block, RL_KIND_VOLUME,
+			       RL_SOLE_INSTANCE);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -1330,7 +1317,8 @@ verify_sub_index(struct index_layout *layout, u64 start_block, struct region_tab
 
 	for (i = 0; i < layout->super.max_saves; i++) {
 		sil->saves[i].index_save = table->regions[i + 4];
-		result = verify_region(&sil->saves[i].index_save, next_block, RL_KIND_SAVE, i);
+		result = verify_region(&sil->saves[i].index_save, next_block,
+				       RL_KIND_SAVE, i);
 		if (result != UDS_SUCCESS)
 			return result;
 
@@ -1346,28 +1334,28 @@ verify_sub_index(struct index_layout *layout, u64 start_block, struct region_tab
 	return UDS_SUCCESS;
 }
 
-static int __must_check
-reconstitute_layout(struct index_layout *layout, struct region_table *table, u64 first_block)
+static int __must_check reconstitute_layout(struct index_layout *layout,
+					    struct region_table *table, u64 first_block)
 {
 	int result;
 	u64 next_block = first_block;
 
-	result = uds_allocate(layout->super.max_saves,
-			      struct index_save_layout,
-			      __func__,
-			      &layout->index.saves);
+	result = uds_allocate(layout->super.max_saves, struct index_save_layout,
+			      __func__, &layout->index.saves);
 	if (result != UDS_SUCCESS)
 		return result;
 
 	layout->total_blocks = table->header.region_blocks;
 
 	layout->header = table->regions[0];
-	result = verify_region(&layout->header, next_block++, RL_KIND_HEADER, RL_SOLE_INSTANCE);
+	result = verify_region(&layout->header, next_block++, RL_KIND_HEADER,
+			       RL_SOLE_INSTANCE);
 	if (result != UDS_SUCCESS)
 		return result;
 
 	layout->config = table->regions[1];
-	result = verify_region(&layout->config, next_block++, RL_KIND_CONFIG, RL_SOLE_INSTANCE);
+	result = verify_region(&layout->config, next_block++, RL_KIND_CONFIG,
+			       RL_SOLE_INSTANCE);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -1378,10 +1366,8 @@ reconstitute_layout(struct index_layout *layout, struct region_table *table, u64
 	next_block += layout->index.sub_index.block_count;
 
 	layout->seal = table->regions[table->header.region_count - 1];
-	result = verify_region(&layout->seal,
-			       next_block + layout->super.volume_offset,
-			       RL_KIND_SEAL,
-			       RL_SOLE_INSTANCE);
+	result = verify_region(&layout->seal, next_block + layout->super.volume_offset,
+			       RL_KIND_SEAL, RL_SOLE_INSTANCE);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -1393,10 +1379,8 @@ reconstitute_layout(struct index_layout *layout, struct region_table *table, u64
 	return UDS_SUCCESS;
 }
 
-static int __must_check load_super_block(struct index_layout *layout,
-					 size_t block_size,
-					 u64 first_block,
-					 struct buffered_reader *reader)
+static int __must_check load_super_block(struct index_layout *layout, size_t block_size,
+					 u64 first_block, struct buffered_reader *reader)
 {
 	int result;
 	struct region_table *table = NULL;
@@ -1408,7 +1392,8 @@ static int __must_check load_super_block(struct index_layout *layout,
 
 	if (table->header.type != RH_TYPE_SUPER) {
 		uds_free(table);
-		return uds_log_error_strerror(UDS_CORRUPT_DATA, "not a superblock region table");
+		return uds_log_error_strerror(UDS_CORRUPT_DATA,
+					      "not a superblock region table");
 	}
 
 	result = read_super_block_data(reader, layout, table->header.payload);
@@ -1421,8 +1406,7 @@ static int __must_check load_super_block(struct index_layout *layout,
 		uds_free(table);
 		return uds_log_error_strerror(UDS_CORRUPT_DATA,
 					      "superblock saved block_size %u differs from supplied block_size %zu",
-					      super->block_size,
-					      block_size);
+					      super->block_size, block_size);
 	}
 
 	first_block -= (super->volume_offset - super->start_offset);
@@ -1480,8 +1464,8 @@ static int __must_check read_index_save_data(struct buffered_reader *reader,
 	return UDS_SUCCESS;
 }
 
-static int __must_check
-reconstruct_index_save(struct index_save_layout *isl, struct region_table *table)
+static int __must_check reconstruct_index_save(struct index_save_layout *isl,
+					       struct region_table *table)
 {
 	int result;
 	unsigned int z;
@@ -1505,14 +1489,13 @@ reconstruct_index_save(struct index_save_layout *isl, struct region_table *table
 	}
 
 	isl->header = table->regions[0];
-	result = verify_region(&isl->header, next_block++, RL_KIND_HEADER, RL_SOLE_INSTANCE);
+	result = verify_region(&isl->header, next_block++, RL_KIND_HEADER,
+			       RL_SOLE_INSTANCE);
 	if (result != UDS_SUCCESS)
 		return result;
 
 	isl->index_page_map = table->regions[1];
-	result = verify_region(&isl->index_page_map,
-			       next_block,
-			       RL_KIND_INDEX_PAGE_MAP,
+	result = verify_region(&isl->index_page_map, next_block, RL_KIND_INDEX_PAGE_MAP,
 			       RL_SOLE_INSTANCE);
 	if (result != UDS_SUCCESS)
 		return result;
@@ -1521,10 +1504,8 @@ reconstruct_index_save(struct index_save_layout *isl, struct region_table *table
 
 	for (z = 0; z < isl->zone_count; z++) {
 		isl->volume_index_zones[z] = table->regions[z + 2];
-		result = verify_region(&isl->volume_index_zones[z],
-				       next_block,
-				       RL_KIND_VOLUME_INDEX,
-				       z);
+		result = verify_region(&isl->volume_index_zones[z], next_block,
+				       RL_KIND_VOLUME_INDEX, z);
 		if (result != UDS_SUCCESS)
 			return result;
 
@@ -1532,16 +1513,15 @@ reconstruct_index_save(struct index_save_layout *isl, struct region_table *table
 	}
 
 	isl->open_chapter = table->regions[isl->zone_count + 2];
-	result = verify_region(&isl->open_chapter,
-			       next_block,
-			       RL_KIND_OPEN_CHAPTER,
+	result = verify_region(&isl->open_chapter, next_block, RL_KIND_OPEN_CHAPTER,
 			       RL_SOLE_INSTANCE);
 	if (result != UDS_SUCCESS)
 		return result;
 
 	next_block += isl->open_chapter.block_count;
 
-	result = verify_region(&isl->free_space, next_block, RL_KIND_EMPTY, RL_SOLE_INSTANCE);
+	result = verify_region(&isl->free_space, next_block, RL_KIND_EMPTY,
+			       RL_SOLE_INSTANCE);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -1563,8 +1543,7 @@ static int __must_check load_index_save(struct index_save_layout *isl,
 
 	result = load_region_table(reader, &table);
 	if (result != UDS_SUCCESS) {
-		return uds_log_error_strerror(result,
-					      "cannot read index save %u header",
+		return uds_log_error_strerror(result, "cannot read index save %u header",
 					      instance);
 	}
 
@@ -1589,8 +1568,7 @@ static int __must_check load_index_save(struct index_save_layout *isl,
 		uds_free(table);
 		return uds_log_error_strerror(UDS_CORRUPT_DATA,
 					      "unexpected index save %u header type %u",
-					      instance,
-					      table->header.type);
+					      instance, table->header.type);
 	}
 
 	result = read_index_save_data(reader, isl, table->header.payload);
@@ -1604,8 +1582,7 @@ static int __must_check load_index_save(struct index_save_layout *isl,
 	result = reconstruct_index_save(isl, table);
 	uds_free(table);
 	if (result != UDS_SUCCESS) {
-		return uds_log_error_strerror(result,
-					      "cannot reconstruct index save %u",
+		return uds_log_error_strerror(result, "cannot reconstruct index save %u",
 					      instance);
 	}
 
@@ -1624,7 +1601,9 @@ static int __must_check load_sub_index_regions(struct index_layout *layout)
 		result = open_region_reader(layout, &isl->index_save, &reader);
 
 		if (result != UDS_SUCCESS) {
-			uds_log_error_strerror(result, "cannot get reader for index 0 save %u", j);
+			uds_log_error_strerror(result,
+					       "cannot get reader for index 0 save %u",
+					       j);
 			return result;
 		}
 
@@ -1640,8 +1619,8 @@ static int __must_check load_sub_index_regions(struct index_layout *layout)
 	return UDS_SUCCESS;
 }
 
-static int __must_check
-verify_uds_index_config(struct index_layout *layout, struct configuration *config)
+static int __must_check verify_uds_index_config(struct index_layout *layout,
+						struct configuration *config)
 {
 	int result;
 	struct buffered_reader *reader = NULL;
@@ -1668,13 +1647,12 @@ static int load_index_layout(struct index_layout *layout, struct configuration *
 	struct buffered_reader *reader;
 
 	result = uds_make_buffered_reader(layout->factory,
-					  layout->offset / UDS_BLOCK_SIZE,
-					  1,
-					  &reader);
+					  layout->offset / UDS_BLOCK_SIZE, 1, &reader);
 	if (result != UDS_SUCCESS)
 		return uds_log_error_strerror(result, "unable to read superblock");
 
-	result = load_super_block(layout, UDS_BLOCK_SIZE, layout->offset / UDS_BLOCK_SIZE, reader);
+	result = load_super_block(layout, UDS_BLOCK_SIZE,
+				  layout->offset / UDS_BLOCK_SIZE, reader);
 	uds_free_buffered_reader(reader);
 	if (result != UDS_SUCCESS)
 		return result;
@@ -1686,7 +1664,8 @@ static int load_index_layout(struct index_layout *layout, struct configuration *
 	return load_sub_index_regions(layout);
 }
 
-static int create_layout_factory(struct index_layout *layout, const struct configuration *config)
+static int create_layout_factory(struct index_layout *layout,
+				 const struct configuration *config)
 {
 	int result;
 	size_t writable_size;
@@ -1700,8 +1679,7 @@ static int create_layout_factory(struct index_layout *layout, const struct confi
 	if (writable_size < config->size + config->offset) {
 		uds_put_io_factory(factory);
 		uds_log_error("index storage (%zu) is smaller than the requested size %zu",
-			      writable_size,
-			      config->size + config->offset);
+			      writable_size, config->size + config->offset);
 		return -ENOSPC;
 	}
 
@@ -1711,8 +1689,7 @@ static int create_layout_factory(struct index_layout *layout, const struct confi
 	return UDS_SUCCESS;
 }
 
-int uds_make_index_layout(struct configuration *config,
-			  bool new_layout,
+int uds_make_index_layout(struct configuration *config, bool new_layout,
 			  struct index_layout **layout_ptr)
 {
 	int result;
@@ -1766,14 +1743,14 @@ void uds_free_index_layout(struct index_layout *layout)
 	uds_free(layout);
 }
 
-int uds_replace_index_layout_storage(struct index_layout *layout, struct block_device *bdev)
+int uds_replace_index_layout_storage(struct index_layout *layout,
+				     struct block_device *bdev)
 {
 	return uds_replace_storage(layout->factory, bdev);
 }
 
 /* Obtain a dm_bufio_client for the volume region. */
-int uds_open_volume_bufio(struct index_layout *layout,
-			  size_t block_size,
+int uds_open_volume_bufio(struct index_layout *layout, size_t block_size,
 			  unsigned int reserved_buffers,
 			  struct dm_bufio_client **client_ptr)
 {
@@ -1781,7 +1758,8 @@ int uds_open_volume_bufio(struct index_layout *layout,
 			layout->super.volume_offset -
 			layout->super.start_offset);
 
-	return uds_make_bufio(layout->factory, offset, block_size, reserved_buffers, client_ptr);
+	return uds_make_bufio(layout->factory, offset, block_size, reserved_buffers,
+			      client_ptr);
 }
 
 u64 uds_get_volume_nonce(struct index_layout *layout)

--- a/drivers/md/dm-vdo/index-layout.h
+++ b/drivers/md/dm-vdo/index-layout.h
@@ -18,8 +18,7 @@
 
 struct index_layout;
 
-int __must_check uds_make_index_layout(struct configuration *config,
-				       bool new_layout,
+int __must_check uds_make_index_layout(struct configuration *config, bool new_layout,
 				       struct index_layout **layout_ptr);
 
 void uds_free_index_layout(struct index_layout *layout);
@@ -27,16 +26,17 @@ void uds_free_index_layout(struct index_layout *layout);
 int __must_check uds_replace_index_layout_storage(struct index_layout *layout,
 						  struct block_device *bdev);
 
-int __must_check uds_load_index_state(struct index_layout *layout, struct uds_index *index);
+int __must_check uds_load_index_state(struct index_layout *layout,
+				      struct uds_index *index);
 
-int __must_check uds_save_index_state(struct index_layout *layout, struct uds_index *index);
+int __must_check uds_save_index_state(struct index_layout *layout,
+				      struct uds_index *index);
 
 int __must_check uds_discard_open_chapter(struct index_layout *layout);
 
 u64 __must_check uds_get_volume_nonce(struct index_layout *layout);
 
-int __must_check uds_open_volume_bufio(struct index_layout *layout,
-				       size_t block_size,
+int __must_check uds_open_volume_bufio(struct index_layout *layout, size_t block_size,
 				       unsigned int reserved_buffers,
 				       struct dm_bufio_client **client_ptr);
 

--- a/drivers/md/dm-vdo/index-page-map.c
+++ b/drivers/md/dm-vdo/index-page-map.c
@@ -33,7 +33,8 @@ static inline u32 get_entry_count(const struct geometry *geometry)
 	return geometry->chapters_per_volume * (geometry->index_pages_per_chapter - 1);
 }
 
-int uds_make_index_page_map(const struct geometry *geometry, struct index_page_map **map_ptr)
+int uds_make_index_page_map(const struct geometry *geometry,
+			    struct index_page_map **map_ptr)
 {
 	int result;
 	struct index_page_map *map;
@@ -44,9 +45,7 @@ int uds_make_index_page_map(const struct geometry *geometry, struct index_page_m
 
 	map->geometry = geometry;
 	map->entries_per_chapter = geometry->index_pages_per_chapter - 1;
-	result = uds_allocate(get_entry_count(geometry),
-			      u16,
-			      "Index Page Map Entries",
+	result = uds_allocate(get_entry_count(geometry), u16, "Index Page Map Entries",
 			      &map->entries);
 	if (result != UDS_SUCCESS) {
 		uds_free_index_page_map(map);
@@ -65,10 +64,8 @@ void uds_free_index_page_map(struct index_page_map *map)
 	}
 }
 
-void uds_update_index_page_map(struct index_page_map *map,
-			       u64 virtual_chapter_number,
-			       u32 chapter_number,
-			       u32 index_page_number,
+void uds_update_index_page_map(struct index_page_map *map, u64 virtual_chapter_number,
+			       u32 chapter_number, u32 index_page_number,
 			       u32 delta_list_number)
 {
 	size_t slot;
@@ -82,8 +79,7 @@ void uds_update_index_page_map(struct index_page_map *map,
 }
 
 u32 uds_find_index_page_number(const struct index_page_map *map,
-			       const struct uds_record_name *name,
-			       u32 chapter_number)
+			       const struct uds_record_name *name, u32 chapter_number)
 {
 	u32 delta_list_number = uds_hash_to_chapter_delta_list(name, map->geometry);
 	u32 slot = chapter_number * map->entries_per_chapter;
@@ -97,10 +93,8 @@ u32 uds_find_index_page_number(const struct index_page_map *map,
 	return page;
 }
 
-void uds_get_list_number_bounds(const struct index_page_map *map,
-				u32 chapter_number,
-				u32 index_page_number,
-				u32 *lowest_list,
+void uds_get_list_number_bounds(const struct index_page_map *map, u32 chapter_number,
+				u32 index_page_number, u32 *lowest_list,
 				u32 *highest_list)
 {
 	u32 slot = chapter_number * map->entries_per_chapter;

--- a/drivers/md/dm-vdo/index-page-map.h
+++ b/drivers/md/dm-vdo/index-page-map.h
@@ -22,31 +22,27 @@ struct index_page_map {
 	u16 *entries;
 };
 
-int __must_check
-uds_make_index_page_map(const struct geometry *geometry, struct index_page_map **map_ptr);
+int __must_check uds_make_index_page_map(const struct geometry *geometry,
+					 struct index_page_map **map_ptr);
 
 void uds_free_index_page_map(struct index_page_map *map);
 
-int __must_check
-uds_read_index_page_map(struct index_page_map *map, struct buffered_reader *reader);
+int __must_check uds_read_index_page_map(struct index_page_map *map,
+					 struct buffered_reader *reader);
 
-int __must_check
-uds_write_index_page_map(struct index_page_map *map, struct buffered_writer *writer);
+int __must_check uds_write_index_page_map(struct index_page_map *map,
+					  struct buffered_writer *writer);
 
-void uds_update_index_page_map(struct index_page_map *map,
-			       u64 virtual_chapter_number,
-			       u32 chapter_number,
-			       u32 index_page_number,
+void uds_update_index_page_map(struct index_page_map *map, u64 virtual_chapter_number,
+			       u32 chapter_number, u32 index_page_number,
 			       u32 delta_list_number);
 
 u32 __must_check uds_find_index_page_number(const struct index_page_map *map,
 					    const struct uds_record_name *name,
 					    u32 chapter_number);
 
-void uds_get_list_number_bounds(const struct index_page_map *map,
-				u32 chapter_number,
-				u32 index_page_number,
-				u32 *lowest_list,
+void uds_get_list_number_bounds(const struct index_page_map *map, u32 chapter_number,
+				u32 index_page_number, u32 *lowest_list,
 				u32 *highest_list);
 
 u64 uds_compute_index_page_map_save_size(const struct geometry *geometry);

--- a/drivers/md/dm-vdo/index-session.c
+++ b/drivers/md/dm-vdo/index-session.c
@@ -120,7 +120,8 @@ int uds_launch_request(struct uds_request *request)
 	}
 
 	/* Reset all internal fields before processing. */
-	internal_size = sizeof(struct uds_request) - offsetof(struct uds_request, zone_number);
+	internal_size =
+		sizeof(struct uds_request) - offsetof(struct uds_request, zone_number);
 	// FIXME should be using struct_group for this instead
 	memset((char *) request + sizeof(*request) - internal_size, 0, internal_size);
 
@@ -410,9 +411,11 @@ static void suspend_rebuild(struct uds_index_session *session)
 
 		/* Wait until the index indicates that it is not replaying. */
 		while ((session->load_context.status != INDEX_SUSPENDED) &&
-		       (session->load_context.status != INDEX_READY))
+		       (session->load_context.status != INDEX_READY)) {
 			uds_wait_cond(&session->load_context.cond,
 				      &session->load_context.mutex);
+		}
+
 		break;
 
 	case INDEX_READY:

--- a/drivers/md/dm-vdo/index-session.c
+++ b/drivers/md/dm-vdo/index-session.c
@@ -198,7 +198,8 @@ static void update_session_stats(struct uds_request *request)
 		break;
 
 	default:
-		request->status = ASSERT(false, "unknown request type: %d", request->type);
+		request->status = ASSERT(false, "unknown request type: %d",
+					 request->type);
 	}
 }
 
@@ -253,7 +254,8 @@ static int __must_check make_empty_index_session(struct uds_index_session **inde
 		return result;
 	}
 
-	result = uds_make_request_queue("callbackW", &handle_callbacks, &session->callback_queue);
+	result = uds_make_request_queue("callbackW", &handle_callbacks,
+					&session->callback_queue);
 	if (result != UDS_SUCCESS) {
 		uds_destroy_cond(&session->load_context.cond);
 		uds_destroy_mutex(&session->load_context.mutex);
@@ -296,7 +298,8 @@ static int __must_check start_loading_index_session(struct uds_index_session *in
 	return result;
 }
 
-static void finish_loading_index_session(struct uds_index_session *index_session, int result)
+static void finish_loading_index_session(struct uds_index_session *index_session,
+					 int result)
 {
 	uds_lock_mutex(&index_session->request_mutex);
 	index_session->state &= ~IS_FLAG_LOADING;
@@ -320,11 +323,8 @@ static int initialize_index_session(struct uds_index_session *index_session,
 	}
 
 	memset(&index_session->stats, 0, sizeof(index_session->stats));
-	result = uds_make_index(config,
-				open_type,
-				&index_session->load_context,
-				enter_callback_stage,
-				&index_session->index);
+	result = uds_make_index(config, open_type, &index_session->load_context,
+				enter_callback_stage, &index_session->index);
 	if (result != UDS_SUCCESS)
 		uds_log_error_strerror(result, "Failed to make index");
 	else
@@ -382,7 +382,8 @@ int uds_open_index(enum uds_open_index_type open_type,
 
 	result = initialize_index_session(session, open_type);
 	if (result != UDS_SUCCESS)
-		uds_log_error_strerror(result, "Failed %s", get_open_type_string(open_type));
+		uds_log_error_strerror(result, "Failed %s",
+				       get_open_type_string(open_type));
 
 	finish_loading_index_session(session, result);
 	return uds_map_to_system_error(result);
@@ -392,7 +393,8 @@ static void wait_for_no_requests_in_progress(struct uds_index_session *index_ses
 {
 	uds_lock_mutex(&index_session->request_mutex);
 	while (index_session->request_count > 0)
-		uds_wait_cond(&index_session->request_cond, &index_session->request_mutex);
+		uds_wait_cond(&index_session->request_cond,
+			      &index_session->request_mutex);
 	uds_unlock_mutex(&index_session->request_mutex);
 }
 
@@ -427,7 +429,8 @@ static void suspend_rebuild(struct uds_index_session *session)
 	case INDEX_FREEING:
 	default:
 		/* These cases should not happen. */
-		ASSERT_LOG_ONLY(false, "Bad load context state %u", session->load_context.status);
+		ASSERT_LOG_ONLY(false, "Bad load context state %u",
+				session->load_context.status);
 		break;
 	}
 	uds_unlock_mutex(&session->load_context.mutex);
@@ -500,7 +503,8 @@ static int replace_device(struct uds_index_session *session, struct block_device
  * Resume index operation after being suspended. If the index is suspended and the supplied block
  * device differs from the current backing store, the index will start using the new backing store.
  */
-int uds_resume_index_session(struct uds_index_session *session, struct block_device *bdev)
+int uds_resume_index_session(struct uds_index_session *session,
+			     struct block_device *bdev)
 {
 	int result = UDS_SUCCESS;
 	bool no_work = false;
@@ -554,8 +558,7 @@ int uds_resume_index_session(struct uds_index_session *session, struct block_dev
 		case INDEX_FREEING:
 		default:
 			/* These cases should not happen; do nothing. */
-			ASSERT_LOG_ONLY(false,
-					"Bad load context state %u",
+			ASSERT_LOG_ONLY(false, "Bad load context state %u",
 					session->load_context.status);
 			break;
 		}
@@ -586,7 +589,8 @@ static int save_and_free_index(struct uds_index_session *index_session)
 	if (!suspended) {
 		result = uds_save_index(index);
 		if (result != UDS_SUCCESS)
-			uds_log_warning_strerror(result, "ignoring error from save_index");
+			uds_log_warning_strerror(result,
+						 "ignoring error from save_index");
 	}
 	uds_free_index(index);
 	index_session->index = NULL;
@@ -616,7 +620,8 @@ int uds_close_index(struct uds_index_session *index_session)
 	uds_lock_mutex(&index_session->request_mutex);
 	while ((index_session->state & IS_FLAG_WAITING) ||
 	       (index_session->state & IS_FLAG_CLOSING))
-		uds_wait_cond(&index_session->request_cond, &index_session->request_mutex);
+		uds_wait_cond(&index_session->request_cond,
+			      &index_session->request_mutex);
 
 	if (index_session->state & IS_FLAG_SUSPENDED) {
 		uds_log_info("Index session is suspended");
@@ -656,7 +661,8 @@ int uds_destroy_index_session(struct uds_index_session *index_session)
 	uds_lock_mutex(&index_session->request_mutex);
 	while ((index_session->state & IS_FLAG_WAITING) ||
 	       (index_session->state & IS_FLAG_CLOSING))
-		uds_wait_cond(&index_session->request_cond, &index_session->request_mutex);
+		uds_wait_cond(&index_session->request_cond,
+			      &index_session->request_mutex);
 
 	if (index_session->state & IS_FLAG_DESTROYING) {
 		uds_unlock_mutex(&index_session->request_mutex);
@@ -681,7 +687,8 @@ int uds_destroy_index_session(struct uds_index_session *index_session)
 		/* Wait until the load exits before proceeding. */
 		uds_lock_mutex(&index_session->request_mutex);
 		while (index_session->state & IS_FLAG_LOADING)
-			uds_wait_cond(&index_session->request_cond, &index_session->request_mutex);
+			uds_wait_cond(&index_session->request_cond,
+				      &index_session->request_mutex);
 		uds_unlock_mutex(&index_session->request_mutex);
 	}
 
@@ -707,8 +714,8 @@ int uds_flush_index_session(struct uds_index_session *index_session)
 }
 
 /* Statistics collection is intended to be thread-safe. */
-static void
-collect_stats(const struct uds_index_session *index_session, struct uds_index_stats *stats)
+static void collect_stats(const struct uds_index_session *index_session,
+			  struct uds_index_stats *stats)
 {
 	const struct session_stats *session_stats = &index_session->stats;
 

--- a/drivers/md/dm-vdo/index.c
+++ b/drivers/md/dm-vdo/index.c
@@ -1163,7 +1163,7 @@ static int make_index_zone(struct uds_index *index, unsigned int zone_number)
 }
 
 int uds_make_index(struct configuration *config, enum uds_open_index_type open_type,
-		   struct index_load_context *load_context, index_callback_t callback,
+		   struct index_load_context *load_context, index_callback_fn callback,
 		   struct uds_index **new_index)
 {
 	int result;

--- a/drivers/md/dm-vdo/index.c
+++ b/drivers/md/dm-vdo/index.c
@@ -78,12 +78,11 @@ static bool is_zone_chapter_sparse(const struct index_zone *zone, u64 virtual_ch
 {
 	return uds_is_chapter_sparse(zone->index->volume->geometry,
 				     zone->oldest_virtual_chapter,
-				     zone->newest_virtual_chapter,
-				     virtual_chapter);
+				     zone->newest_virtual_chapter, virtual_chapter);
 }
 
-static int
-launch_zone_message(struct uds_zone_message message, unsigned int zone, struct uds_index *index)
+static int launch_zone_message(struct uds_zone_message message, unsigned int zone,
+			       struct uds_index *index)
 {
 	int result;
 	struct uds_request *request;
@@ -126,7 +125,8 @@ static u64 triage_index_request(struct uds_index *index, struct uds_request *req
 	u64 virtual_chapter;
 	struct index_zone *zone;
 
-	virtual_chapter = uds_lookup_volume_index_name(index->volume_index, &request->record_name);
+	virtual_chapter = uds_lookup_volume_index_name(index->volume_index,
+						       &request->record_name);
 	if (virtual_chapter == NO_CHAPTER)
 		return NO_CHAPTER;
 
@@ -147,8 +147,8 @@ static u64 triage_index_request(struct uds_index *index, struct uds_request *req
  * allows us to forgo the complicated locking required by a multi-zone sparse index. Any other kind
  * of index does nothing here.
  */
-static int
-simulate_index_zone_barrier_message(struct index_zone *zone, struct uds_request *request)
+static int simulate_index_zone_barrier_message(struct index_zone *zone,
+					       struct uds_request *request)
 {
 	u64 sparse_virtual_chapter;
 
@@ -187,7 +187,8 @@ static int finish_previous_chapter(struct uds_index *index, u64 current_chapter_
 	uds_unlock_mutex(&writer->mutex);
 
 	if (result != UDS_SUCCESS)
-		return uds_log_error_strerror(result, "Writing of previous open chapter failed");
+		return uds_log_error_strerror(result,
+					      "Writing of previous open chapter failed");
 
 	return UDS_SUCCESS;
 }
@@ -257,8 +258,7 @@ static int open_next_chapter(struct index_zone *zone)
 	u32 expire_chapters;
 
 	uds_log_debug("closing chapter %llu of zone %u after %u entries (%u short)",
-		      (unsigned long long) zone->newest_virtual_chapter,
-		      zone->id,
+		      (unsigned long long) zone->newest_virtual_chapter, zone->id,
 		      zone->open_chapter->size,
 		      zone->open_chapter->capacity - zone->open_chapter->size);
 
@@ -267,12 +267,12 @@ static int open_next_chapter(struct index_zone *zone)
 		return result;
 
 	closed_chapter = zone->newest_virtual_chapter++;
-	uds_set_volume_index_zone_open_chapter(zone->index->volume_index,
-					       zone->id,
+	uds_set_volume_index_zone_open_chapter(zone->index->volume_index, zone->id,
 					       zone->newest_virtual_chapter);
 	uds_reset_open_chapter(zone->open_chapter);
 
-	finished_zones = start_closing_chapter(zone->index, zone->id, zone->writing_chapter);
+	finished_zones = start_closing_chapter(zone->index, zone->id,
+					       zone->writing_chapter);
 	if ((finished_zones == 1) && (zone->index->zone_count > 1)) {
 		result = announce_chapter_closed(zone, closed_chapter);
 		if (result != UDS_SUCCESS)
@@ -319,7 +319,8 @@ static int dispatch_index_zone_control_request(struct uds_request *request)
 	}
 }
 
-static void set_request_location(struct uds_request *request, enum uds_index_region new_location)
+static void set_request_location(struct uds_request *request,
+				 enum uds_index_region new_location)
 {
 	request->location = new_location;
 	request->found = ((new_location == UDS_LOCATION_IN_OPEN_CHAPTER) ||
@@ -328,8 +329,7 @@ static void set_request_location(struct uds_request *request, enum uds_index_reg
 }
 
 static void set_chapter_location(struct uds_request *request,
-				 const struct index_zone *zone,
-				 u64 virtual_chapter)
+				 const struct index_zone *zone, u64 virtual_chapter)
 {
 	request->found = true;
 	if (virtual_chapter == zone->newest_virtual_chapter)
@@ -340,19 +340,15 @@ static void set_chapter_location(struct uds_request *request,
 		request->location = UDS_LOCATION_IN_DENSE;
 }
 
-static int search_sparse_cache_in_zone(struct index_zone *zone,
-				       struct uds_request *request,
-				       u64 virtual_chapter,
-				       bool *found)
+static int search_sparse_cache_in_zone(struct index_zone *zone, struct uds_request *request,
+				       u64 virtual_chapter, bool *found)
 {
 	int result;
 	struct volume *volume;
 	u16 record_page_number;
 	u32 chapter;
 
-	result = uds_search_sparse_cache(zone,
-					 &request->record_name,
-					 &virtual_chapter,
+	result = uds_search_sparse_cache(zone, &request->record_name, &virtual_chapter,
 					 &record_page_number);
 	if ((result != UDS_SUCCESS) || (virtual_chapter == NO_CHAPTER))
 		return result;
@@ -360,10 +356,12 @@ static int search_sparse_cache_in_zone(struct index_zone *zone,
 	request->virtual_chapter = virtual_chapter;
 	volume = zone->index->volume;
 	chapter = uds_map_to_physical_chapter(volume->geometry, virtual_chapter);
-	return uds_search_cached_record_page(volume, request, chapter, record_page_number, found);
+	return uds_search_cached_record_page(volume, request, chapter,
+					     record_page_number, found);
 }
 
-static int get_record_from_zone(struct index_zone *zone, struct uds_request *request, bool *found)
+static int get_record_from_zone(struct index_zone *zone, struct uds_request *request,
+				bool *found)
 {
 	struct volume *volume;
 
@@ -376,40 +374,36 @@ static int get_record_from_zone(struct index_zone *zone, struct uds_request *req
 	}
 
 	if (request->virtual_chapter == zone->newest_virtual_chapter) {
-		uds_search_open_chapter(zone->open_chapter,
-					&request->record_name,
-					&request->old_metadata,
-					found);
+		uds_search_open_chapter(zone->open_chapter, &request->record_name,
+					&request->old_metadata, found);
 		return UDS_SUCCESS;
 	}
 
 	if ((zone->newest_virtual_chapter > 0) &&
 	    (request->virtual_chapter == (zone->newest_virtual_chapter - 1)) &&
 	    (zone->writing_chapter->size > 0)) {
-		uds_search_open_chapter(zone->writing_chapter,
-					&request->record_name,
-					&request->old_metadata,
-					found);
+		uds_search_open_chapter(zone->writing_chapter, &request->record_name,
+					&request->old_metadata, found);
 		return UDS_SUCCESS;
 	}
 
 	volume = zone->index->volume;
 	if (is_zone_chapter_sparse(zone, request->virtual_chapter) &&
-	    uds_sparse_cache_contains(volume->sparse_cache,
-				      request->virtual_chapter,
+	    uds_sparse_cache_contains(volume->sparse_cache, request->virtual_chapter,
 				      request->zone_number))
-		return search_sparse_cache_in_zone(zone, request, request->virtual_chapter, found);
+		return search_sparse_cache_in_zone(zone, request,
+						   request->virtual_chapter, found);
 
 	return uds_search_volume_page_cache(volume, request, found);
 }
 
-static int put_record_in_zone(struct index_zone *zone,
-			      struct uds_request *request,
+static int put_record_in_zone(struct index_zone *zone, struct uds_request *request,
 			      const struct uds_record_data *metadata)
 {
 	unsigned int remaining;
 
-	remaining = uds_put_open_chapter(zone->open_chapter, &request->record_name, metadata);
+	remaining = uds_put_open_chapter(zone->open_chapter, &request->record_name,
+					 metadata);
 	if (remaining == 0)
 		return open_next_chapter(zone);
 
@@ -425,8 +419,7 @@ static int search_index_zone(struct index_zone *zone, struct uds_request *reques
 	u64 chapter;
 
 	result = uds_get_volume_index_record(zone->index->volume_index,
-					     &request->record_name,
-					     &record);
+					     &request->record_name, &record);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -482,7 +475,8 @@ static int search_index_zone(struct index_zone *zone, struct uds_request *reques
 		} else if (uds_is_sparse_geometry(zone->index->volume->geometry) &&
 			   !uds_is_volume_index_sample(zone->index->volume_index,
 						       &request->record_name)) {
-			result = search_sparse_cache_in_zone(zone, request, NO_CHAPTER, &found);
+			result = search_sparse_cache_in_zone(zone, request, NO_CHAPTER,
+							     &found);
 			if (result != UDS_SUCCESS)
 				return result;
 		}
@@ -531,8 +525,7 @@ static int remove_from_index_zone(struct index_zone *zone, struct uds_request *r
 	struct volume_index_record record;
 
 	result = uds_get_volume_index_record(zone->index->volume_index,
-					     &request->record_name,
-					     &record);
+					     &request->record_name, &record);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -624,8 +617,7 @@ static void execute_zone_request(struct uds_request *request)
 	if (request->zone_message.type != UDS_MESSAGE_NONE) {
 		result = dispatch_index_zone_control_request(request);
 		if (result != UDS_SUCCESS) {
-			uds_log_error_strerror(result,
-					       "error executing message: %d",
+			uds_log_error_strerror(result, "error executing message: %d",
 					       request->zone_message.type);
 		}
 
@@ -654,14 +646,14 @@ static void execute_zone_request(struct uds_request *request)
 	index->callback(request);
 }
 
-static int initialize_index_queues(struct uds_index *index, const struct geometry *geometry)
+static int initialize_index_queues(struct uds_index *index,
+				   const struct geometry *geometry)
 {
 	int result;
 	unsigned int i;
 
 	for (i = 0; i < index->zone_count; i++) {
-		result = uds_make_request_queue("indexW",
-						&execute_zone_request,
+		result = uds_make_request_queue("indexW", &execute_zone_request,
 						&index->zone_queues[i]);
 		if (result != UDS_SUCCESS)
 			return result;
@@ -669,7 +661,8 @@ static int initialize_index_queues(struct uds_index *index, const struct geometr
 
 	/* The triage queue is only needed for sparse multi-zone indexes. */
 	if ((index->zone_count > 1) && uds_is_sparse_geometry(geometry)) {
-		result = uds_make_request_queue("triageW", &triage_request, &index->triage_queue);
+		result = uds_make_request_queue("triageW", &triage_request,
+						&index->triage_queue);
 		if (result != UDS_SUCCESS)
 			return result;
 	}
@@ -720,8 +713,7 @@ static void close_chapters(void *arg)
 				uds_log_debug("Discarding saved open chapter");
 		}
 
-		result = uds_close_open_chapter(writer->chapters,
-						index->zone_count,
+		result = uds_close_open_chapter(writer->chapters, index->zone_count,
 						index->volume,
 						writer->open_chapter_index,
 						writer->collated_records,
@@ -768,17 +760,16 @@ static void free_chapter_writer(struct chapter_writer *writer)
 	uds_free(writer);
 }
 
-static int make_chapter_writer(struct uds_index *index, struct chapter_writer **writer_ptr)
+static int make_chapter_writer(struct uds_index *index,
+			       struct chapter_writer **writer_ptr)
 {
 	int result;
 	struct chapter_writer *writer;
 	size_t collated_records_size =
 		(sizeof(struct uds_volume_record) * index->volume->geometry->records_per_chapter);
 
-	result = uds_allocate_extended(struct chapter_writer,
-				       index->zone_count,
-				       struct open_chapter_zone *,
-				       "Chapter Writer",
+	result = uds_allocate_extended(struct chapter_writer, index->zone_count,
+				       struct open_chapter_zone *, "Chapter Writer",
 				       &writer);
 	if (result != UDS_SUCCESS)
 		return result;
@@ -797,8 +788,7 @@ static int make_chapter_writer(struct uds_index *index, struct chapter_writer **
 		return result;
 	}
 
-	result = uds_allocate_cache_aligned(collated_records_size,
-					    "collated records",
+	result = uds_allocate_cache_aligned(collated_records_size, "collated records",
 					    &writer->collated_records);
 	if (result != UDS_SUCCESS) {
 		free_chapter_writer(writer);
@@ -860,15 +850,13 @@ static int rebuild_index_page_map(struct uds_index *index, u64 vcn)
 	for (index_page_number = 0;
 	     index_page_number < geometry->index_pages_per_chapter;
 	     index_page_number++) {
-		result = uds_get_volume_index_page(index->volume,
-						   chapter,
+		result = uds_get_volume_index_page(index->volume, chapter,
 						   index_page_number,
 						   &chapter_index_page);
 		if (result != UDS_SUCCESS) {
 			return uds_log_error_strerror(result,
 						      "failed to read index page %u in chapter %u",
-						      index_page_number,
-						      chapter);
+						      index_page_number, chapter);
 		}
 
 		lowest_delta_list = chapter_index_page->lowest_list_number;
@@ -876,31 +864,26 @@ static int rebuild_index_page_map(struct uds_index *index, u64 vcn)
 		if (lowest_delta_list != expected_list_number) {
 			return uds_log_error_strerror(UDS_CORRUPT_DATA,
 						      "chapter %u index page %u is corrupt",
-						      chapter,
-						      index_page_number);
+						      chapter, index_page_number);
 		}
 
-		uds_update_index_page_map(index->volume->index_page_map,
-					  vcn,
-					  chapter,
-					  index_page_number,
-					  highest_delta_list);
+		uds_update_index_page_map(index->volume->index_page_map, vcn, chapter,
+					  index_page_number, highest_delta_list);
 		expected_list_number = highest_delta_list + 1;
 	}
 
 	return UDS_SUCCESS;
 }
 
-static int replay_record(struct uds_index *index,
-			 const struct uds_record_name *name,
-			 u64 virtual_chapter,
-			 bool will_be_sparse_chapter)
+static int replay_record(struct uds_index *index, const struct uds_record_name *name,
+			 u64 virtual_chapter, bool will_be_sparse_chapter)
 {
 	int result;
 	struct volume_index_record record;
 	bool update_record;
 
-	if (will_be_sparse_chapter && !uds_is_volume_index_sample(index->volume_index, name)) {
+	if (will_be_sparse_chapter &&
+	    !uds_is_volume_index_sample(index->volume_index, name)) {
 		/*
 		 * This entry will be in a sparse chapter after the rebuild completes, and it is
 		 * not a sample, so just skip over it.
@@ -1030,13 +1013,10 @@ static int replay_chapter(struct uds_index *index, u64 virtual, bool sparse)
 		u32 record_page_number;
 
 		record_page_number = geometry->index_pages_per_chapter + i;
-		result = uds_get_volume_record_page(index->volume,
-						    physical_chapter,
-						    record_page_number,
-						    &record_page);
+		result = uds_get_volume_record_page(index->volume, physical_chapter,
+						    record_page_number, &record_page);
 		if (result != UDS_SUCCESS) {
-			return uds_log_error_strerror(result,
-						      "could not get page %d",
+			return uds_log_error_strerror(result, "could not get page %d",
 						      record_page_number);
 		}
 
@@ -1083,8 +1063,7 @@ static int replay_volume(struct uds_index *index)
 	old_map_update = index->volume->index_page_map->last_update;
 	for (virtual = from_virtual; virtual < upto_virtual; virtual++) {
 		will_be_sparse = uds_is_chapter_sparse(index->volume->geometry,
-						       from_virtual,
-						       upto_virtual,
+						       from_virtual, upto_virtual,
 						       virtual);
 		result = replay_chapter(index, virtual, will_be_sparse);
 		if (result != UDS_SUCCESS)
@@ -1113,7 +1092,8 @@ static int rebuild_index(struct uds_index *index)
 	u32 chapters_per_volume = index->volume->geometry->chapters_per_volume;
 
 	index->volume->lookup_mode = LOOKUP_FOR_REBUILD;
-	result = uds_find_volume_chapter_boundaries(index->volume, &lowest, &highest, &is_empty);
+	result = uds_find_volume_chapter_boundaries(index->volume, &lowest, &highest,
+						    &is_empty);
 	if (result != UDS_SUCCESS) {
 		return uds_log_fatal_strerror(result,
 					      "cannot rebuild index: unknown volume chapter boundaries");
@@ -1161,16 +1141,14 @@ static int make_index_zone(struct uds_index *index, unsigned int zone_number)
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = uds_make_open_chapter(index->volume->geometry,
-				       index->zone_count,
+	result = uds_make_open_chapter(index->volume->geometry, index->zone_count,
 				       &zone->open_chapter);
 	if (result != UDS_SUCCESS) {
 		free_index_zone(zone);
 		return result;
 	}
 
-	result = uds_make_open_chapter(index->volume->geometry,
-				       index->zone_count,
+	result = uds_make_open_chapter(index->volume->geometry, index->zone_count,
 				       &zone->writing_chapter);
 	if (result != UDS_SUCCESS) {
 		free_index_zone(zone);
@@ -1184,10 +1162,8 @@ static int make_index_zone(struct uds_index *index, unsigned int zone_number)
 	return UDS_SUCCESS;
 }
 
-int uds_make_index(struct configuration *config,
-		   enum uds_open_index_type open_type,
-		   struct index_load_context *load_context,
-		   index_callback_t callback,
+int uds_make_index(struct configuration *config, enum uds_open_index_type open_type,
+		   struct index_load_context *load_context, index_callback_t callback,
 		   struct uds_index **new_index)
 {
 	int result;
@@ -1198,11 +1174,8 @@ int uds_make_index(struct configuration *config,
 	u64 nonce;
 	unsigned int z;
 
-	result = uds_allocate_extended(struct uds_index,
-				       config->zone_count,
-				       struct uds_request_queue *,
-				       "index",
-				       &index);
+	result = uds_allocate_extended(struct uds_index, config->zone_count,
+				       struct uds_request_queue *, "index", &index);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -1214,7 +1187,8 @@ int uds_make_index(struct configuration *config,
 		return result;
 	}
 
-	result = uds_allocate(index->zone_count, struct index_zone *, "zones", &index->zones);
+	result = uds_allocate(index->zone_count, struct index_zone *, "zones",
+			      &index->zones);
 	if (result != UDS_SUCCESS) {
 		uds_free_index(index);
 		return result;
@@ -1231,7 +1205,8 @@ int uds_make_index(struct configuration *config,
 		result = make_index_zone(index, z);
 		if (result != UDS_SUCCESS) {
 			uds_free_index(index);
-			return uds_log_error_strerror(result, "Could not create index zone");
+			return uds_log_error_strerror(result,
+						      "Could not create index zone");
 		}
 	}
 
@@ -1366,7 +1341,8 @@ int uds_save_index(struct uds_index *index)
 	} else {
 		index->has_saved_open_chapter = true;
 		index->need_to_save = false;
-		uds_log_info("finished save (vcn %llu)", (unsigned long long) index->last_save);
+		uds_log_info("finished save (vcn %llu)",
+			     (unsigned long long) index->last_save);
 	}
 
 	return result;

--- a/drivers/md/dm-vdo/index.c
+++ b/drivers/md/dm-vdo/index.c
@@ -453,20 +453,22 @@ static int search_index_zone(struct index_zone *zone, struct uds_request *reques
 	chapter = zone->newest_virtual_chapter;
 	if (found || overflow_record) {
 		if ((request->type == UDS_QUERY_NO_UPDATE) ||
-		    ((request->type == UDS_QUERY) && overflow_record))
+		    ((request->type == UDS_QUERY) && overflow_record)) {
 			/* There is nothing left to do. */
 			return UDS_SUCCESS;
+		}
 
-		if (record.virtual_chapter != chapter)
+		if (record.virtual_chapter != chapter) {
 			/*
 			 * Update the volume index to reference the new chapter for the block. If
 			 * the record had been deleted or dropped from the chapter index, it will
 			 * be back.
 			 */
 			result = uds_set_volume_index_record_chapter(&record, chapter);
-		else if (request->type != UDS_UPDATE)
+		} else if (request->type != UDS_UPDATE) {
 			/* The record is already in the open chapter. */
 			return UDS_SUCCESS;
+		}
 	} else {
 		/*
 		 * The record wasn't in the volume index, so check whether the
@@ -489,9 +491,10 @@ static int search_index_zone(struct index_zone *zone, struct uds_request *reques
 			set_request_location(request, UDS_LOCATION_IN_SPARSE);
 
 		if ((request->type == UDS_QUERY_NO_UPDATE) ||
-		    ((request->type == UDS_QUERY) && !found))
+		    ((request->type == UDS_QUERY) && !found)) {
 			/* There is nothing left to do. */
 			return UDS_SUCCESS;
+		}
 
 		/*
 		 * Add a new entry to the volume index referencing the open chapter. This needs to
@@ -500,22 +503,24 @@ static int search_index_zone(struct index_zone *zone, struct uds_request *reques
 		result = uds_put_volume_index_record(&record, chapter);
 	}
 
-	if (result == UDS_OVERFLOW)
+	if (result == UDS_OVERFLOW) {
 		/*
 		 * The volume index encountered a delta list overflow. The condition was already
 		 * logged. We will go on without adding the record to the open chapter.
 		 */
 		return UDS_SUCCESS;
+	}
 
 	if (result != UDS_SUCCESS)
 		return result;
 
-	if (!found || (request->type == UDS_UPDATE))
+	if (!found || (request->type == UDS_UPDATE)) {
 		/* This is a new record or we're updating an existing record. */
 		metadata = &request->new_metadata;
-	else
+	} else {
 		/* Move the existing record to the open chapter. */
 		metadata = &request->old_metadata;
+	}
 
 	return put_record_in_zone(zone, request, metadata);
 }
@@ -550,9 +555,10 @@ static int remove_from_index_zone(struct index_zone *zone, struct uds_request *r
 		if (result != UDS_SUCCESS)
 			return result;
 
-		if (!found)
+		if (!found) {
 			/* There is no record to remove. */
 			return UDS_SUCCESS;
+		}
 	}
 
 	set_chapter_location(request, zone, record.virtual_chapter);
@@ -617,10 +623,11 @@ static void execute_zone_request(struct uds_request *request)
 
 	if (request->zone_message.type != UDS_MESSAGE_NONE) {
 		result = dispatch_index_zone_control_request(request);
-		if (result != UDS_SUCCESS)
+		if (result != UDS_SUCCESS) {
 			uds_log_error_strerror(result,
 					       "error executing message: %d",
 					       request->zone_message.type);
+		}
 
 		/* Once the message is processed it can be freed. */
 		uds_free(uds_forget(request));
@@ -635,9 +642,10 @@ static void execute_zone_request(struct uds_request *request)
 	}
 
 	result = dispatch_index_request(index, request);
-	if (result == UDS_QUEUED)
+	if (result == UDS_QUEUED) {
 		/* The request has been requeued so don't let it complete. */
 		return;
+	}
 
 	if (!request->found)
 		set_request_location(request, UDS_LOCATION_UNAVAILABLE);
@@ -856,19 +864,21 @@ static int rebuild_index_page_map(struct uds_index *index, u64 vcn)
 						   chapter,
 						   index_page_number,
 						   &chapter_index_page);
-		if (result != UDS_SUCCESS)
+		if (result != UDS_SUCCESS) {
 			return uds_log_error_strerror(result,
 						      "failed to read index page %u in chapter %u",
 						      index_page_number,
 						      chapter);
+		}
 
 		lowest_delta_list = chapter_index_page->lowest_list_number;
 		highest_delta_list = chapter_index_page->highest_list_number;
-		if (lowest_delta_list != expected_list_number)
+		if (lowest_delta_list != expected_list_number) {
 			return uds_log_error_strerror(UDS_CORRUPT_DATA,
 						      "chapter %u index page %u is corrupt",
 						      chapter,
 						      index_page_number);
+		}
 
 		uds_update_index_page_map(index->volume->index_page_map,
 					  vcn,
@@ -890,12 +900,13 @@ static int replay_record(struct uds_index *index,
 	struct volume_index_record record;
 	bool update_record;
 
-	if (will_be_sparse_chapter && !uds_is_volume_index_sample(index->volume_index, name))
+	if (will_be_sparse_chapter && !uds_is_volume_index_sample(index->volume_index, name)) {
 		/*
 		 * This entry will be in a sparse chapter after the rebuild completes, and it is
 		 * not a sample, so just skip over it.
 		 */
 		return UDS_SUCCESS;
+	}
 
 	result = uds_get_volume_index_record(index->volume_index, name, &record);
 	if (result != UDS_SUCCESS)
@@ -903,9 +914,10 @@ static int replay_record(struct uds_index *index,
 
 	if (record.is_found) {
 		if (record.is_collision) {
-			if (record.virtual_chapter == virtual_chapter)
+			if (record.virtual_chapter == virtual_chapter) {
 				/* The record is already correct. */
 				return UDS_SUCCESS;
+			}
 
 			update_record = true;
 		} else if (record.virtual_chapter == virtual_chapter) {
@@ -937,13 +949,13 @@ static int replay_record(struct uds_index *index,
 		update_record = false;
 	}
 
-	if (update_record)
+	if (update_record) {
 		/*
 		 * Update the volume index to reference the new chapter for the block. If the
 		 * record had been deleted or dropped from the chapter index, it will be back.
 		 */
 		result = uds_set_volume_index_record_chapter(&record, virtual_chapter);
-	else
+	} else {
 		/*
 		 * Add a new entry to the volume index referencing the open chapter. This should be
 		 * done regardless of whether we are a brand new record or a sparse record, i.e.
@@ -951,10 +963,12 @@ static int replay_record(struct uds_index *index,
 		 * we would want to un-sparsify if it did exist.
 		 */
 		result = uds_put_volume_index_record(&record, virtual_chapter);
+	}
 
-	if ((result == UDS_DUPLICATE_NAME) || (result == UDS_OVERFLOW))
+	if ((result == UDS_DUPLICATE_NAME) || (result == UDS_OVERFLOW)) {
 		/* The rebuilt index will lose these records. */
 		return UDS_SUCCESS;
+	}
 
 	return result;
 }
@@ -1005,10 +1019,11 @@ static int replay_chapter(struct uds_index *index, u64 virtual, bool sparse)
 	uds_set_volume_index_open_chapter(index->volume_index, virtual);
 
 	result = rebuild_index_page_map(index, virtual);
-	if (result != UDS_SUCCESS)
+	if (result != UDS_SUCCESS) {
 		return uds_log_error_strerror(result,
 					      "could not rebuild index page map for chapter %u",
 					      physical_chapter);
+	}
 
 	for (i = 0; i < geometry->record_pages_per_chapter; i++) {
 		u8 *record_page;
@@ -1019,10 +1034,11 @@ static int replay_chapter(struct uds_index *index, u64 virtual, bool sparse)
 						    physical_chapter,
 						    record_page_number,
 						    &record_page);
-		if (result != UDS_SUCCESS)
+		if (result != UDS_SUCCESS) {
 			return uds_log_error_strerror(result,
 						      "could not get page %d",
 						      record_page_number);
+		}
 
 		for (j = 0; j < geometry->records_per_page; j++) {
 			const u8 *name_bytes;
@@ -1079,10 +1095,11 @@ static int replay_volume(struct uds_index *index)
 	uds_set_volume_index_open_chapter(index->volume_index, upto_virtual);
 
 	new_map_update = index->volume->index_page_map->last_update;
-	if (new_map_update != old_map_update)
+	if (new_map_update != old_map_update) {
 		uds_log_info("replay changed index page map update from %llu to %llu",
 			     (unsigned long long) old_map_update,
 			     (unsigned long long) new_map_update);
+	}
 
 	return UDS_SUCCESS;
 }
@@ -1097,9 +1114,10 @@ static int rebuild_index(struct uds_index *index)
 
 	index->volume->lookup_mode = LOOKUP_FOR_REBUILD;
 	result = uds_find_volume_chapter_boundaries(index->volume, &lowest, &highest, &is_empty);
-	if (result != UDS_SUCCESS)
+	if (result != UDS_SUCCESS) {
 		return uds_log_fatal_strerror(result,
 					      "cannot rebuild index: unknown volume chapter boundaries");
+	}
 
 	if (is_empty) {
 		index->newest_virtual_chapter = 0;
@@ -1110,9 +1128,11 @@ static int rebuild_index(struct uds_index *index)
 
 	index->newest_virtual_chapter = highest + 1;
 	index->oldest_virtual_chapter = lowest;
-	if (index->newest_virtual_chapter == (index->oldest_virtual_chapter + chapters_per_volume))
+	if (index->newest_virtual_chapter ==
+	    (index->oldest_virtual_chapter + chapters_per_volume)) {
 		/* Skip the chapter shadowed by the open chapter. */
 		index->oldest_virtual_chapter++;
+	}
 
 	result = replay_volume(index);
 	if (result != UDS_SUCCESS)
@@ -1251,9 +1271,10 @@ int uds_make_index(struct configuration *config,
 			uds_log_error_strerror(result, "index could not be loaded");
 			if (open_type == UDS_LOAD) {
 				result = rebuild_index(index);
-				if (result != UDS_SUCCESS)
+				if (result != UDS_SUCCESS) {
 					uds_log_error_strerror(result,
 							       "index could not be rebuilt");
+				}
 			}
 			break;
 		}

--- a/drivers/md/dm-vdo/index.c
+++ b/drivers/md/dm-vdo/index.c
@@ -1065,7 +1065,7 @@ static int replay_volume(struct uds_index *index)
 	 * Also, go through each index page for each chapter and rebuild the index page map.
 	 */
 	old_map_update = index->volume->index_page_map->last_update;
-	for (virtual = from_virtual; virtual < upto_virtual; ++virtual) {
+	for (virtual = from_virtual; virtual < upto_virtual; virtual++) {
 		will_be_sparse = uds_is_chapter_sparse(index->volume->geometry,
 						       from_virtual,
 						       upto_virtual,

--- a/drivers/md/dm-vdo/index.h
+++ b/drivers/md/dm-vdo/index.h
@@ -23,7 +23,7 @@
  * each zone usually operate without interference or coordination between zones.
  */
 
-typedef void (*index_callback_t)(struct uds_request *request);
+typedef void (*index_callback_fn)(struct uds_request *request);
 
 struct index_zone {
 	struct uds_index *index;
@@ -51,7 +51,7 @@ struct uds_index {
 	u64 prev_save;
 	struct chapter_writer *chapter_writer;
 
-	index_callback_t callback;
+	index_callback_fn callback;
 	struct uds_request_queue *triage_queue;
 	struct uds_request_queue *zone_queues[];
 };
@@ -65,7 +65,7 @@ enum request_stage {
 int __must_check uds_make_index(struct configuration *config,
 				enum uds_open_index_type open_type,
 				struct index_load_context *load_context,
-				index_callback_t callback, struct uds_index **new_index);
+				index_callback_fn callback, struct uds_index **new_index);
 
 int __must_check uds_save_index(struct uds_index *index);
 

--- a/drivers/md/dm-vdo/index.h
+++ b/drivers/md/dm-vdo/index.h
@@ -65,8 +65,7 @@ enum request_stage {
 int __must_check uds_make_index(struct configuration *config,
 				enum uds_open_index_type open_type,
 				struct index_load_context *load_context,
-				index_callback_t callback,
-				struct uds_index **new_index);
+				index_callback_t callback, struct uds_index **new_index);
 
 int __must_check uds_save_index(struct uds_index *index);
 

--- a/drivers/md/dm-vdo/io-factory.c
+++ b/drivers/md/dm-vdo/io-factory.c
@@ -217,7 +217,7 @@ static int reset_reader(struct buffered_reader *reader)
 
 	block_number = reader->block_number;
 	if (reader->end != NULL)
-		++block_number;
+		block_number++;
 
 	return position_reader(reader, block_number, 0);
 }

--- a/drivers/md/dm-vdo/io-factory.c
+++ b/drivers/md/dm-vdo/io-factory.c
@@ -94,21 +94,13 @@ size_t uds_get_writable_size(struct io_factory *factory)
 }
 
 /* Create a struct dm_bufio_client for an index region starting at offset. */
-int uds_make_bufio(struct io_factory *factory,
-		   off_t block_offset,
-		   size_t block_size,
-		   unsigned int reserved_buffers,
-		   struct dm_bufio_client **client_ptr)
+int uds_make_bufio(struct io_factory *factory, off_t block_offset, size_t block_size,
+		   unsigned int reserved_buffers, struct dm_bufio_client **client_ptr)
 {
 	struct dm_bufio_client *client;
 
-	client = dm_bufio_client_create(factory->bdev,
-					block_size,
-					reserved_buffers,
-					0,
-					NULL,
-					NULL,
-					0);
+	client = dm_bufio_client_create(factory->bdev, block_size, reserved_buffers, 0,
+					NULL, NULL, 0);
 	if (IS_ERR(client))
 		return -PTR_ERR(client);
 
@@ -120,8 +112,8 @@ int uds_make_bufio(struct io_factory *factory,
 static void read_ahead(struct buffered_reader *reader, sector_t block_number)
 {
 	if (block_number < reader->limit) {
-		sector_t read_ahead =
-			min((sector_t) MAX_READ_AHEAD_BLOCKS, reader->limit - block_number);
+		sector_t read_ahead = min((sector_t) MAX_READ_AHEAD_BLOCKS,
+					  reader->limit - block_number);
 
 		dm_bufio_prefetch(reader->client, block_number, read_ahead);
 	}
@@ -141,9 +133,7 @@ void uds_free_buffered_reader(struct buffered_reader *reader)
 }
 
 /* Create a buffered reader for an index region starting at offset. */
-int uds_make_buffered_reader(struct io_factory *factory,
-			     off_t offset,
-			     u64 block_count,
+int uds_make_buffered_reader(struct io_factory *factory, off_t offset, u64 block_count,
 			     struct buffered_reader **reader_ptr)
 {
 	int result;
@@ -176,7 +166,8 @@ int uds_make_buffered_reader(struct io_factory *factory,
 	return UDS_SUCCESS;
 }
 
-static int position_reader(struct buffered_reader *reader, sector_t block_number, off_t offset)
+static int position_reader(struct buffered_reader *reader, sector_t block_number,
+			   off_t offset)
 {
 	struct dm_buffer *buffer = NULL;
 	void *data;
@@ -222,7 +213,8 @@ static int reset_reader(struct buffered_reader *reader)
 	return position_reader(reader, block_number, 0);
 }
 
-int uds_read_from_buffered_reader(struct buffered_reader *reader, u8 *data, size_t length)
+int uds_read_from_buffered_reader(struct buffered_reader *reader, u8 *data,
+				  size_t length)
 {
 	int result = UDS_SUCCESS;
 	size_t chunk_size;
@@ -246,7 +238,8 @@ int uds_read_from_buffered_reader(struct buffered_reader *reader, u8 *data, size
  * Verify that the next data on the reader matches the required value. If the value matches, the
  * matching contents are consumed. If the value does not match, the reader state is unchanged.
  */
-int uds_verify_buffered_data(struct buffered_reader *reader, const u8 *value, size_t length)
+int uds_verify_buffered_data(struct buffered_reader *reader, const u8 *value,
+			     size_t length)
 {
 	int result = UDS_SUCCESS;
 	size_t chunk_size;
@@ -278,9 +271,7 @@ int uds_verify_buffered_data(struct buffered_reader *reader, const u8 *value, si
 }
 
 /* Create a buffered writer for an index region starting at offset. */
-int uds_make_buffered_writer(struct io_factory *factory,
-			     off_t offset,
-			     u64 block_count,
+int uds_make_buffered_writer(struct io_factory *factory, off_t offset, u64 block_count,
 			     struct buffered_writer **writer_ptr)
 {
 	int result;
@@ -385,7 +376,8 @@ void uds_free_buffered_writer(struct buffered_writer *writer)
  * Append data to the buffer, writing as needed. If no data is provided, zeros are written instead.
  * If a write error occurs, it is recorded and returned on every subsequent write attempt.
  */
-int uds_write_to_buffered_writer(struct buffered_writer *writer, const u8 *data, size_t length)
+int uds_write_to_buffered_writer(struct buffered_writer *writer, const u8 *data,
+				 size_t length)
 {
 	int result = writer->error;
 	size_t chunk_size;

--- a/drivers/md/dm-vdo/io-factory.h
+++ b/drivers/md/dm-vdo/io-factory.h
@@ -24,42 +24,40 @@ enum {
 	SECTORS_PER_BLOCK = UDS_BLOCK_SIZE >> SECTOR_SHIFT,
 };
 
-int __must_check uds_make_io_factory(struct block_device *bdev, struct io_factory **factory_ptr);
+int __must_check uds_make_io_factory(struct block_device *bdev,
+				     struct io_factory **factory_ptr);
 
-int __must_check uds_replace_storage(struct io_factory *factory, struct block_device *bdev);
+int __must_check uds_replace_storage(struct io_factory *factory,
+				     struct block_device *bdev);
 
 void uds_put_io_factory(struct io_factory *factory);
 
 size_t __must_check uds_get_writable_size(struct io_factory *factory);
 
-int __must_check uds_make_bufio(struct io_factory *factory,
-				off_t block_offset,
-				size_t block_size,
-				unsigned int reserved_buffers,
+int __must_check uds_make_bufio(struct io_factory *factory, off_t block_offset,
+				size_t block_size, unsigned int reserved_buffers,
 				struct dm_bufio_client **client_ptr);
 
-int __must_check uds_make_buffered_reader(struct io_factory *factory,
-					  off_t offset,
+int __must_check uds_make_buffered_reader(struct io_factory *factory, off_t offset,
 					  u64 block_count,
 					  struct buffered_reader **reader_ptr);
 
 void uds_free_buffered_reader(struct buffered_reader *reader);
 
-int __must_check
-uds_read_from_buffered_reader(struct buffered_reader *reader, u8 *data, size_t length);
+int __must_check uds_read_from_buffered_reader(struct buffered_reader *reader, u8 *data,
+					       size_t length);
 
-int __must_check
-uds_verify_buffered_data(struct buffered_reader *reader, const u8 *value, size_t length);
+int __must_check uds_verify_buffered_data(struct buffered_reader *reader, const u8 *value,
+					  size_t length);
 
-int __must_check uds_make_buffered_writer(struct io_factory *factory,
-					  off_t offset,
+int __must_check uds_make_buffered_writer(struct io_factory *factory, off_t offset,
 					  u64 block_count,
 					  struct buffered_writer **writer_ptr);
 
 void uds_free_buffered_writer(struct buffered_writer *buffer);
 
-int __must_check
-uds_write_to_buffered_writer(struct buffered_writer *writer, const u8 *data, size_t length);
+int __must_check uds_write_to_buffered_writer(struct buffered_writer *writer,
+					      const u8 *data, size_t length);
 
 int __must_check uds_flush_buffered_writer(struct buffered_writer *writer);
 

--- a/drivers/md/dm-vdo/io-submitter.c
+++ b/drivers/md/dm-vdo/io-submitter.c
@@ -47,14 +47,14 @@ struct io_submitter {
 
 static void start_bio_queue(void *ptr)
 {
-	struct bio_queue_data *bio_queue_data = (struct bio_queue_data *) ptr;
+	struct bio_queue_data *bio_queue_data = ptr;
 
 	blk_start_plug(&bio_queue_data->plug);
 }
 
 static void finish_bio_queue(void *ptr)
 {
-	struct bio_queue_data *bio_queue_data = (struct bio_queue_data *) ptr;
+	struct bio_queue_data *bio_queue_data = ptr;
 
 	blk_finish_plug(&bio_queue_data->plug);
 }

--- a/drivers/md/dm-vdo/io-submitter.c
+++ b/drivers/md/dm-vdo/io-submitter.c
@@ -189,7 +189,8 @@ static void process_data_vio_io(struct vdo_completion *completion)
  *
  * Return: the vio to merge to, NULL if no merging is possible.
  */
-static struct vio *get_mergeable_locked(struct int_map *map, struct vio *vio, bool back_merge)
+static struct vio *get_mergeable_locked(struct int_map *map, struct vio *vio,
+					bool back_merge)
 {
 	struct bio *bio = vio->bio;
 	sector_t merge_sector = get_bio_sector(bio);
@@ -214,33 +215,38 @@ static struct vio *get_mergeable_locked(struct int_map *map, struct vio *vio, bo
 	if (bio_list_empty(&vio_merge->bios_merged))
 		return NULL;
 
-	if (back_merge)
-		return ((get_bio_sector(vio_merge->bios_merged.tail) == merge_sector) ?
-			vio_merge :
-			NULL);
+	if (back_merge) {
+		return (get_bio_sector(vio_merge->bios_merged.tail) == merge_sector ?
+			vio_merge : NULL);
+	}
 
-	return ((get_bio_sector(vio_merge->bios_merged.head) == merge_sector) ? vio_merge : NULL);
+	return (get_bio_sector(vio_merge->bios_merged.head) == merge_sector ?
+		vio_merge : NULL);
 }
 
 static int map_merged_vio(struct int_map *bio_map, struct vio *vio)
 {
 	int result;
 
-	result = vdo_int_map_put(bio_map, get_bio_sector(vio->bios_merged.head), vio, true, NULL);
+	result = vdo_int_map_put(bio_map, get_bio_sector(vio->bios_merged.head), vio,
+				 true, NULL);
 	if (result != VDO_SUCCESS)
 		return result;
 
-	return vdo_int_map_put(bio_map, get_bio_sector(vio->bios_merged.tail), vio, true, NULL);
+	return vdo_int_map_put(bio_map, get_bio_sector(vio->bios_merged.tail), vio, true,
+			       NULL);
 }
 
-static int merge_to_prev_tail(struct int_map *bio_map, struct vio *vio, struct vio *prev_vio)
+static int merge_to_prev_tail(struct int_map *bio_map, struct vio *vio,
+			      struct vio *prev_vio)
 {
 	vdo_int_map_remove(bio_map, get_bio_sector(prev_vio->bios_merged.tail));
 	bio_list_merge(&prev_vio->bios_merged, &vio->bios_merged);
 	return map_merged_vio(bio_map, prev_vio);
 }
 
-static int merge_to_next_head(struct int_map *bio_map, struct vio *vio, struct vio *next_vio)
+static int merge_to_next_head(struct int_map *bio_map, struct vio *vio,
+			      struct vio *next_vio)
 {
 	/*
 	 * Handle "next merge" and "gap fill" cases the same way so as to reorder bios in a way
@@ -285,9 +291,7 @@ static bool try_bio_map_merge(struct vio *vio)
 		merged = false;
 		result = vdo_int_map_put(bio_queue_data->map,
 					 get_bio_sector(bio),
-					 vio,
-					 true,
-					 NULL);
+					 vio, true, NULL);
 	} else if (next_vio == NULL) {
 		/* Only prev. merge to prev's tail */
 		result = merge_to_prev_tail(bio_queue_data->map, vio, prev_vio);
@@ -295,7 +299,6 @@ static bool try_bio_map_merge(struct vio *vio)
 		/* Only next. merge to next's head */
 		result = merge_to_next_head(bio_queue_data->map, vio, next_vio);
 	}
-
 	mutex_unlock(&bio_queue_data->lock);
 
 	/* We don't care about failure of int_map_put in this case. */
@@ -335,12 +338,9 @@ void submit_data_vio_io(struct data_vio *data_vio)
  * no error can occur on the bio queue. Currently this is true for all callers, but additional care
  * will be needed if this ever changes.
  */
-void vdo_submit_metadata_io(struct vio *vio,
-			    physical_block_number_t physical,
-			    bio_end_io_t callback,
-			    vdo_action *error_handler,
-			    unsigned int operation,
-			    char *data)
+void vdo_submit_metadata_io(struct vio *vio, physical_block_number_t physical,
+			    bio_end_io_t callback, vdo_action *error_handler,
+			    unsigned int operation, char *data)
 {
 	struct vdo_completion *completion = &vio->completion;
 	int result;
@@ -358,7 +358,8 @@ void vdo_submit_metadata_io(struct vio *vio,
 		return;
 	}
 
-	vdo_set_completion_callback(completion, process_vio_io, get_vio_bio_zone_thread_id(vio));
+	vdo_set_completion_callback(completion, process_vio_io,
+				    get_vio_bio_zone_thread_id(vio));
 	vdo_launch_completion_with_priority(completion, get_metadata_priority(vio));
 }
 
@@ -373,20 +374,16 @@ void vdo_submit_metadata_io(struct vio *vio,
  *
  * Return: VDO_SUCCESS or an error.
  */
-int vdo_make_io_submitter(unsigned int thread_count,
-			  unsigned int rotation_interval,
-			  unsigned int max_requests_active,
-			  struct vdo *vdo,
+int vdo_make_io_submitter(unsigned int thread_count, unsigned int rotation_interval,
+			  unsigned int max_requests_active, struct vdo *vdo,
 			  struct io_submitter **io_submitter_ptr)
 {
 	unsigned int i;
 	struct io_submitter *io_submitter;
 	int result;
 
-	result = uds_allocate_extended(struct io_submitter,
-				       thread_count,
-				       struct bio_queue_data,
-				       "bio submission data",
+	result = uds_allocate_extended(struct io_submitter, thread_count,
+				       struct bio_queue_data, "bio submission data",
 				       &io_submitter);
 	if (result != UDS_SUCCESS)
 		return result;
@@ -406,7 +403,8 @@ int vdo_make_io_submitter(unsigned int thread_count,
 		 * uneven. So for now, we'll assume that all requests *may* wind up on one thread,
 		 * and thus all in the same map.
 		 */
-		result = vdo_make_int_map(max_requests_active * 2, 0, &bio_queue_data->map);
+		result = vdo_make_int_map(max_requests_active * 2, 0,
+					  &bio_queue_data->map);
 		if (result != 0) {
 			/*
 			 * Clean up the partially initialized bio-queue entirely and indicate that
@@ -419,11 +417,8 @@ int vdo_make_io_submitter(unsigned int thread_count,
 		}
 
 		bio_queue_data->queue_number = i;
-		result = vdo_make_thread(vdo,
-					 vdo->thread_config.bio_threads[i],
-					 &bio_queue_type,
-					 1,
-					 (void **) &bio_queue_data);
+		result = vdo_make_thread(vdo, vdo->thread_config.bio_threads[i],
+					 &bio_queue_type, 1, (void **) &bio_queue_data);
 		if (result != VDO_SUCCESS) {
 			/*
 			 * Clean up the partially initialized bio-queue entirely and indicate that

--- a/drivers/md/dm-vdo/io-submitter.c
+++ b/drivers/md/dm-vdo/io-submitter.c
@@ -215,13 +215,12 @@ static struct vio *get_mergeable_locked(struct int_map *map, struct vio *vio,
 	if (bio_list_empty(&vio_merge->bios_merged))
 		return NULL;
 
-	if (back_merge) {
-		return (get_bio_sector(vio_merge->bios_merged.tail) == merge_sector ?
-			vio_merge : NULL);
-	}
+	if (back_merge)
+		return ((get_bio_sector(vio_merge->bios_merged.tail) == merge_sector) ?
+			vio_merge :
+			NULL);
 
-	return (get_bio_sector(vio_merge->bios_merged.head) == merge_sector ?
-		vio_merge : NULL);
+	return ((get_bio_sector(vio_merge->bios_merged.head) == merge_sector) ? vio_merge : NULL);
 }
 
 static int map_merged_vio(struct int_map *bio_map, struct vio *vio)
@@ -289,9 +288,8 @@ static bool try_bio_map_merge(struct vio *vio)
 	if ((prev_vio == NULL) && (next_vio == NULL)) {
 		/* no merge. just add to bio_queue */
 		merged = false;
-		result = vdo_int_map_put(bio_queue_data->map,
-					 get_bio_sector(bio),
-					 vio, true, NULL);
+		result = vdo_int_map_put(bio_queue_data->map, get_bio_sector(bio), vio,
+					 true, NULL);
 	} else if (next_vio == NULL) {
 		/* Only prev. merge to prev's tail */
 		result = merge_to_prev_tail(bio_queue_data->map, vio, prev_vio);
@@ -299,6 +297,7 @@ static bool try_bio_map_merge(struct vio *vio)
 		/* Only next. merge to next's head */
 		result = merge_to_next_head(bio_queue_data->map, vio, next_vio);
 	}
+
 	mutex_unlock(&bio_queue_data->lock);
 
 	/* We don't care about failure of int_map_put in this case. */
@@ -339,7 +338,7 @@ void submit_data_vio_io(struct data_vio *data_vio)
  * will be needed if this ever changes.
  */
 void vdo_submit_metadata_io(struct vio *vio, physical_block_number_t physical,
-			    bio_end_io_t callback, vdo_action *error_handler,
+			    bio_end_io_t callback, vdo_action_fn error_handler,
 			    unsigned int operation, char *data)
 {
 	struct vdo_completion *completion = &vio->completion;

--- a/drivers/md/dm-vdo/io-submitter.c
+++ b/drivers/md/dm-vdo/io-submitter.c
@@ -267,7 +267,8 @@ static bool try_bio_map_merge(struct vio *vio)
 	struct bio *bio = vio->bio;
 	struct vio *prev_vio, *next_vio;
 	struct vdo *vdo = vio->completion.vdo;
-	struct bio_queue_data *bio_queue_data = &vdo->io_submitter->bio_queue_data[vio->bio_zone];
+	struct bio_queue_data *bio_queue_data =
+		&vdo->io_submitter->bio_queue_data[vio->bio_zone];
 
 	bio->bi_next = NULL;
 	bio_list_init(&vio->bios_merged);

--- a/drivers/md/dm-vdo/io-submitter.h
+++ b/drivers/md/dm-vdo/io-submitter.h
@@ -12,10 +12,8 @@
 
 struct io_submitter;
 
-int vdo_make_io_submitter(unsigned int thread_count,
-			  unsigned int rotation_interval,
-			  unsigned int max_requests_active,
-			  struct vdo *vdo,
+int vdo_make_io_submitter(unsigned int thread_count, unsigned int rotation_interval,
+			  unsigned int max_requests_active, struct vdo *vdo,
 			  struct io_submitter **io_submitter);
 
 void vdo_cleanup_io_submitter(struct io_submitter *io_submitter);
@@ -26,27 +24,24 @@ void process_vio_io(struct vdo_completion *completion);
 
 void submit_data_vio_io(struct data_vio *data_vio);
 
-void vdo_submit_metadata_io(struct vio *vio,
-			    physical_block_number_t physical,
-			    bio_end_io_t callback,
-			    vdo_action *error_handler,
-			    unsigned int operation,
-			    char *data);
+void vdo_submit_metadata_io(struct vio *vio, physical_block_number_t physical,
+			    bio_end_io_t callback, vdo_action *error_handler,
+			    unsigned int operation, char *data);
 
-static inline void submit_metadata_vio(struct vio *vio,
-				       physical_block_number_t physical,
-				       bio_end_io_t callback,
-				       vdo_action *error_handler,
+static inline void submit_metadata_vio(struct vio *vio, physical_block_number_t physical,
+				       bio_end_io_t callback, vdo_action *error_handler,
 				       unsigned int operation)
 {
-	vdo_submit_metadata_io(vio, physical, callback, error_handler, operation, vio->data);
+	vdo_submit_metadata_io(vio, physical, callback, error_handler,
+			       operation, vio->data);
 }
 
-static inline void
-submit_flush_vio(struct vio *vio, bio_end_io_t callback, vdo_action *error_handler)
+static inline void submit_flush_vio(struct vio *vio, bio_end_io_t callback,
+				    vdo_action *error_handler)
 {
 	/* FIXME: Can we just use REQ_OP_FLUSH? */
-	vdo_submit_metadata_io(vio, 0, callback, error_handler, REQ_OP_WRITE | REQ_PREFLUSH, NULL);
+	vdo_submit_metadata_io(vio, 0, callback, error_handler,
+			       REQ_OP_WRITE | REQ_PREFLUSH, NULL);
 }
 
 #endif /* VDO_IO_SUBMITTER_H */

--- a/drivers/md/dm-vdo/io-submitter.h
+++ b/drivers/md/dm-vdo/io-submitter.h
@@ -25,19 +25,19 @@ void process_vio_io(struct vdo_completion *completion);
 void submit_data_vio_io(struct data_vio *data_vio);
 
 void vdo_submit_metadata_io(struct vio *vio, physical_block_number_t physical,
-			    bio_end_io_t callback, vdo_action *error_handler,
+			    bio_end_io_t callback, vdo_action_fn error_handler,
 			    unsigned int operation, char *data);
 
 static inline void submit_metadata_vio(struct vio *vio, physical_block_number_t physical,
-				       bio_end_io_t callback, vdo_action *error_handler,
+				       bio_end_io_t callback, vdo_action_fn error_handler,
 				       unsigned int operation)
 {
-	vdo_submit_metadata_io(vio, physical, callback, error_handler,
-			       operation, vio->data);
+	vdo_submit_metadata_io(vio, physical, callback, error_handler, operation,
+			       vio->data);
 }
 
 static inline void submit_flush_vio(struct vio *vio, bio_end_io_t callback,
-				    vdo_action *error_handler)
+				    vdo_action_fn error_handler)
 {
 	/* FIXME: Can we just use REQ_OP_FLUSH? */
 	vdo_submit_metadata_io(vio, 0, callback, error_handler,

--- a/drivers/md/dm-vdo/logger.c
+++ b/drivers/md/dm-vdo/logger.c
@@ -159,11 +159,8 @@ static void emit_log_message_to_kernel(int priority, const char *fmt, ...)
  * @vaf1: The first message format descriptor
  * @vaf2: The second message format descriptor
  */
-static void emit_log_message(int priority,
-			     const char *module,
-			     const char *prefix,
-			     const struct va_format *vaf1,
-			     const struct va_format *vaf2)
+static void emit_log_message(int priority, const char *module, const char *prefix,
+			     const struct va_format *vaf1, const struct va_format *vaf2)
 {
 	int device_instance;
 
@@ -174,19 +171,17 @@ static void emit_log_message(int priority,
 	if (in_interrupt()) {
 		const char *type = get_current_interrupt_type();
 
-		emit_log_message_to_kernel(priority,
-					   "%s[%s]: %s%pV%pV\n",
-					   module, type, prefix, vaf1, vaf2);
+		emit_log_message_to_kernel(priority, "%s[%s]: %s%pV%pV\n", module, type,
+					   prefix, vaf1, vaf2);
 		return;
 	}
 
 	/* Not at interrupt level; we have a process we can look at, and might have a device ID. */
 	device_instance = uds_get_thread_device_id();
 	if (device_instance >= 0) {
-		emit_log_message_to_kernel(priority,
-					   "%s%u:%s: %s%pV%pV\n",
-					   module, device_instance,
-					   current->comm, prefix, vaf1, vaf2);
+		emit_log_message_to_kernel(priority, "%s%u:%s: %s%pV%pV\n", module,
+					   device_instance, current->comm, prefix, vaf1,
+					   vaf2);
 		return;
 	}
 
@@ -196,16 +191,14 @@ static void emit_log_message(int priority,
 	 */
 	if (((current->flags & PF_KTHREAD) != 0) &&
 	    (strncmp(module, current->comm, strlen(module)) == 0)) {
-		emit_log_message_to_kernel(priority,
-					   "%s: %s%pV%pV\n",
-					   current->comm, prefix, vaf1, vaf2);
+		emit_log_message_to_kernel(priority, "%s: %s%pV%pV\n", current->comm,
+					   prefix, vaf1, vaf2);
 		return;
 	}
 
 	/* Identify the module and the process. */
-	emit_log_message_to_kernel(priority,
-				   "%s: %s: %s%pV%pV\n",
-				   module, current->comm, prefix, vaf1, vaf2);
+	emit_log_message_to_kernel(priority, "%s: %s: %s%pV%pV\n", module, current->comm,
+				   prefix, vaf1, vaf2);
 }
 
 /*
@@ -217,13 +210,8 @@ static void emit_log_message(int priority,
  * @args1: arguments for message first part (required)
  * @fmt2: format of message second part
  */
-void uds_log_embedded_message(int priority,
-			      const char *module,
-			      const char *prefix,
-			      const char *fmt1,
-			      va_list args1,
-			      const char *fmt2,
-			      ...)
+void uds_log_embedded_message(int priority, const char *module, const char *prefix,
+			      const char *fmt1, va_list args1, const char *fmt2, ...)
 {
 	va_list args1_copy;
 	va_list args2;
@@ -255,23 +243,14 @@ void uds_log_embedded_message(int priority,
 	va_end(args2);
 }
 
-int uds_vlog_strerror(int priority,
-		      int errnum,
-		      const char *module,
-		      const char *format,
+int uds_vlog_strerror(int priority, int errnum, const char *module, const char *format,
 		      va_list args)
 {
 	char errbuf[UDS_MAX_ERROR_MESSAGE_SIZE];
 	const char *message = uds_string_error(errnum, errbuf, sizeof(errbuf));
 
-	uds_log_embedded_message(priority,
-				 module,
-				 NULL,
-				 format,
-				 args,
-				 ": %s (%d)",
-				 message,
-				 errnum);
+	uds_log_embedded_message(priority, module, NULL, format, args, ": %s (%d)",
+				 message, errnum);
 	return errnum;
 }
 

--- a/drivers/md/dm-vdo/logger.c
+++ b/drivers/md/dm-vdo/logger.c
@@ -63,9 +63,11 @@ int uds_log_string_to_priority(const char *string)
 {
 	int i;
 
-	for (i = 0; PRIORITIES[i].name != NULL; i++)
+	for (i = 0; PRIORITIES[i].name != NULL; i++) {
 		if (strcasecmp(string, PRIORITIES[i].name) == 0)
 			return PRIORITIES[i].priority;
+	}
+
 	return UDS_LOG_INFO;
 }
 
@@ -73,6 +75,7 @@ const char *uds_log_priority_to_string(int priority)
 {
 	if ((priority < 0) || (priority >= (int) ARRAY_SIZE(PRIORITY_STRINGS)))
 		return "unknown";
+
 	return PRIORITY_STRINGS[priority];
 }
 
@@ -80,10 +83,13 @@ static const char *get_current_interrupt_type(void)
 {
 	if (in_nmi())
 		return "NMI";
+
 	if (in_irq())
 		return "HI";
+
 	if (in_softirq())
 		return "SI";
+
 	return "INTR";
 }
 
@@ -227,6 +233,7 @@ void uds_log_embedded_message(int priority,
 
 	if (module == NULL)
 		module = UDS_LOGGING_MODULE_NAME;
+
 	if (prefix == NULL)
 		prefix = "";
 
@@ -282,6 +289,7 @@ void uds_log_backtrace(int priority)
 {
 	if (priority > uds_get_log_level())
 		return;
+
 	dump_stack();
 }
 

--- a/drivers/md/dm-vdo/logger.h
+++ b/drivers/md/dm-vdo/logger.h
@@ -45,13 +45,8 @@ int uds_log_string_to_priority(const char *string);
 
 const char *uds_log_priority_to_string(int priority);
 
-void uds_log_embedded_message(int priority,
-			      const char *module,
-			      const char *prefix,
-			      const char *fmt1,
-			      va_list args1,
-			      const char *fmt2,
-			      ...)
+void uds_log_embedded_message(int priority, const char *module, const char *prefix,
+			      const char *fmt1, va_list args1, const char *fmt2, ...)
 	__printf(4, 0) __printf(6, 7);
 
 void uds_log_backtrace(int priority);
@@ -61,13 +56,11 @@ void uds_log_backtrace(int priority);
 #define uds_log_strerror(priority, errnum, ...) \
 	__uds_log_strerror(priority, errnum, UDS_LOGGING_MODULE_NAME, __VA_ARGS__)
 
-int __uds_log_strerror(int priority, int errnum, const char *module, const char *format, ...)
+int __uds_log_strerror(int priority, int errnum, const char *module,
+		       const char *format, ...)
 	__printf(4, 5);
 
-int uds_vlog_strerror(int priority,
-		      int errnum,
-		      const char *module,
-		      const char *format,
+int uds_vlog_strerror(int priority, int errnum, const char *module, const char *format,
 		      va_list args)
 	__printf(4, 0);
 

--- a/drivers/md/dm-vdo/logical-zone.c
+++ b/drivers/md/dm-vdo/logical-zone.c
@@ -64,7 +64,8 @@ static int initialize_zone(struct logical_zones *zones, zone_count_t zone_number
 	if (zone_number < vdo->thread_config.logical_zone_count - 1)
 		zone->next = &zones->zones[zone_number + 1];
 
-	vdo_initialize_completion(&zone->completion, vdo, VDO_GENERATION_FLUSHED_COMPLETION);
+	vdo_initialize_completion(&zone->completion, vdo,
+				  VDO_GENERATION_FLUSHED_COMPLETION);
 	zone->zones = zones;
 	zone->zone_number = zone_number;
 	zone->thread_id = vdo->thread_config.logical_threads[zone_number];
@@ -110,13 +111,9 @@ int vdo_make_logical_zones(struct vdo *vdo, struct logical_zones **zones_ptr)
 		}
 	}
 
-	result = vdo_make_action_manager(zones->zone_count,
-					 get_thread_id_for_zone,
-					 vdo->thread_config.admin_thread,
-					 zones,
-					 NULL,
-					 vdo,
-					 &zones->manager);
+	result = vdo_make_action_manager(zones->zone_count, get_thread_id_for_zone,
+					 vdo->thread_config.admin_thread, zones, NULL,
+					 vdo, &zones->manager);
 	if (result != VDO_SUCCESS) {
 		vdo_free_logical_zones(zones);
 		return result;
@@ -179,14 +176,13 @@ static void initiate_drain(struct admin_state *state)
  *
  * Implements vdo_zone_action.
  */
-static void
-drain_logical_zone(void *context, zone_count_t zone_number, struct vdo_completion *parent)
+static void drain_logical_zone(void *context, zone_count_t zone_number,
+			       struct vdo_completion *parent)
 {
 	struct logical_zones *zones = context;
 
 	vdo_start_draining(&zones->zones[zone_number].state,
-			   vdo_get_current_manager_operation(zones->manager),
-			   parent,
+			   vdo_get_current_manager_operation(zones->manager), parent,
 			   initiate_drain);
 }
 
@@ -194,7 +190,8 @@ void vdo_drain_logical_zones(struct logical_zones *zones,
 			     const struct admin_state_code *operation,
 			     struct vdo_completion *parent)
 {
-	vdo_schedule_operation(zones->manager, operation, NULL, drain_logical_zone, NULL, parent);
+	vdo_schedule_operation(zones->manager, operation, NULL, drain_logical_zone, NULL,
+			       parent);
 }
 
 /**
@@ -202,8 +199,8 @@ void vdo_drain_logical_zones(struct logical_zones *zones,
  *
  * Implements vdo_zone_action.
  */
-static void
-resume_logical_zone(void *context, zone_count_t zone_number, struct vdo_completion *parent)
+static void resume_logical_zone(void *context, zone_count_t zone_number,
+				struct vdo_completion *parent)
 {
 	struct logical_zone *zone = &(((struct logical_zones *) context)->zones[zone_number]);
 
@@ -230,7 +227,8 @@ void vdo_resume_logical_zones(struct logical_zones *zones, struct vdo_completion
 static bool update_oldest_active_generation(struct logical_zone *zone)
 {
 	struct data_vio *data_vio =
-		list_first_entry_or_null(&zone->write_vios, struct data_vio, write_entry);
+		list_first_entry_or_null(&zone->write_vios, struct data_vio,
+					 write_entry);
 	sequence_number_t oldest =
 		(data_vio == NULL) ? zone->flush_generation : data_vio->flush_generation;
 
@@ -253,8 +251,7 @@ void vdo_increment_logical_zone_flush_generation(struct logical_zone *zone,
 	assert_on_zone_thread(zone, __func__);
 	ASSERT_LOG_ONLY((zone->flush_generation == expected_generation),
 			"logical zone %u flush generation %llu should be %llu before increment",
-			zone->zone_number,
-			(unsigned long long) zone->flush_generation,
+			zone->zone_number, (unsigned long long) zone->flush_generation,
 			(unsigned long long) expected_generation);
 
 	zone->flush_generation++;

--- a/drivers/md/dm-vdo/logical-zone.c
+++ b/drivers/md/dm-vdo/logical-zone.c
@@ -37,7 +37,7 @@ static struct logical_zone *as_logical_zone(struct vdo_completion *completion)
 	return container_of(completion, struct logical_zone, completion);
 }
 
-/* get_thread_id_for_zone() - Implements vdo_zone_thread_getter. */
+/* get_thread_id_for_zone() - Implements vdo_zone_thread_getter_fn. */
 static thread_id_t get_thread_id_for_zone(void *context, zone_count_t zone_number)
 {
 	struct logical_zones *zones = context;
@@ -164,7 +164,7 @@ static void check_for_drain_complete(struct logical_zone *zone)
 /**
  * initiate_drain() - Initiate a drain.
  *
- * Implements vdo_admin_initiator.
+ * Implements vdo_admin_initiator_fn.
  */
 static void initiate_drain(struct admin_state *state)
 {
@@ -174,7 +174,7 @@ static void initiate_drain(struct admin_state *state)
 /**
  * drain_logical_zone() - Drain a logical zone.
  *
- * Implements vdo_zone_action.
+ * Implements vdo_zone_action_fn.
  */
 static void drain_logical_zone(void *context, zone_count_t zone_number,
 			       struct vdo_completion *parent)
@@ -197,7 +197,7 @@ void vdo_drain_logical_zones(struct logical_zones *zones,
 /**
  * resume_logical_zone() - Resume a logical zone.
  *
- * Implements vdo_zone_action.
+ * Implements vdo_zone_action_fn.
  */
 static void resume_logical_zone(void *context, zone_count_t zone_number,
 				struct vdo_completion *parent)

--- a/drivers/md/dm-vdo/logical-zone.h
+++ b/drivers/md/dm-vdo/logical-zone.h
@@ -63,7 +63,8 @@ struct logical_zones {
 	struct logical_zone zones[];
 };
 
-int __must_check vdo_make_logical_zones(struct vdo *vdo, struct logical_zones **zones_ptr);
+int __must_check vdo_make_logical_zones(struct vdo *vdo,
+					struct logical_zones **zones_ptr);
 
 void vdo_free_logical_zones(struct logical_zones *zones);
 
@@ -71,7 +72,8 @@ void vdo_drain_logical_zones(struct logical_zones *zones,
 			     const struct admin_state_code *operation,
 			     struct vdo_completion *completion);
 
-void vdo_resume_logical_zones(struct logical_zones *zones, struct vdo_completion *parent);
+void vdo_resume_logical_zones(struct logical_zones *zones,
+			      struct vdo_completion *parent);
 
 void vdo_increment_logical_zone_flush_generation(struct logical_zone *zone,
 						 sequence_number_t expected_generation);

--- a/drivers/md/dm-vdo/memory-alloc.c
+++ b/drivers/md/dm-vdo/memory-alloc.c
@@ -39,7 +39,8 @@ static bool allocations_allowed(void)
  * @new_thread: registered_thread structure to use for the current thread
  * @flag_ptr: Location of the allocation-allowed flag
  */
-void uds_register_allocating_thread(struct registered_thread *new_thread, const bool *flag_ptr)
+void uds_register_allocating_thread(struct registered_thread *new_thread,
+				    const bool *flag_ptr)
 {
 	if (flag_ptr == NULL) {
 		static const bool allocation_always_allowed = true;
@@ -340,7 +341,8 @@ void uds_free(void *ptr)
  *
  * Return: UDS_SUCCESS or an error code
  */
-int uds_reallocate_memory(void *ptr, size_t old_size, size_t size, const char *what, void *new_ptr)
+int uds_reallocate_memory(void *ptr, size_t old_size, size_t size, const char *what,
+			  void *new_ptr)
 {
 	int result;
 
@@ -389,12 +391,10 @@ void uds_memory_exit(void)
 {
 	ASSERT_LOG_ONLY(memory_stats.kmalloc_bytes == 0,
 			"kmalloc memory used (%zd bytes in %zd blocks) is returned to the kernel",
-			memory_stats.kmalloc_bytes,
-			memory_stats.kmalloc_blocks);
+			memory_stats.kmalloc_bytes, memory_stats.kmalloc_blocks);
 	ASSERT_LOG_ONLY(memory_stats.vmalloc_bytes == 0,
 			"vmalloc memory used (%zd bytes in %zd blocks) is returned to the kernel",
-			memory_stats.vmalloc_bytes,
-			memory_stats.vmalloc_blocks);
+			memory_stats.vmalloc_bytes, memory_stats.vmalloc_blocks);
 	uds_log_debug("peak usage %zd bytes", memory_stats.peak_bytes);
 }
 
@@ -438,6 +438,5 @@ void uds_report_memory_usage(void)
 		     (unsigned long long) vmalloc_bytes,
 		     (unsigned long long) vmalloc_blocks);
 	uds_log_info("  total %llu bytes, peak usage %llu bytes",
-		     (unsigned long long) total_bytes,
-		     (unsigned long long) peak_usage);
+		     (unsigned long long) total_bytes, (unsigned long long) peak_usage);
 }

--- a/drivers/md/dm-vdo/memory-alloc.h
+++ b/drivers/md/dm-vdo/memory-alloc.h
@@ -37,12 +37,8 @@ int __must_check uds_allocate_memory(size_t size, size_t align, const char *what
  *
  * Return: UDS_SUCCESS or an error code
  */
-static inline int uds_do_allocation(size_t count,
-				    size_t size,
-				    size_t extra,
-				    size_t align,
-				    const char *what,
-				    void *ptr)
+static inline int uds_do_allocation(size_t count, size_t size, size_t extra,
+				    size_t align, const char *what, void *ptr)
 {
 	size_t total_size = count * size + extra;
 
@@ -127,13 +123,11 @@ static inline int __must_check uds_allocate_cache_aligned(size_t size, const cha
  */
 void *__must_check uds_allocate_memory_nowait(size_t size, const char *what);
 
-int __must_check uds_reallocate_memory(void *ptr,
-				       size_t old_size,
-				       size_t size,
-				       const char *what,
-				       void *new_ptr);
+int __must_check uds_reallocate_memory(void *ptr, size_t old_size, size_t size,
+				       const char *what, void *new_ptr);
 
-int __must_check uds_duplicate_string(const char *string, const char *what, char **new_string);
+int __must_check uds_duplicate_string(const char *string, const char *what,
+				      char **new_string);
 
 /* Free memory allocated with uds_allocate(). */
 void uds_free(void *ptr);
@@ -156,7 +150,8 @@ void uds_memory_init(void);
 
 void uds_memory_exit(void);
 
-void uds_register_allocating_thread(struct registered_thread *new_thread, const bool *flag_ptr);
+void uds_register_allocating_thread(struct registered_thread *new_thread,
+				    const bool *flag_ptr);
 
 void uds_unregister_allocating_thread(void);
 

--- a/drivers/md/dm-vdo/memory-alloc.h
+++ b/drivers/md/dm-vdo/memory-alloc.h
@@ -47,7 +47,7 @@ static inline int uds_do_allocation(size_t count,
 	size_t total_size = count * size + extra;
 
 	/* Overflow check: */
-	if ((size > 0) && (count > ((SIZE_MAX - extra) / size)))
+	if ((size > 0) && (count > ((SIZE_MAX - extra) / size))) {
 		/*
 		 * This is kind of a hack: We rely on the fact that SIZE_MAX would cover the entire
 		 * address space (minus one byte) and thus the system can never allocate that much
@@ -55,6 +55,7 @@ static inline int uds_do_allocation(size_t count,
 		 * by asking for "merely" SIZE_MAX bytes.
 		 */
 		total_size = SIZE_MAX;
+	}
 
 	return uds_allocate_memory(total_size, align, what, ptr);
 }

--- a/drivers/md/dm-vdo/murmurhash3.c
+++ b/drivers/md/dm-vdo/murmurhash3.c
@@ -51,7 +51,7 @@ static __always_inline u64 fmix64(u64 k)
 
 void murmurhash3_128(const void *key, const int len, const u32 seed, void *out)
 {
-	const u8 *data = (const u8 *)key;
+	const u8 *data = key;
 	const int nblocks = len / 16;
 
 	u64 h1 = seed;

--- a/drivers/md/dm-vdo/open-chapter.c
+++ b/drivers/md/dm-vdo/open-chapter.c
@@ -423,11 +423,12 @@ int uds_load_open_chapter(struct uds_index *index, struct buffered_reader *reade
 	if (result != UDS_SUCCESS)
 		return result;
 
-	if (memcmp(OPEN_CHAPTER_VERSION, version, sizeof(version)) != 0)
+	if (memcmp(OPEN_CHAPTER_VERSION, version, sizeof(version)) != 0) {
 		return uds_log_error_strerror(UDS_CORRUPT_DATA,
 					      "Invalid open chapter version: %.*s",
 					      (int) sizeof(version),
 					      version);
+	}
 
 	return load_version20(index, reader);
 }

--- a/drivers/md/dm-vdo/open-chapter.h
+++ b/drivers/md/dm-vdo/open-chapter.h
@@ -51,8 +51,7 @@ void uds_reset_open_chapter(struct open_chapter_zone *open_chapter);
 
 void uds_search_open_chapter(struct open_chapter_zone *open_chapter,
 			     const struct uds_record_name *name,
-			     struct uds_record_data *metadata,
-			     bool *found);
+			     struct uds_record_data *metadata, bool *found);
 
 int __must_check uds_put_open_chapter(struct open_chapter_zone *open_chapter,
 				      const struct uds_record_name *name,
@@ -64,15 +63,16 @@ void uds_remove_from_open_chapter(struct open_chapter_zone *open_chapter,
 void uds_free_open_chapter(struct open_chapter_zone *open_chapter);
 
 int __must_check uds_close_open_chapter(struct open_chapter_zone **chapter_zones,
-					unsigned int zone_count,
-					struct volume *volume,
+					unsigned int zone_count, struct volume *volume,
 					struct open_chapter_index *chapter_index,
 					struct uds_volume_record *collated_records,
 					u64 virtual_chapter_number);
 
-int __must_check uds_save_open_chapter(struct uds_index *index, struct buffered_writer *writer);
+int __must_check uds_save_open_chapter(struct uds_index *index,
+				       struct buffered_writer *writer);
 
-int __must_check uds_load_open_chapter(struct uds_index *index, struct buffered_reader *reader);
+int __must_check uds_load_open_chapter(struct uds_index *index,
+				       struct buffered_reader *reader);
 
 u64 uds_compute_saved_open_chapter_size(struct geometry *geometry);
 

--- a/drivers/md/dm-vdo/packer.c
+++ b/drivers/md/dm-vdo/packer.c
@@ -463,11 +463,12 @@ static void write_bin(struct packer *packer, struct packer_bin *bin)
 		return;
 	}
 
-	if (slot < VDO_MAX_COMPRESSION_SLOTS)
+	if (slot < VDO_MAX_COMPRESSION_SLOTS) {
 		/* Clear out the sizes of the unused slots */
 		memset(&block->header.sizes[slot],
 		       0,
 		       (VDO_MAX_COMPRESSION_SLOTS - slot) * sizeof(__le16));
+	}
 
 	agent->vio.completion.error_handler = handle_compressed_write_error;
 	if (vdo_is_read_only(vdo_from_data_vio(agent))) {
@@ -543,9 +544,10 @@ select_bin(struct packer *packer, struct data_vio *data_vio)
 	 */
 	struct packer_bin *bin, *fullest_bin;
 
-	list_for_each_entry(bin, &packer->bins, list)
+	list_for_each_entry(bin, &packer->bins, list) {
 		if (bin->free_space >= data_vio->compression.size)
 			return bin;
+	}
 
 	/*
 	 * None of the bins have enough space for the data_vio. We're not allowed to create new

--- a/drivers/md/dm-vdo/packer.c
+++ b/drivers/md/dm-vdo/packer.c
@@ -713,7 +713,7 @@ void vdo_increment_packer_flush_generation(struct packer *packer)
 /**
  * initiate_drain() - Initiate a drain.
  *
- * Implements vdo_admin_initiator.
+ * Implements vdo_admin_initiator_fn.
  */
 static void initiate_drain(struct admin_state *state)
 {

--- a/drivers/md/dm-vdo/packer.c
+++ b/drivers/md/dm-vdo/packer.c
@@ -47,8 +47,7 @@ enum {
  */
 int vdo_get_compressed_block_fragment(enum block_mapping_state mapping_state,
 				      struct compressed_block *block,
-				      u16 *fragment_offset,
-				      u16 *fragment_size)
+				      u16 *fragment_offset, u16 *fragment_size)
 {
 	u16 compressed_size;
 	u16 offset = 0;
@@ -123,11 +122,8 @@ static int __must_check make_bin(struct packer *packer)
 	struct packer_bin *bin;
 	int result;
 
-	result = uds_allocate_extended(struct packer_bin,
-				       VDO_MAX_COMPRESSION_SLOTS,
-				       struct vio *,
-				       __func__,
-				       &bin);
+	result = uds_allocate_extended(struct packer_bin, VDO_MAX_COMPRESSION_SLOTS,
+				       struct vio *, __func__, &bin);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -174,10 +170,8 @@ int vdo_make_packer(struct vdo *vdo, block_count_t bin_count, struct packer **pa
 	 * bin must have a canceler for which it is waiting, and any canceler will only have
 	 * canceled one lock holder at a time.
 	 */
-	result = uds_allocate_extended(struct packer_bin,
-				       MAXIMUM_VDO_USER_VIOS / 2,
-				       struct vio *, __func__,
-				       &packer->canceled_bin);
+	result = uds_allocate_extended(struct packer_bin, MAXIMUM_VDO_USER_VIOS / 2,
+				       struct vio *, __func__, &packer->canceled_bin);
 	if (result != VDO_SUCCESS) {
 		vdo_free_packer(packer);
 		return result;
@@ -262,8 +256,8 @@ static void abort_packing(struct data_vio *data_vio)
  * @data_vio: The data_vio to release.
  * @allocation: The allocation to which the compressed block was written.
  */
-static void
-release_compressed_write_waiter(struct data_vio *data_vio, struct allocation *allocation)
+static void release_compressed_write_waiter(struct data_vio *data_vio,
+					    struct allocation *allocation)
 {
 	data_vio->new_mapped = (struct zoned_pbn) {
 		.pbn = allocation->pbn,
@@ -395,12 +389,10 @@ static void initialize_compressed_block(struct compressed_block *block, u16 size
  *
  * Return: The new amount of space used.
  */
-static block_size_t __must_check
-pack_fragment(struct compression_state *compression,
-	      struct data_vio *data_vio,
-	      block_size_t offset,
-	      slot_number_t slot,
-	      struct compressed_block *block)
+static block_size_t __must_check pack_fragment(struct compression_state *compression,
+					       struct data_vio *data_vio,
+					       block_size_t offset, slot_number_t slot,
+					       struct compressed_block *block)
 {
 	struct compression_state *to_pack = &data_vio->compression;
 	char *fragment = to_pack->block->data;
@@ -465,8 +457,7 @@ static void write_bin(struct packer *packer, struct packer_bin *bin)
 
 	if (slot < VDO_MAX_COMPRESSION_SLOTS) {
 		/* Clear out the sizes of the unused slots */
-		memset(&block->header.sizes[slot],
-		       0,
+		memset(&block->header.sizes[slot], 0,
 		       (VDO_MAX_COMPRESSION_SLOTS - slot) * sizeof(__le16));
 	}
 
@@ -476,11 +467,8 @@ static void write_bin(struct packer *packer, struct packer_bin *bin)
 		return;
 	}
 
-	result = vio_reset_bio(&agent->vio,
-			       (char *) block,
-			       compressed_write_end_io,
-			       REQ_OP_WRITE,
-			       agent->allocation.pbn);
+	result = vio_reset_bio(&agent->vio, (char *) block, compressed_write_end_io,
+			       REQ_OP_WRITE, agent->allocation.pbn);
 	if (result != VDO_SUCCESS) {
 		continue_data_vio_with_error(agent, result);
 		return;
@@ -495,7 +483,8 @@ static void write_bin(struct packer *packer, struct packer_bin *bin)
 		   (stats->compressed_fragments_in_packer - slot));
 	WRITE_ONCE(stats->compressed_fragments_written,
 		   (stats->compressed_fragments_written + slot));
-	WRITE_ONCE(stats->compressed_blocks_written, stats->compressed_blocks_written + 1);
+	WRITE_ONCE(stats->compressed_blocks_written,
+		   stats->compressed_blocks_written + 1);
 
 	submit_data_vio_io(agent);
 }
@@ -509,8 +498,7 @@ static void write_bin(struct packer *packer, struct packer_bin *bin)
  * Adds a data_vio to a bin's incoming queue, handles logical space change, and calls physical
  * space processor.
  */
-static void add_data_vio_to_packer_bin(struct packer *packer,
-				       struct packer_bin *bin,
+static void add_data_vio_to_packer_bin(struct packer *packer, struct packer_bin *bin,
 				       struct data_vio *data_vio)
 {
 	/* If the selected bin doesn't have room, start a new batch to make room. */
@@ -535,8 +523,8 @@ static void add_data_vio_to_packer_bin(struct packer *packer,
  * @packer: The packer.
  * @data_vio: The data_vio.
  */
-static struct packer_bin * __must_check
-select_bin(struct packer *packer, struct data_vio *data_vio)
+static struct packer_bin * __must_check select_bin(struct packer *packer,
+						   struct data_vio *data_vio)
 {
 	/*
 	 * First best fit: select the bin with the least free space that has enough room for the
@@ -743,7 +731,8 @@ static void initiate_drain(struct admin_state *state)
 void vdo_drain_packer(struct packer *packer, struct vdo_completion *completion)
 {
 	assert_on_packer_thread(packer, __func__);
-	vdo_start_draining(&packer->state, VDO_ADMIN_STATE_SUSPENDING, completion, initiate_drain);
+	vdo_start_draining(&packer->state, VDO_ADMIN_STATE_SUSPENDING, completion,
+			   initiate_drain);
 }
 
 /**
@@ -764,8 +753,7 @@ static void dump_packer_bin(const struct packer_bin *bin, bool canceled)
 		return;
 
 	uds_log_info("	  %sBin slots_used=%u free_space=%zu",
-		     (canceled ? "Canceled" : ""), bin->slots_used,
-		     bin->free_space);
+		     (canceled ? "Canceled" : ""), bin->slots_used, bin->free_space);
 
 	/*
 	 * FIXME: dump vios in bin->incoming? The vios should have been dumped from the vio pool.

--- a/drivers/md/dm-vdo/packer.h
+++ b/drivers/md/dm-vdo/packer.h
@@ -96,11 +96,10 @@ struct packer {
 
 int vdo_get_compressed_block_fragment(enum block_mapping_state mapping_state,
 				      struct compressed_block *block,
-				      u16 *fragment_offset,
-				      u16 *fragment_size);
+				      u16 *fragment_offset, u16 *fragment_size);
 
-int __must_check
-vdo_make_packer(struct vdo *vdo, block_count_t bin_count, struct packer **packer_ptr);
+int __must_check vdo_make_packer(struct vdo *vdo, block_count_t bin_count,
+				 struct packer **packer_ptr);
 
 void vdo_free_packer(struct packer *packer);
 

--- a/drivers/md/dm-vdo/permassert.c
+++ b/drivers/md/dm-vdo/permassert.c
@@ -8,25 +8,16 @@
 #include "errors.h"
 #include "logger.h"
 
-int uds_assertion_failed(const char *expression_string,
-			 const char *file_name,
-			 int line_number,
-			 const char *format,
-			 ...)
+int uds_assertion_failed(const char *expression_string, const char *file_name,
+			 int line_number, const char *format, ...)
 {
 	va_list args;
 
 	va_start(args, format);
 
-	uds_log_embedded_message(UDS_LOG_ERR,
-				 UDS_LOGGING_MODULE_NAME,
-				 "assertion \"",
-				 format,
-				 args,
-				 "\" (%s) failed at %s:%d",
-				 expression_string,
-				 file_name,
-				 line_number);
+	uds_log_embedded_message(UDS_LOG_ERR, UDS_LOGGING_MODULE_NAME, "assertion \"",
+				 format, args, "\" (%s) failed at %s:%d",
+				 expression_string, file_name, line_number);
 	uds_log_backtrace(UDS_LOG_ERR);
 
 	va_end(args);

--- a/drivers/md/dm-vdo/permassert.h
+++ b/drivers/md/dm-vdo/permassert.h
@@ -39,11 +39,8 @@ static inline int __must_check uds_must_use(int value)
 		      : uds_assertion_failed(STRINGIFY(expr), __FILE__, __LINE__, __VA_ARGS__))
 
 /* Log an assertion failure message. */
-int uds_assertion_failed(const char *expression_string,
-			 const char *file_name,
-			 int line_number,
-			 const char *format,
-			 ...)
+int uds_assertion_failed(const char *expression_string, const char *file_name,
+			 int line_number, const char *format, ...)
 	__printf(4, 5);
 
 #endif /* PERMASSERT_H */

--- a/drivers/md/dm-vdo/physical-zone.c
+++ b/drivers/md/dm-vdo/physical-zone.c
@@ -165,11 +165,12 @@ release_pbn_lock_provisional_reference(struct pbn_lock *lock,
 		return;
 
 	result = vdo_release_block_reference(allocator, locked_pbn);
-	if (result != VDO_SUCCESS)
+	if (result != VDO_SUCCESS) {
 		uds_log_error_strerror(result,
 				       "Failed to release reference to %s physical block %llu",
 				       lock->implementation->release_reason,
 				       (unsigned long long) locked_pbn);
+	}
 
 	vdo_unassign_pbn_lock_provisional_reference(lock);
 }
@@ -507,12 +508,13 @@ static int allocate_and_lock_block(struct allocation *allocation)
 	if (result != VDO_SUCCESS)
 		return result;
 
-	if (lock->holder_count > 0)
+	if (lock->holder_count > 0) {
 		/* This block is already locked, which should be impossible. */
 		return uds_log_error_strerror(VDO_LOCK_ERROR,
 					      "Newly allocated block %llu was spuriously locked (holder_count=%u)",
 					      (unsigned long long) allocation->pbn,
 					      lock->holder_count);
+	}
 
 	/* We've successfully acquired a new lock, so mark it as ours. */
 	lock->holder_count += 1;
@@ -568,9 +570,10 @@ static bool continue_allocating(struct data_vio *data_vio)
 	if (allocation->wait_for_clean_slab) {
 		data_vio->waiter.callback = retry_allocation;
 		result = vdo_enqueue_clean_slab_waiter(zone->allocator, &data_vio->waiter);
-		if (result == VDO_SUCCESS)
+		if (result == VDO_SUCCESS) {
 			/* We've enqueued to wait for a slab to be scrubbed. */
 			return true;
+		}
 
 		if ((result != VDO_NO_SPACE) || (was_waiting && tried_all)) {
 			vdo_set_completion_result(completion, result);
@@ -627,9 +630,10 @@ void vdo_release_physical_zone_pbn_lock(struct physical_zone *zone,
 	ASSERT_LOG_ONLY(lock->holder_count > 0, "should not be releasing a lock that is not held");
 
 	lock->holder_count -= 1;
-	if (lock->holder_count > 0)
+	if (lock->holder_count > 0) {
 		/* The lock was shared and is still referenced, so don't release it yet. */
 		return;
+	}
 
 	holder = vdo_int_map_remove(zone->pbn_operations, locked_pbn);
 	ASSERT_LOG_ONLY((lock == holder),

--- a/drivers/md/dm-vdo/physical-zone.c
+++ b/drivers/md/dm-vdo/physical-zone.c
@@ -154,10 +154,9 @@ void vdo_unassign_pbn_lock_provisional_reference(struct pbn_lock *lock)
  *
  * This method is called when the lock is released.
  */
-static void
-release_pbn_lock_provisional_reference(struct pbn_lock *lock,
-				       physical_block_number_t locked_pbn,
-				       struct block_allocator *allocator)
+static void release_pbn_lock_provisional_reference(struct pbn_lock *lock,
+						   physical_block_number_t locked_pbn,
+						   struct block_allocator *allocator)
 {
 	int result;
 
@@ -242,11 +241,8 @@ static int make_pbn_lock_pool(size_t capacity, struct pbn_lock_pool **pool_ptr)
 	struct pbn_lock_pool *pool;
 	int result;
 
-	result = uds_allocate_extended(struct pbn_lock_pool,
-				       capacity,
-				       idle_pbn_lock,
-				       __func__,
-				       &pool);
+	result = uds_allocate_extended(struct pbn_lock_pool, capacity, idle_pbn_lock,
+				       __func__, &pool);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -291,17 +287,17 @@ static void free_pbn_lock_pool(struct pbn_lock_pool *pool)
  *
  * Return: VDO_SUCCESS, or VDO_LOCK_ERROR if the pool is empty.
  */
-static int __must_check
-borrow_pbn_lock_from_pool(struct pbn_lock_pool *pool,
-			  enum pbn_lock_type type,
-			  struct pbn_lock **lock_ptr)
+static int __must_check borrow_pbn_lock_from_pool(struct pbn_lock_pool *pool,
+						  enum pbn_lock_type type,
+						  struct pbn_lock **lock_ptr)
 {
 	int result;
 	struct list_head *idle_entry;
 	idle_pbn_lock *idle;
 
 	if (pool->borrowed >= pool->capacity)
-		return uds_log_error_strerror(VDO_LOCK_ERROR, "no free PBN locks left to borrow");
+		return uds_log_error_strerror(VDO_LOCK_ERROR,
+					      "no free PBN locks left to borrow");
 	pool->borrowed += 1;
 
 	result = ASSERT(!list_empty(&pool->idle_list),
@@ -373,11 +369,8 @@ int vdo_make_physical_zones(struct vdo *vdo, struct physical_zones **zones_ptr)
 	if (zone_count == 0)
 		return VDO_SUCCESS;
 
-	result = uds_allocate_extended(struct physical_zones,
-				       zone_count,
-				       struct physical_zone,
-				       __func__,
-				       &zones);
+	result = uds_allocate_extended(struct physical_zones, zone_count,
+				       struct physical_zone, __func__, &zones);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -421,8 +414,8 @@ void vdo_free_physical_zones(struct physical_zones *zones)
  *
  * Return: The lock or NULL if the PBN is not locked.
  */
-struct pbn_lock *
-vdo_get_physical_zone_pbn_lock(struct physical_zone *zone, physical_block_number_t pbn)
+struct pbn_lock *vdo_get_physical_zone_pbn_lock(struct physical_zone *zone,
+						physical_block_number_t pbn)
 {
 	return ((zone == NULL) ? NULL : vdo_int_map_get(zone->pbn_operations, pbn));
 }
@@ -460,7 +453,8 @@ int vdo_attempt_physical_zone_pbn_lock(struct physical_zone *zone,
 		return result;
 	}
 
-	result = vdo_int_map_put(zone->pbn_operations, pbn, new_lock, false, (void **) &lock);
+	result = vdo_int_map_put(zone->pbn_operations, pbn, new_lock, false,
+				 (void **) &lock);
 	if (result != VDO_SUCCESS) {
 		return_pbn_lock_to_pool(zone->lock_pool, new_lock);
 		return result;
@@ -469,8 +463,7 @@ int vdo_attempt_physical_zone_pbn_lock(struct physical_zone *zone,
 	if (lock != NULL) {
 		/* The lock is already held, so we don't need the borrowed one. */
 		return_pbn_lock_to_pool(zone->lock_pool, uds_forget(new_lock));
-		result = ASSERT(lock->holder_count > 0,
-				"physical block %llu lock held",
+		result = ASSERT(lock->holder_count > 0, "physical block %llu lock held",
 				(unsigned long long) pbn);
 		if (result != VDO_SUCCESS)
 			return result;
@@ -501,10 +494,8 @@ static int allocate_and_lock_block(struct allocation *allocation)
 	if (result != VDO_SUCCESS)
 		return result;
 
-	result = vdo_attempt_physical_zone_pbn_lock(allocation->zone,
-						    allocation->pbn,
-						    allocation->write_lock_type,
-						    &lock);
+	result = vdo_attempt_physical_zone_pbn_lock(allocation->zone, allocation->pbn,
+						    allocation->write_lock_type, &lock);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -569,7 +560,8 @@ static bool continue_allocating(struct data_vio *data_vio)
 
 	if (allocation->wait_for_clean_slab) {
 		data_vio->waiter.callback = retry_allocation;
-		result = vdo_enqueue_clean_slab_waiter(zone->allocator, &data_vio->waiter);
+		result = vdo_enqueue_clean_slab_waiter(zone->allocator,
+						       &data_vio->waiter);
 		if (result == VDO_SUCCESS) {
 			/* We've enqueued to wait for a slab to be scrubbed. */
 			return true;
@@ -627,7 +619,8 @@ void vdo_release_physical_zone_pbn_lock(struct physical_zone *zone,
 	if (lock == NULL)
 		return;
 
-	ASSERT_LOG_ONLY(lock->holder_count > 0, "should not be releasing a lock that is not held");
+	ASSERT_LOG_ONLY(lock->holder_count > 0,
+			"should not be releasing a lock that is not held");
 
 	lock->holder_count -= 1;
 	if (lock->holder_count > 0) {
@@ -636,8 +629,7 @@ void vdo_release_physical_zone_pbn_lock(struct physical_zone *zone,
 	}
 
 	holder = vdo_int_map_remove(zone->pbn_operations, locked_pbn);
-	ASSERT_LOG_ONLY((lock == holder),
-			"physical block lock mismatch for block %llu",
+	ASSERT_LOG_ONLY((lock == holder), "physical block lock mismatch for block %llu",
 			(unsigned long long) locked_pbn);
 
 	release_pbn_lock_provisional_reference(lock, locked_pbn, zone->allocator);

--- a/drivers/md/dm-vdo/physical-zone.h
+++ b/drivers/md/dm-vdo/physical-zone.h
@@ -91,18 +91,18 @@ static inline bool vdo_pbn_lock_has_provisional_reference(struct pbn_lock *lock)
 void vdo_assign_pbn_lock_provisional_reference(struct pbn_lock *lock);
 void vdo_unassign_pbn_lock_provisional_reference(struct pbn_lock *lock);
 
-int __must_check vdo_make_physical_zones(struct vdo *vdo, struct physical_zones **zones_ptr);
+int __must_check vdo_make_physical_zones(struct vdo *vdo,
+					 struct physical_zones **zones_ptr);
 
 void vdo_free_physical_zones(struct physical_zones *zones);
 
-struct pbn_lock * __must_check
-vdo_get_physical_zone_pbn_lock(struct physical_zone *zone, physical_block_number_t pbn);
+struct pbn_lock * __must_check vdo_get_physical_zone_pbn_lock(struct physical_zone *zone,
+							      physical_block_number_t pbn);
 
-int __must_check
-vdo_attempt_physical_zone_pbn_lock(struct physical_zone *zone,
-				   physical_block_number_t pbn,
-				   enum pbn_lock_type type,
-				   struct pbn_lock **lock_ptr);
+int __must_check vdo_attempt_physical_zone_pbn_lock(struct physical_zone *zone,
+						    physical_block_number_t pbn,
+						    enum pbn_lock_type type,
+						    struct pbn_lock **lock_ptr);
 
 bool __must_check vdo_allocate_block_in_zone(struct data_vio *data_vio);
 

--- a/drivers/md/dm-vdo/pointer-map.c
+++ b/drivers/md/dm-vdo/pointer-map.c
@@ -441,12 +441,13 @@ move_empty_bucket(struct pointer_map *map __always_unused, struct bucket *hole)
 		 */
 		struct bucket *new_hole = dereference_hop(bucket, bucket->first_hop);
 
-		if (new_hole == NULL)
+		if (new_hole == NULL) {
 			/*
 			 * There are no buckets in this neighborhood that are in use by this one
 			 * (they must all be owned by overlapping neighborhoods).
 			 */
 			continue;
+		}
 
 		/*
 		 * Skip this bucket if its first entry is actually further away than the hole that
@@ -502,9 +503,10 @@ static bool update_mapping(struct pointer_map *map,
 {
 	struct bucket *bucket = search_hop_list(map, neighborhood, key, NULL);
 
-	if (bucket == NULL)
+	if (bucket == NULL) {
 		/* There is no bucket containing the key in the neighborhood. */
 		return false;
+	}
 
 	/*
 	 * Return the value of the current mapping (if desired) and update the mapping with the new
@@ -548,12 +550,13 @@ static struct bucket *find_or_make_vacancy(struct pointer_map *map, struct bucke
 	while (hole != NULL) {
 		int distance = hole - neighborhood;
 
-		if (distance < NEIGHBORHOOD)
+		if (distance < NEIGHBORHOOD) {
 			/*
 			 * We've found or relocated an empty bucket close enough to the initial
 			 * hash bucket to be referenced by its hop vector.
 			 */
 			return hole;
+		}
 
 		/*
 		 * The nearest empty bucket isn't within the neighborhood that must contain the new
@@ -667,9 +670,10 @@ void *vdo_pointer_map_remove(struct pointer_map *map, const void *key)
 	struct bucket *previous;
 	struct bucket *victim = search_hop_list(map, bucket, key, &previous);
 
-	if (victim == NULL)
+	if (victim == NULL) {
 		/* There is no matching entry to remove. */
 		return NULL;
+	}
 
 	/*
 	 * We found an entry to remove. Save the mapped value to return later and empty the bucket.
@@ -680,12 +684,13 @@ void *vdo_pointer_map_remove(struct pointer_map *map, const void *key)
 	victim->key = 0;
 
 	/* The victim bucket is now empty, but it still needs to be spliced out of the hop list. */
-	if (previous == NULL)
+	if (previous == NULL) {
 		/* The victim is the head of the list, so swing first_hop. */
 		bucket->first_hop = victim->next_hop;
-	else
+	} else {
 		previous->next_hop = victim->next_hop;
-	victim->next_hop = NULL_HOP_OFFSET;
+	}
 
+	victim->next_hop = NULL_HOP_OFFSET;
 	return value;
 }

--- a/drivers/md/dm-vdo/pool-sysfs.c
+++ b/drivers/md/dm-vdo/pool-sysfs.c
@@ -20,9 +20,11 @@ struct pool_attribute {
 	ssize_t (*store)(struct vdo *vdo, const char *value, size_t count);
 };
 
-static ssize_t vdo_pool_attr_show(struct kobject *directory, struct attribute *attr, char *buf)
+static ssize_t vdo_pool_attr_show(struct kobject *directory, struct attribute *attr,
+				  char *buf)
 {
-	struct pool_attribute *pool_attr = container_of(attr, struct pool_attribute, attr);
+	struct pool_attribute *pool_attr = container_of(attr, struct pool_attribute,
+							attr);
 	struct vdo *vdo = container_of(directory, struct vdo, vdo_directory);
 
 	if (pool_attr->show == NULL)
@@ -30,12 +32,11 @@ static ssize_t vdo_pool_attr_show(struct kobject *directory, struct attribute *a
 	return pool_attr->show(vdo, buf);
 }
 
-static ssize_t vdo_pool_attr_store(struct kobject *directory,
-				   struct attribute *attr,
-				   const char *buf,
-				   size_t length)
+static ssize_t vdo_pool_attr_store(struct kobject *directory, struct attribute *attr,
+				   const char *buf, size_t length)
 {
-	struct pool_attribute *pool_attr = container_of(attr, struct pool_attribute, attr);
+	struct pool_attribute *pool_attr = container_of(attr, struct pool_attribute,
+							attr);
 	struct vdo *vdo = container_of(directory, struct vdo, vdo_directory);
 
 	if (pool_attr->store == NULL)
@@ -55,7 +56,8 @@ static ssize_t pool_compressing_show(struct vdo *vdo, char *buf)
 
 static ssize_t pool_discards_active_show(struct vdo *vdo, char *buf)
 {
-	return sprintf(buf, "%u\n", get_data_vio_pool_active_discards(vdo->data_vio_pool));
+	return sprintf(buf, "%u\n",
+		       get_data_vio_pool_active_discards(vdo->data_vio_pool));
 }
 
 static ssize_t pool_discards_limit_show(struct vdo *vdo, char *buf)
@@ -80,7 +82,8 @@ static ssize_t pool_discards_limit_store(struct vdo *vdo, const char *buf, size_
 
 static ssize_t pool_discards_maximum_show(struct vdo *vdo, char *buf)
 {
-	return sprintf(buf, "%u\n", get_data_vio_pool_maximum_discards(vdo->data_vio_pool));
+	return sprintf(buf, "%u\n",
+		       get_data_vio_pool_maximum_discards(vdo->data_vio_pool));
 }
 
 static ssize_t pool_instance_show(struct vdo *vdo, char *buf)
@@ -90,7 +93,8 @@ static ssize_t pool_instance_show(struct vdo *vdo, char *buf)
 
 static ssize_t pool_requests_active_show(struct vdo *vdo, char *buf)
 {
-	return sprintf(buf, "%u\n", get_data_vio_pool_active_requests(vdo->data_vio_pool));
+	return sprintf(buf, "%u\n",
+		       get_data_vio_pool_active_requests(vdo->data_vio_pool));
 }
 
 static ssize_t pool_requests_limit_show(struct vdo *vdo, char *buf)
@@ -100,7 +104,8 @@ static ssize_t pool_requests_limit_show(struct vdo *vdo, char *buf)
 
 static ssize_t pool_requests_maximum_show(struct vdo *vdo, char *buf)
 {
-	return sprintf(buf, "%u\n", get_data_vio_pool_maximum_requests(vdo->data_vio_pool));
+	return sprintf(buf, "%u\n",
+		       get_data_vio_pool_maximum_requests(vdo->data_vio_pool));
 }
 
 static void vdo_pool_release(struct kobject *directory)

--- a/drivers/md/dm-vdo/priority-table.c
+++ b/drivers/md/dm-vdo/priority-table.c
@@ -161,9 +161,10 @@ struct list_head *vdo_priority_table_dequeue(struct priority_table *table)
 	struct list_head *entry;
 	int top_priority;
 
-	if (table->search_vector == 0)
+	if (table->search_vector == 0) {
 		/* All buckets are empty. */
 		return NULL;
+	}
 
 	/*
 	 * Find the highest priority non-empty bucket by finding the highest-order non-zero bit in

--- a/drivers/md/dm-vdo/priority-table.c
+++ b/drivers/md/dm-vdo/priority-table.c
@@ -126,8 +126,7 @@ void vdo_reset_priority_table(struct priority_table *table)
  * @entry: The list_head embedded in the entry to store in the table (the caller must have
  *         initialized it).
  */
-void vdo_priority_table_enqueue(struct priority_table *table,
-				unsigned int priority,
+void vdo_priority_table_enqueue(struct priority_table *table, unsigned int priority,
 				struct list_head *entry)
 {
 	ASSERT_LOG_ONLY((priority <= table->max_priority),

--- a/drivers/md/dm-vdo/priority-table.h
+++ b/drivers/md/dm-vdo/priority-table.h
@@ -28,13 +28,12 @@
 
 struct priority_table;
 
-int __must_check
-vdo_make_priority_table(unsigned int max_priority, struct priority_table **table_ptr);
+int __must_check vdo_make_priority_table(unsigned int max_priority,
+					 struct priority_table **table_ptr);
 
 void vdo_free_priority_table(struct priority_table *table);
 
-void vdo_priority_table_enqueue(struct priority_table *table,
-				unsigned int priority,
+void vdo_priority_table_enqueue(struct priority_table *table, unsigned int priority,
 				struct list_head *entry);
 
 void vdo_reset_priority_table(struct priority_table *table);

--- a/drivers/md/dm-vdo/radix-sort.c
+++ b/drivers/md/dm-vdo/radix-sort.c
@@ -98,11 +98,8 @@ static inline void insertion_sort(const struct task task)
 }
 
 /* Push a sorting task onto a task stack. */
-static inline void push_task(struct task **stack_pointer,
-			     sort_key_t *first_key,
-			     u32 count,
-			     u16 offset,
-			     u16 length)
+static inline void push_task(struct task **stack_pointer, sort_key_t *first_key,
+			     u32 count, u16 offset, u16 length)
 {
 	struct task *task = (*stack_pointer)++;
 
@@ -174,14 +171,10 @@ static inline void measure_bins(const struct task task, struct histogram *bins)
  *
  * Return: UDS_SUCCESS or an error code
  */
-static inline int push_bins(struct task **stack,
-			    struct task *end_of_stack,
-			    struct task **list,
-			    sort_key_t *pile[],
-			    struct histogram *bins,
-			    sort_key_t *first_key,
-			    u16 offset,
-			    u16 length)
+static inline int push_bins(struct task **stack, struct task *end_of_stack,
+			    struct task **list, sort_key_t *pile[],
+			    struct histogram *bins, sort_key_t *first_key,
+			    u16 offset, u16 length)
 {
 	sort_key_t *pile_start = first_key;
 	int bin;
@@ -220,11 +213,8 @@ int uds_make_radix_sorter(unsigned int count, struct radix_sorter **sorter)
 	unsigned int stack_size = count / INSERTION_SORT_THRESHOLD;
 	struct radix_sorter *radix_sorter;
 
-	result = uds_allocate_extended(struct radix_sorter,
-				       stack_size,
-				       struct task,
-				       __func__,
-				       &radix_sorter);
+	result = uds_allocate_extended(struct radix_sorter, stack_size, struct task,
+				       __func__, &radix_sorter);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -243,10 +233,8 @@ void uds_free_radix_sorter(struct radix_sorter *sorter)
  * Sort pointers to fixed-length keys (arrays of bytes) using a radix sort. The sort implementation
  * is unstable, so the relative ordering of equal keys is not preserved.
  */
-int uds_radix_sort(struct radix_sorter *sorter,
-		   const unsigned char *keys[],
-		   unsigned int count,
-		   unsigned short length)
+int uds_radix_sort(struct radix_sorter *sorter, const unsigned char *keys[],
+		   unsigned int count, unsigned short length)
 {
 	struct task start;
 	struct histogram *bins = &sorter->bins;
@@ -293,14 +281,9 @@ int uds_radix_sort(struct radix_sorter *sorter,
 		 * and push a new task to sort each pile by the next radix byte.
 		 */
 		insertion_task_list = sorter->insertion_list;
-		result = push_bins(&task_stack,
-				   sorter->end_of_stack,
-				   &insertion_task_list,
-				   pile,
-				   bins,
-				   task.first_key,
-				   task.offset + 1,
-				   task.length - 1);
+		result = push_bins(&task_stack, sorter->end_of_stack,
+				   &insertion_task_list, pile, bins, task.first_key,
+				   task.offset + 1, task.length - 1);
 		if (result != UDS_SUCCESS) {
 			memset(bins, 0, sizeof(*bins));
 			return result;

--- a/drivers/md/dm-vdo/radix-sort.h
+++ b/drivers/md/dm-vdo/radix-sort.h
@@ -20,9 +20,7 @@ int __must_check uds_make_radix_sorter(unsigned int count, struct radix_sorter *
 
 void uds_free_radix_sorter(struct radix_sorter *sorter);
 
-int __must_check uds_radix_sort(struct radix_sorter *sorter,
-				const unsigned char *keys[],
-				unsigned int count,
-				unsigned short length);
+int __must_check uds_radix_sort(struct radix_sorter *sorter, const unsigned char *keys[],
+				unsigned int count, unsigned short length);
 
 #endif /* UDS_RADIX_SORT_H */

--- a/drivers/md/dm-vdo/recovery-journal.c
+++ b/drivers/md/dm-vdo/recovery-journal.c
@@ -949,7 +949,7 @@ get_block_header(const struct recovery_journal_block *block)
  */
 static void set_active_sector(struct recovery_journal_block *block, void *sector)
 {
-	block->sector = (struct packed_journal_sector *) sector;
+	block->sector = sector;
 	block->sector->check_byte = get_block_header(block)->check_byte;
 	block->sector->recovery_count = block->journal->recovery_count;
 	block->sector->entry_count = 0;
@@ -1106,7 +1106,7 @@ static void update_usages(struct recovery_journal *journal, struct data_vio *dat
 static void assign_entry(struct waiter *waiter, void *context)
 {
 	struct data_vio *data_vio = waiter_as_data_vio(waiter);
-	struct recovery_journal_block *block = (struct recovery_journal_block *) context;
+	struct recovery_journal_block *block = context;
 	struct recovery_journal *journal = block->journal;
 
 	/* Record the point at which we will make the journal entry. */
@@ -1193,7 +1193,7 @@ static void recycle_journal_block(struct recovery_journal_block *block)
 static void continue_committed_waiter(struct waiter *waiter, void *context)
 {
 	struct data_vio *data_vio = waiter_as_data_vio(waiter);
-	struct recovery_journal *journal = (struct recovery_journal *)context;
+	struct recovery_journal *journal = context;
 	int result = (is_read_only(journal) ? VDO_READ_ONLY : VDO_SUCCESS);
 	bool has_decrement;
 

--- a/drivers/md/dm-vdo/recovery-journal.c
+++ b/drivers/md/dm-vdo/recovery-journal.c
@@ -820,11 +820,13 @@ void vdo_free_recovery_journal(struct recovery_journal *journal)
 	 * FIXME: eventually, the journal should be constructed in a quiescent state which
 	 *        requires opening before use.
 	 */
-	if (!vdo_is_state_quiescent(&journal->state))
+	if (!vdo_is_state_quiescent(&journal->state)) {
 		ASSERT_LOG_ONLY(list_empty(&journal->active_tail_blocks),
 				"journal being freed has no active tail blocks");
-	else if (!vdo_is_state_saved(&journal->state) && !list_empty(&journal->active_tail_blocks))
+	} else if (!vdo_is_state_saved(&journal->state) &&
+		   !list_empty(&journal->active_tail_blocks)) {
 		uds_log_warning("journal being freed has uncommitted entries");
+	}
 
 	for (i = 0; i < RECOVERY_JOURNAL_RESERVED_BLOCKS; i++) {
 		struct recovery_journal_block *block = &journal->blocks[i];
@@ -911,18 +913,19 @@ vdo_record_recovery_journal(const struct recovery_journal *journal)
 		.block_map_data_blocks = journal->block_map_data_blocks,
 	};
 
-	if (vdo_is_state_saved(&journal->state))
+	if (vdo_is_state_saved(&journal->state)) {
 		/*
 		 * If the journal is saved, we should start one past the active block (since the
 		 * active block is not guaranteed to be empty).
 		 */
 		state.journal_start = journal->tail;
-	else
+	} else {
 		/*
 		 * When we're merely suspended or have gone read-only, we must record the first
 		 * block that might have entries that need to be applied.
 		 */
 		state.journal_start = get_recovery_journal_head(journal);
+	}
 
 	return state;
 }
@@ -1123,12 +1126,13 @@ static void assign_entry(struct waiter *waiter, void *context)
 	block->uncommitted_entry_count++;
 	journal->events.entries.started++;
 
-	if (is_block_full(block))
+	if (is_block_full(block)) {
 		/*
 		 * The block is full, so we can write it anytime henceforth. If it is already
 		 * committing, we'll queue it for writing when it comes back.
 		 */
 		schedule_block_write(journal, block);
+	}
 
 	/* Force out slab journal tail blocks when threshold is reached. */
 	check_slab_journal_commit_threshold(journal);
@@ -1136,15 +1140,17 @@ static void assign_entry(struct waiter *waiter, void *context)
 
 static void assign_entries(struct recovery_journal *journal)
 {
-	if (journal->adding_entries)
+	if (journal->adding_entries) {
 		/* Protect against re-entrancy. */
 		return;
+	}
 
 	journal->adding_entries = true;
-	while (vdo_has_waiters(&journal->entry_waiters) && prepare_to_assign_entry(journal))
+	while (vdo_has_waiters(&journal->entry_waiters) && prepare_to_assign_entry(journal)) {
 		vdo_notify_next_waiter(&journal->entry_waiters,
 				       assign_entry,
 				       journal->active_block);
+	}
 
 	/* Now that we've finished with entries, see if we have a batch of blocks to write. */
 	write_blocks(journal);
@@ -1231,13 +1237,14 @@ static void notify_commit_waiters(struct recovery_journal *journal)
 			return;
 
 		vdo_notify_all_waiters(&block->commit_waiters, continue_committed_waiter, journal);
-		if (is_read_only(journal))
+		if (is_read_only(journal)) {
 			vdo_notify_all_waiters(&block->entry_waiters,
 					       continue_committed_waiter,
 					       journal);
-		else if (is_block_dirty(block) || !is_block_full(block))
+		} else if (is_block_dirty(block) || !is_block_full(block)) {
 			/* Stop at partially-committed or partially-filled blocks. */
 			return;
+		}
 	}
 }
 
@@ -1250,16 +1257,18 @@ static void recycle_journal_blocks(struct recovery_journal *journal)
 	struct recovery_journal_block *block, *tmp;
 
 	list_for_each_entry_safe(block, tmp, &journal->active_tail_blocks, list_node) {
-		if (block->committing)
+		if (block->committing) {
 			/* Don't recycle committing blocks. */
 			return;
+		}
 
-		if (!is_read_only(journal) && (is_block_dirty(block) || !is_block_full(block)))
+		if (!is_read_only(journal) && (is_block_dirty(block) || !is_block_full(block))) {
 			/*
 			 * Don't recycle partially written or partially full blocks, except in
 			 * read-only mode.
 			 */
 			return;
+		}
 
 		recycle_journal_block(block);
 	}
@@ -1509,16 +1518,18 @@ is_lock_locked(struct recovery_journal *journal,
  */
 static void reap_recovery_journal(struct recovery_journal *journal)
 {
-	if (journal->reaping)
+	if (journal->reaping) {
 		/*
 		 * We already have an outstanding reap in progress. We need to wait for it to
 		 * finish.
 		 */
 		return;
+	}
 
-	if (vdo_is_state_quiescent(&journal->state))
+	if (vdo_is_state_quiescent(&journal->state)) {
 		/* We are supposed to not do IO. Don't botch it by reaping. */
 		return;
+	}
 
 	/*
 	 * Start reclaiming blocks only when the journal head has no references. Then stop when a
@@ -1543,9 +1554,10 @@ static void reap_recovery_journal(struct recovery_journal *journal)
 	}
 
 	if ((journal->block_map_reap_head == journal->block_map_head) &&
-	    (journal->slab_journal_reap_head == journal->slab_journal_head))
+	    (journal->slab_journal_reap_head == journal->slab_journal_head)) {
 		/* Nothing happened. */
 		return;
+	}
 
 	/*
 	 * If the block map head will advance, we must flush any block map page modified by the
@@ -1593,6 +1605,7 @@ void vdo_acquire_recovery_journal_block_reference(struct recovery_journal *journ
 		/* same as before_atomic */
 		smp_mb__after_atomic();
 	}
+
 	*current_value += 1;
 }
 
@@ -1691,9 +1704,10 @@ void vdo_resume_recovery_journal(struct recovery_journal *journal, struct vdo_co
 	if (saved)
 		initialize_journal_state(journal);
 
-	if (resume_lock_counter(&journal->lock_counter))
+	if (resume_lock_counter(&journal->lock_counter)) {
 		/* We might have missed a notification. */
 		reap_recovery_journal(journal);
+	}
 
 	vdo_launch_completion(parent);
 }

--- a/drivers/md/dm-vdo/recovery-journal.c
+++ b/drivers/md/dm-vdo/recovery-journal.c
@@ -265,7 +265,7 @@ static void assert_on_journal_thread(struct recovery_journal *journal,
  * continue_waiter() - Release a data_vio from the journal.
  *
  * Invoked whenever a data_vio is to be released from the journal, either because its entry was
- * committed to disk, or because there was an error. Implements waiter_callback.
+ * committed to disk, or because there was an error. Implements waiter_callback_fn.
  */
 static void continue_waiter(struct waiter *waiter, void *context)
 {
@@ -375,7 +375,7 @@ static void check_for_drain_complete(struct recovery_journal *journal)
  * @listener: The journal.
  * @parent: The completion to notify in order to acknowledge the notification.
  *
- * Implements vdo_read_only_notification.
+ * Implements vdo_read_only_notification_fn.
  */
 static void notify_recovery_journal_of_read_only_mode(void *listener,
 						      struct vdo_completion *parent)
@@ -1082,7 +1082,7 @@ static void update_usages(struct recovery_journal *journal, struct data_vio *dat
 /**
  * assign_entry() - Assign an entry waiter to the active block.
  *
- * Implements waiter_callback.
+ * Implements waiter_callback_fn.
  */
 static void assign_entry(struct waiter *waiter, void *context)
 {
@@ -1168,7 +1168,7 @@ static void recycle_journal_block(struct recovery_journal_block *block)
  * continue_committed_waiter() - invoked whenever a VIO is to be released from the journal because
  *                               its entry was committed to disk.
  *
- * Implements waiter_callback.
+ * Implements waiter_callback_fn.
  */
 static void continue_committed_waiter(struct waiter *waiter, void *context)
 {
@@ -1364,7 +1364,7 @@ static void add_queued_recovery_entries(struct recovery_journal_block *block)
 /**
  * write_block() - Issue a block for writing.
  *
- * Implements waiter_callback.
+ * Implements waiter_callback_fn.
  */
 static void write_block(struct waiter *waiter, void *context __always_unused)
 {
@@ -1613,7 +1613,7 @@ void vdo_release_journal_entry_lock(struct recovery_journal *journal,
 /**
  * initiate_drain() - Initiate a drain.
  *
- * Implements vdo_admin_initiator.
+ * Implements vdo_admin_initiator_fn.
  */
 static void initiate_drain(struct admin_state *state)
 {

--- a/drivers/md/dm-vdo/recovery-journal.c
+++ b/drivers/md/dm-vdo/recovery-journal.c
@@ -86,8 +86,7 @@ static inline atomic_t *get_zone_count_ptr(struct recovery_journal *journal,
  * Return: The counter for the given lock and zone.
  */
 static inline u16 *get_counter(struct recovery_journal *journal,
-			       block_count_t lock_number,
-			       enum vdo_zone_type zone_type,
+			       block_count_t lock_number, enum vdo_zone_type zone_type,
 			       zone_count_t zone_id)
 {
 	struct lock_counter *counter = &journal->lock_counter;
@@ -102,7 +101,8 @@ static inline u16 *get_counter(struct recovery_journal *journal,
 	return &counter->physical_counters[zone_counter];
 }
 
-static atomic_t *get_decrement_counter(struct recovery_journal *journal, block_count_t lock_number)
+static atomic_t *get_decrement_counter(struct recovery_journal *journal,
+				       block_count_t lock_number)
 {
 	return &journal->lock_counter.journal_decrement_counts[lock_number];
 }
@@ -114,9 +114,10 @@ static atomic_t *get_decrement_counter(struct recovery_journal *journal, block_c
  *
  * Return: true if the journal zone is locked.
  */
-static bool is_journal_zone_locked(struct recovery_journal *journal, block_count_t lock_number)
+static bool is_journal_zone_locked(struct recovery_journal *journal,
+				   block_count_t lock_number)
 {
-	u16 journal_value = *(get_counter(journal, lock_number, VDO_ZONE_TYPE_JOURNAL, 0));
+	u16 journal_value = *get_counter(journal, lock_number, VDO_ZONE_TYPE_JOURNAL, 0);
 	u32 decrements = atomic_read(get_decrement_counter(journal, lock_number));
 
 	/* Pairs with barrier in vdo_release_journal_entry_lock() */
@@ -152,7 +153,8 @@ void vdo_release_recovery_journal_block_reference(struct recovery_journal *journ
 	lock_number = vdo_get_recovery_journal_block_number(journal, sequence_number);
 	current_value = get_counter(journal, lock_number, zone_type, zone_id);
 
-	ASSERT_LOG_ONLY((*current_value >= 1), "decrement of lock counter must not underflow");
+	ASSERT_LOG_ONLY((*current_value >= 1),
+			"decrement of lock counter must not underflow");
 	*current_value -= 1;
 
 	if (zone_type == VDO_ZONE_TYPE_JOURNAL) {
@@ -187,8 +189,7 @@ void vdo_release_recovery_journal_block_reference(struct recovery_journal *journ
 	vdo_launch_completion(&journal->lock_counter.completion);
 }
 
-static inline struct recovery_journal_block * __must_check
-get_journal_block(struct list_head *list)
+static inline struct recovery_journal_block * __must_check get_journal_block(struct list_head *list)
 {
 	return list_first_entry_or_null(list, struct recovery_journal_block, list_node);
 }
@@ -199,8 +200,7 @@ get_journal_block(struct list_head *list)
  *
  * Return: The block or NULL if the list is empty.
  */
-static struct recovery_journal_block * __must_check
-pop_free_list(struct recovery_journal *journal)
+static struct recovery_journal_block * __must_check pop_free_list(struct recovery_journal *journal)
 {
 	struct recovery_journal_block *block;
 
@@ -208,8 +208,7 @@ pop_free_list(struct recovery_journal *journal)
 		return NULL;
 
 	block = list_last_entry(&journal->free_tail_blocks,
-				struct recovery_journal_block,
-				list_node);
+				struct recovery_journal_block, list_node);
 	list_del_init(&block->list_node);
 	return block;
 }
@@ -255,7 +254,8 @@ static inline bool __must_check is_block_full(const struct recovery_journal_bloc
  * @journal: The journal.
  * @function_name: The function doing the check (for logging).
  */
-static void assert_on_journal_thread(struct recovery_journal *journal, const char *function_name)
+static void assert_on_journal_thread(struct recovery_journal *journal,
+				     const char *function_name)
 {
 	ASSERT_LOG_ONLY((vdo_get_callback_thread_id() == journal->thread_id),
 			"%s() called on journal thread", function_name);
@@ -310,8 +310,7 @@ static bool suspend_lock_counter(struct lock_counter *counter)
 	 * implicitly had them.
 	 */
 	smp_mb__before_atomic();
-	prior_state = atomic_cmpxchg(&counter->state,
-				     LOCK_COUNTER_STATE_NOT_NOTIFYING,
+	prior_state = atomic_cmpxchg(&counter->state, LOCK_COUNTER_STATE_NOT_NOTIFYING,
 				     LOCK_COUNTER_STATE_SUSPENDED);
 	/* same as before_atomic */
 	smp_mb__after_atomic();
@@ -344,7 +343,8 @@ static void check_for_drain_complete(struct recovery_journal *journal)
 		recycle_journal_blocks(journal);
 
 		/* Release any data_vios waiting to be assigned entries. */
-		vdo_notify_all_waiters(&journal->entry_waiters, continue_waiter, &result);
+		vdo_notify_all_waiters(&journal->entry_waiters, continue_waiter,
+				       &result);
 	}
 
 	if (!vdo_is_state_draining(&journal->state) ||
@@ -377,8 +377,8 @@ static void check_for_drain_complete(struct recovery_journal *journal)
  *
  * Implements vdo_read_only_notification.
  */
-static void
-notify_recovery_journal_of_read_only_mode(void *listener, struct vdo_completion *parent)
+static void notify_recovery_journal_of_read_only_mode(void *listener,
+						      struct vdo_completion *parent)
 {
 	check_for_drain_complete(listener);
 	vdo_finish_completion(parent);
@@ -392,7 +392,8 @@ notify_recovery_journal_of_read_only_mode(void *listener, struct vdo_completion 
  * All attempts to add entries after this function is called will fail. All VIOs waiting for
  * commits will be awakened with an error.
  */
-static void enter_journal_read_only_mode(struct recovery_journal *journal, int error_code)
+static void enter_journal_read_only_mode(struct recovery_journal *journal,
+					 int error_code)
 {
 	vdo_enter_read_only_mode(journal->flush_vio->completion.vdo, error_code);
 	check_for_drain_complete(journal);
@@ -407,8 +408,7 @@ static void enter_journal_read_only_mode(struct recovery_journal *journal, int e
  *
  * Return: The sequence number of the tail block.
  */
-sequence_number_t
-vdo_get_recovery_journal_current_sequence_number(struct recovery_journal *journal)
+sequence_number_t vdo_get_recovery_journal_current_sequence_number(struct recovery_journal *journal)
 {
 	return journal->tail;
 }
@@ -528,7 +528,8 @@ static void initialize_journal_state(struct recovery_journal *journal)
 	journal->block_map_head_block_number =
 		vdo_get_recovery_journal_block_number(journal, journal->block_map_head);
 	journal->slab_journal_head_block_number =
-		vdo_get_recovery_journal_block_number(journal, journal->slab_journal_head);
+		vdo_get_recovery_journal_block_number(journal,
+						      journal->slab_journal_head);
 	journal->available_space =
 		(journal->entries_per_block * vdo_get_recovery_journal_length(journal->size));
 }
@@ -586,7 +587,8 @@ static void reap_recovery_journal_callback(struct vdo_completion *completion)
  *
  * Return: VDO_SUCCESS or an error.
  */
-static int __must_check initialize_lock_counter(struct recovery_journal *journal, struct vdo *vdo)
+static int __must_check initialize_lock_counter(struct recovery_journal *journal,
+						struct vdo *vdo)
 {
 	int result;
 	struct thread_config *config = &vdo->thread_config;
@@ -596,40 +598,35 @@ static int __must_check initialize_lock_counter(struct recovery_journal *journal
 	if (result != VDO_SUCCESS)
 		return result;
 
-	result = uds_allocate(journal->size,
-			      atomic_t,
-			      __func__,
+	result = uds_allocate(journal->size, atomic_t, __func__,
 			      &counter->journal_decrement_counts);
 	if (result != VDO_SUCCESS)
 		return result;
 
-	result = uds_allocate(journal->size * config->logical_zone_count,
-			      u16,
-			      __func__,
+	result = uds_allocate(journal->size * config->logical_zone_count, u16, __func__,
 			      &counter->logical_counters);
 	if (result != VDO_SUCCESS)
 		return result;
 
-	result = uds_allocate(journal->size, atomic_t, __func__, &counter->logical_zone_counts);
+	result = uds_allocate(journal->size, atomic_t, __func__,
+			      &counter->logical_zone_counts);
 	if (result != VDO_SUCCESS)
 		return result;
 
-	result = uds_allocate(journal->size * config->physical_zone_count,
-			      u16,
-			      __func__,
+	result = uds_allocate(journal->size * config->physical_zone_count, u16, __func__,
 			      &counter->physical_counters);
 	if (result != VDO_SUCCESS)
 		return result;
 
-	result = uds_allocate(journal->size, atomic_t, __func__, &counter->physical_zone_counts);
+	result = uds_allocate(journal->size, atomic_t, __func__,
+			      &counter->physical_zone_counts);
 	if (result != VDO_SUCCESS)
 		return result;
 
-	vdo_initialize_completion(&counter->completion, vdo, VDO_LOCK_COUNTER_COMPLETION);
-	vdo_prepare_completion(&counter->completion,
-			       reap_recovery_journal_callback,
-			       reap_recovery_journal_callback,
-			       config->journal_thread,
+	vdo_initialize_completion(&counter->completion, vdo,
+				  VDO_LOCK_COUNTER_COMPLETION);
+	vdo_prepare_completion(&counter->completion, reap_recovery_journal_callback,
+			       reap_recovery_journal_callback, config->journal_thread,
 			       journal);
 	counter->logical_zones = config->logical_zone_count;
 	counter->physical_zones = config->physical_zone_count;
@@ -659,8 +656,7 @@ static void set_journal_tail(struct recovery_journal *journal, sequence_number_t
  *
  * Return: VDO_SUCCESS or an error.
  */
-static int initialize_recovery_block(struct vdo *vdo,
-				     struct recovery_journal *journal,
+static int initialize_recovery_block(struct vdo *vdo, struct recovery_journal *journal,
 				     struct recovery_journal_block *block)
 {
 	char *data;
@@ -681,13 +677,8 @@ static int initialize_recovery_block(struct vdo *vdo,
 	if (result != VDO_SUCCESS)
 		return result;
 
-	result = allocate_vio_components(vdo,
-					 VIO_TYPE_RECOVERY_JOURNAL,
-					 VIO_PRIORITY_HIGH,
-					 block,
-					 1,
-					 data,
-					 &block->vio);
+	result = allocate_vio_components(vdo, VIO_TYPE_RECOVERY_JOURNAL,
+					 VIO_PRIORITY_HIGH, block, 1, data, &block->vio);
 	if (result != VDO_SUCCESS) {
 		uds_free(data);
 		return result;
@@ -712,12 +703,9 @@ static int initialize_recovery_block(struct vdo *vdo,
  *
  * Return: A success or error code.
  */
-int vdo_decode_recovery_journal(struct recovery_journal_state_7_0 state,
-				nonce_t nonce,
-				struct vdo *vdo,
-				struct partition *partition,
-				u64 recovery_count,
-				block_count_t journal_size,
+int vdo_decode_recovery_journal(struct recovery_journal_state_7_0 state, nonce_t nonce,
+				struct vdo *vdo, struct partition *partition,
+				u64 recovery_count, block_count_t journal_size,
 				struct recovery_journal **journal_ptr)
 {
 	block_count_t i;
@@ -726,8 +714,7 @@ int vdo_decode_recovery_journal(struct recovery_journal_state_7_0 state,
 
 	result = uds_allocate_extended(struct recovery_journal,
 				       RECOVERY_JOURNAL_RESERVED_BLOCKS,
-				       struct recovery_journal_block,
-				       __func__,
+				       struct recovery_journal_block, __func__,
 				       &journal);
 	if (result != VDO_SUCCESS)
 		return result;
@@ -766,19 +753,14 @@ int vdo_decode_recovery_journal(struct recovery_journal_state_7_0 state,
 		return result;
 	}
 
-	result = create_metadata_vio(vdo,
-				     VIO_TYPE_RECOVERY_JOURNAL,
-				     VIO_PRIORITY_HIGH,
-				     journal,
-				     NULL,
-				     &journal->flush_vio);
+	result = create_metadata_vio(vdo, VIO_TYPE_RECOVERY_JOURNAL, VIO_PRIORITY_HIGH,
+				     journal, NULL, &journal->flush_vio);
 	if (result != VDO_SUCCESS) {
 		vdo_free_recovery_journal(journal);
 		return result;
 	}
 
-	result = vdo_register_read_only_listener(vdo,
-						 journal,
+	result = vdo_register_read_only_listener(vdo, journal,
 						 notify_recovery_journal_of_read_only_mode,
 						 journal->thread_id);
 	if (result != VDO_SUCCESS) {
@@ -847,10 +829,10 @@ void vdo_free_recovery_journal(struct recovery_journal *journal)
  * @block_map_data_blocks: The new number of block map data blocks.
  */
 void vdo_initialize_recovery_journal_post_repair(struct recovery_journal *journal,
-						  u64 recovery_count,
-						  sequence_number_t tail,
-						  block_count_t logical_blocks_used,
-						  block_count_t block_map_data_blocks)
+						 u64 recovery_count,
+						 sequence_number_t tail,
+						 block_count_t logical_blocks_used,
+						 block_count_t block_map_data_blocks)
 {
 	set_journal_tail(journal, tail + 1);
 	journal->recovery_count = compute_recovery_count_byte(recovery_count);
@@ -889,13 +871,11 @@ thread_id_t vdo_get_recovery_journal_thread_id(struct recovery_journal *journal)
  * @block_map: The block map for this VDO.
  */
 void vdo_open_recovery_journal(struct recovery_journal *journal,
-			       struct slab_depot *depot,
-			       struct block_map *block_map)
+			       struct slab_depot *depot, struct block_map *block_map)
 {
 	journal->depot = depot;
 	journal->block_map = block_map;
-	WRITE_ONCE(journal->state.current_state,
-		   VDO_ADMIN_STATE_NORMAL_OPERATION);
+	WRITE_ONCE(journal->state.current_state, VDO_ADMIN_STATE_NORMAL_OPERATION);
 }
 
 /**
@@ -980,7 +960,8 @@ static bool advance_tail(struct recovery_journal *journal)
 		.nonce = journal->nonce,
 		.recovery_count = journal->recovery_count,
 		.sequence_number = journal->tail,
-		.check_byte = vdo_compute_recovery_journal_check_byte(journal, journal->tail),
+		.check_byte = vdo_compute_recovery_journal_check_byte(journal,
+								      journal->tail),
 	};
 
 	header = get_block_header(block);
@@ -988,7 +969,8 @@ static bool advance_tail(struct recovery_journal *journal)
 	block->sequence_number = journal->tail;
 	block->entry_count = 0;
 	block->uncommitted_entry_count = 0;
-	block->block_number = vdo_get_recovery_journal_block_number(journal, journal->tail);
+	block->block_number = vdo_get_recovery_journal_block_number(journal,
+								    journal->tail);
 
 	vdo_pack_recovery_block_header(&unpacked, header);
 	set_active_sector(block, vdo_get_journal_block_sector(header, 1));
@@ -1061,8 +1043,8 @@ static void write_blocks(struct recovery_journal *journal);
  * will be queued for writing when the write finishes. The block must not currently be queued for
  * writing.
  */
-static void
-schedule_block_write(struct recovery_journal *journal, struct recovery_journal_block *block)
+static void schedule_block_write(struct recovery_journal *journal,
+				 struct recovery_journal_block *block)
 {
 	if (!block->committing)
 		vdo_enqueue_waiter(&journal->pending_writes, &block->write_waiter);
@@ -1080,8 +1062,7 @@ static void release_journal_block_reference(struct recovery_journal_block *block
 {
 	vdo_release_recovery_journal_block_reference(block->journal,
 						     block->sequence_number,
-						     VDO_ZONE_TYPE_JOURNAL,
-						     0);
+						     VDO_ZONE_TYPE_JOURNAL, 0);
 }
 
 static void update_usages(struct recovery_journal *journal, struct data_vio *data_vio)
@@ -1147,8 +1128,7 @@ static void assign_entries(struct recovery_journal *journal)
 
 	journal->adding_entries = true;
 	while (vdo_has_waiters(&journal->entry_waiters) && prepare_to_assign_entry(journal)) {
-		vdo_notify_next_waiter(&journal->entry_waiters,
-				       assign_entry,
+		vdo_notify_next_waiter(&journal->entry_waiters, assign_entry,
 				       journal->active_block);
 	}
 
@@ -1236,11 +1216,11 @@ static void notify_commit_waiters(struct recovery_journal *journal)
 		if (block->committing)
 			return;
 
-		vdo_notify_all_waiters(&block->commit_waiters, continue_committed_waiter, journal);
+		vdo_notify_all_waiters(&block->commit_waiters, continue_committed_waiter,
+				       journal);
 		if (is_read_only(journal)) {
 			vdo_notify_all_waiters(&block->entry_waiters,
-					       continue_committed_waiter,
-					       journal);
+					       continue_committed_waiter, journal);
 		} else if (is_block_dirty(block) || !is_block_full(block)) {
 			/* Stop at partially-committed or partially-filled blocks. */
 			return;
@@ -1262,7 +1242,8 @@ static void recycle_journal_blocks(struct recovery_journal *journal)
 			return;
 		}
 
-		if (!is_read_only(journal) && (is_block_dirty(block) || !is_block_full(block))) {
+		if (!is_read_only(journal) &&
+		    (is_block_dirty(block) || !is_block_full(block))) {
 			/*
 			 * Don't recycle partially written or partially full blocks, except in
 			 * read-only mode.
@@ -1355,7 +1336,8 @@ static void add_queued_recovery_entries(struct recovery_journal_block *block)
 		struct recovery_journal_entry new_entry;
 
 		if (block->sector->entry_count == RECOVERY_JOURNAL_ENTRIES_PER_SECTOR)
-			set_active_sector(block, (char *) block->sector + VDO_SECTOR_SIZE);
+			set_active_sector(block,
+					  (char *) block->sector + VDO_SECTOR_SIZE);
 
 		/* Compose and encode the entry. */
 		packed_entry = &block->sector->entries[block->sector->entry_count++];
@@ -1412,11 +1394,8 @@ static void write_block(struct waiter *waiter, void *context __always_unused)
 	 * the data being referenced is stable. The FUA is necessary to ensure that the journal
 	 * block itself is stable before allowing overwrites of the lbn's previous data.
 	 */
-	submit_metadata_vio(&block->vio,
-			    journal->origin + block->block_number,
-			    complete_write_endio,
-			    handle_write_error,
-			    WRITE_FLAGS);
+	submit_metadata_vio(&block->vio, journal->origin + block->block_number,
+			    complete_write_endio, handle_write_error, WRITE_FLAGS);
 }
 
 
@@ -1462,7 +1441,8 @@ static void write_blocks(struct recovery_journal *journal)
  * This method is asynchronous. The data_vio will not be called back until the entry is committed
  * to the on-disk journal.
  */
-void vdo_add_recovery_journal_entry(struct recovery_journal *journal, struct data_vio *data_vio)
+void vdo_add_recovery_journal_entry(struct recovery_journal *journal,
+				    struct data_vio *data_vio)
 {
 	assert_on_journal_thread(journal, __func__);
 	if (!vdo_is_state_normal(&journal->state)) {
@@ -1494,10 +1474,8 @@ void vdo_add_recovery_journal_entry(struct recovery_journal *journal, struct dat
  *
  * Return: true if the specified lock has references (is locked).
  */
-static bool
-is_lock_locked(struct recovery_journal *journal,
-	       block_count_t lock_number,
-	       enum vdo_zone_type zone_type)
+static bool is_lock_locked(struct recovery_journal *journal, block_count_t lock_number,
+			   enum vdo_zone_type zone_type)
 {
 	atomic_t *zone_count;
 	bool locked;
@@ -1536,8 +1514,7 @@ static void reap_recovery_journal(struct recovery_journal *journal)
 	 * block is referenced.
 	 */
 	while ((journal->block_map_reap_head < journal->last_write_acknowledged) &&
-		!is_lock_locked(journal,
-				journal->block_map_head_block_number,
+		!is_lock_locked(journal, journal->block_map_head_block_number,
 				VDO_ZONE_TYPE_LOGICAL)) {
 		journal->block_map_reap_head++;
 		if (++journal->block_map_head_block_number == journal->size)
@@ -1545,8 +1522,7 @@ static void reap_recovery_journal(struct recovery_journal *journal)
 	}
 
 	while ((journal->slab_journal_reap_head < journal->last_write_acknowledged) &&
-		!is_lock_locked(journal,
-				journal->slab_journal_head_block_number,
+		!is_lock_locked(journal, journal->slab_journal_head_block_number,
 				VDO_ZONE_TYPE_PHYSICAL)) {
 		journal->slab_journal_reap_head++;
 		if (++journal->slab_journal_head_block_number == journal->size)
@@ -1675,8 +1651,7 @@ static bool resume_lock_counter(struct lock_counter *counter)
 	 * had them.
 	 */
 	smp_mb__before_atomic();
-	prior_state = atomic_cmpxchg(&counter->state,
-				     LOCK_COUNTER_STATE_SUSPENDED,
+	prior_state = atomic_cmpxchg(&counter->state, LOCK_COUNTER_STATE_SUSPENDED,
 				     LOCK_COUNTER_STATE_NOT_NOTIFYING);
 	/* same as before_atomic */
 	smp_mb__after_atomic();
@@ -1689,7 +1664,8 @@ static bool resume_lock_counter(struct lock_counter *counter)
  * @journal: The journal to resume.
  * @parent: The completion to finish once the journal is resumed.
  */
-void vdo_resume_recovery_journal(struct recovery_journal *journal, struct vdo_completion *parent)
+void vdo_resume_recovery_journal(struct recovery_journal *journal,
+				 struct vdo_completion *parent)
 {
 	bool saved;
 
@@ -1743,8 +1719,7 @@ vdo_get_recovery_journal_statistics(const struct recovery_journal *journal)
 static void dump_recovery_block(const struct recovery_journal_block *block)
 {
 	uds_log_info("    sequence number %llu; entries %u; %s; %zu entry waiters; %zu commit waiters",
-		     (unsigned long long) block->sequence_number,
-		     block->entry_count,
+		     (unsigned long long) block->sequence_number, block->entry_count,
 		     (block->committing ? "committing" : "waiting"),
 		     vdo_count_waiters(&block->entry_waiters),
 		     vdo_count_waiters(&block->commit_waiters));

--- a/drivers/md/dm-vdo/recovery-journal.h
+++ b/drivers/md/dm-vdo/recovery-journal.h
@@ -248,8 +248,7 @@ vdo_compute_recovery_journal_check_byte(const struct recovery_journal *journal,
 }
 
 int __must_check vdo_decode_recovery_journal(struct recovery_journal_state_7_0 state,
-					     nonce_t nonce,
-					     struct vdo *vdo,
+					     nonce_t nonce, struct vdo *vdo,
 					     struct partition *partition,
 					     u64 recovery_count,
 					     block_count_t journal_size,
@@ -269,8 +268,7 @@ vdo_get_journal_block_map_data_blocks_used(struct recovery_journal *journal);
 thread_id_t __must_check vdo_get_recovery_journal_thread_id(struct recovery_journal *journal);
 
 void vdo_open_recovery_journal(struct recovery_journal *journal,
-			       struct slab_depot *depot,
-			       struct block_map *block_map);
+			       struct slab_depot *depot, struct block_map *block_map);
 
 sequence_number_t
 vdo_get_recovery_journal_current_sequence_number(struct recovery_journal *journal);
@@ -280,7 +278,8 @@ block_count_t __must_check vdo_get_recovery_journal_length(block_count_t journal
 struct recovery_journal_state_7_0 __must_check
 vdo_record_recovery_journal(const struct recovery_journal *journal);
 
-void vdo_add_recovery_journal_entry(struct recovery_journal *journal, struct data_vio *data_vio);
+void vdo_add_recovery_journal_entry(struct recovery_journal *journal,
+				    struct data_vio *data_vio);
 
 void vdo_acquire_recovery_journal_block_reference(struct recovery_journal *journal,
 						  sequence_number_t sequence_number,

--- a/drivers/md/dm-vdo/repair.c
+++ b/drivers/md/dm-vdo/repair.c
@@ -200,7 +200,7 @@ as_repair_completion(struct vdo_completion *completion)
 }
 
 static void prepare_repair_completion(struct repair_completion *repair,
-				      vdo_action *callback, enum vdo_zone_type zone_type)
+				      vdo_action_fn callback, enum vdo_zone_type zone_type)
 {
 	struct vdo_completion *completion = &repair->completion;
 	const struct thread_config *thread_config = &completion->vdo->thread_config;
@@ -215,7 +215,7 @@ static void prepare_repair_completion(struct repair_completion *repair,
 }
 
 static void launch_repair_completion(struct repair_completion *repair,
-				     vdo_action *callback, enum vdo_zone_type zone_type)
+				     vdo_action_fn callback, enum vdo_zone_type zone_type)
 {
 	prepare_repair_completion(repair, callback, zone_type);
 	vdo_launch_completion(&repair->completion);
@@ -604,7 +604,7 @@ static void rebuild_from_leaves(struct vdo_completion *completion)
  * @pbn: A pbn which holds a block map tree page.
  * @completion: The parent completion of the traversal.
  *
- * Implements vdo_entry_callback.
+ * Implements vdo_entry_callback_fn.
  *
  * Return: VDO_SUCCESS or an error.
  */
@@ -1710,8 +1710,7 @@ void vdo_repair(struct vdo_completion *parent)
 	}
 
 	result = uds_allocate_extended(struct repair_completion, page_count,
-				       struct vdo_page_completion, __func__,
-				       &repair);
+				       struct vdo_page_completion, __func__, &repair);
 	if (result != VDO_SUCCESS) {
 		vdo_fail_completion(parent, result);
 		return;
@@ -1738,9 +1737,8 @@ void vdo_repair(struct vdo_completion *parent)
 					     MAX_BLOCKS_PER_VIO);
 
 		result = allocate_vio_components(vdo, VIO_TYPE_RECOVERY_JOURNAL,
-						 VIO_PRIORITY_METADATA,
-						 repair, blocks, ptr,
-						 &repair->vios[repair->vio_count]);
+						 VIO_PRIORITY_METADATA, repair, blocks,
+						 ptr, &repair->vios[repair->vio_count]);
 		if (abort_on_error(result, repair))
 			return;
 

--- a/drivers/md/dm-vdo/repair.c
+++ b/drivers/md/dm-vdo/repair.c
@@ -168,8 +168,7 @@ static const struct min_heap_callbacks repair_min_heap = {
 	.swp = swap_mappings,
 };
 
-static struct numbered_block_mapping *
-sort_next_heap_element(struct repair_completion *repair)
+static struct numbered_block_mapping *sort_next_heap_element(struct repair_completion *repair)
 {
 	struct min_heap *heap = &repair->replay_heap;
 	struct numbered_block_mapping *last;
@@ -201,8 +200,7 @@ as_repair_completion(struct vdo_completion *completion)
 }
 
 static void prepare_repair_completion(struct repair_completion *repair,
-				      vdo_action *callback,
-				      enum vdo_zone_type zone_type)
+				      vdo_action *callback, enum vdo_zone_type zone_type)
 {
 	struct vdo_completion *completion = &repair->completion;
 	const struct thread_config *thread_config = &completion->vdo->thread_config;
@@ -217,8 +215,7 @@ static void prepare_repair_completion(struct repair_completion *repair,
 }
 
 static void launch_repair_completion(struct repair_completion *repair,
-				     vdo_action *callback,
-				     enum vdo_zone_type zone_type)
+				     vdo_action *callback, enum vdo_zone_type zone_type)
 {
 	prepare_repair_completion(repair, callback, zone_type);
 	vdo_launch_completion(&repair->completion);
@@ -354,13 +351,14 @@ static void flush_block_map_updates(struct vdo_completion *completion)
 	vdo_assert_on_admin_thread(completion->vdo, __func__);
 
 	uds_log_info("Flushing block map changes");
-	prepare_repair_completion(as_repair_completion(completion),
-				  drain_slab_depot,
+	prepare_repair_completion(as_repair_completion(completion), drain_slab_depot,
 				  VDO_ZONE_TYPE_ADMIN);
-	vdo_drain_block_map(completion->vdo->block_map, VDO_ADMIN_STATE_RECOVERING, completion);
+	vdo_drain_block_map(completion->vdo->block_map, VDO_ADMIN_STATE_RECOVERING,
+			    completion);
 }
 
-static bool fetch_page(struct repair_completion *repair, struct vdo_completion *completion);
+static bool fetch_page(struct repair_completion *repair,
+		       struct vdo_completion *completion);
 
 /**
  * handle_page_load_error() - Handle an error loading a page.
@@ -382,8 +380,8 @@ static void handle_page_load_error(struct vdo_completion *completion)
  * @completion: The page_completion for writing the page
  * @slot: The slot to unmap
  */
-static void
-unmap_entry(struct block_map_page *page, struct vdo_completion *completion, slot_number_t slot)
+static void unmap_entry(struct block_map_page *page, struct vdo_completion *completion,
+			slot_number_t slot)
 {
 	page->entries[slot] = UNMAPPED_BLOCK_MAP_ENTRY;
 	vdo_request_page_write(completion);
@@ -417,8 +415,8 @@ static void remove_out_of_bounds_entries(struct block_map_page *page,
  *
  * Return: true if the entry was a valid mapping
  */
-static bool
-process_slot(struct block_map_page *page, struct vdo_completion *completion, slot_number_t slot)
+static bool process_slot(struct block_map_page *page, struct vdo_completion *completion,
+			 slot_number_t slot)
 {
 	struct slab_depot *depot = completion->vdo->depot;
 	int result;
@@ -446,8 +444,7 @@ process_slot(struct block_map_page *page, struct vdo_completion *completion, slo
 		return false;
 	}
 
-	result = vdo_adjust_reference_count_for_rebuild(depot,
-							mapping.pbn,
+	result = vdo_adjust_reference_count_for_rebuild(depot, mapping.pbn,
 							VDO_JOURNAL_DATA_REMAPPING);
 	if (result == VDO_SUCCESS)
 		return true;
@@ -455,8 +452,7 @@ process_slot(struct block_map_page *page, struct vdo_completion *completion, slo
 	uds_log_error_strerror(result,
 			       "Could not adjust reference count for PBN %llu, slot %u mapped to PBN %llu",
 			       (unsigned long long) vdo_get_block_map_page_pbn(page),
-			       slot,
-			       (unsigned long long) mapping.pbn);
+			       slot, (unsigned long long) mapping.pbn);
 	unmap_entry(page, completion, slot);
 	return false;
 }
@@ -515,8 +511,8 @@ static void page_loaded(struct vdo_completion *completion)
 	fetch_page(repair, completion);
 }
 
-static physical_block_number_t
-get_pbn_to_fetch(struct repair_completion *repair, struct block_map *block_map)
+static physical_block_number_t get_pbn_to_fetch(struct repair_completion *repair,
+						struct block_map *block_map)
 {
 	physical_block_number_t pbn = VDO_ZERO_BLOCK;
 
@@ -540,7 +536,8 @@ get_pbn_to_fetch(struct repair_completion *repair, struct block_map *block_map)
  *
  * Return true if the rebuild is complete
  */
-static bool fetch_page(struct repair_completion *repair, struct vdo_completion *completion)
+static bool fetch_page(struct repair_completion *repair,
+		       struct vdo_completion *completion)
 {
 	struct vdo_page_completion *page_completion = (struct vdo_page_completion *) completion;
 	struct block_map *block_map = repair->completion.vdo->block_map;
@@ -552,14 +549,8 @@ static bool fetch_page(struct repair_completion *repair, struct vdo_completion *
 		 * We must set the requeue flag here to ensure that we don't blow the stack if all
 		 * the requested pages are already in the cache or get load errors.
 		 */
-		vdo_get_page(page_completion,
-			     &block_map->zones[0],
-			     pbn,
-			     true,
-			     repair,
-			     page_loaded,
-			     handle_page_load_error,
-			     true);
+		vdo_get_page(page_completion, &block_map->zones[0], pbn, true, repair,
+			     page_loaded, handle_page_load_error, true);
 	}
 
 	if (repair->outstanding > 0)
@@ -629,8 +620,7 @@ static int process_entry(physical_block_number_t pbn, struct vdo_completion *com
 					      (unsigned long long) pbn);
 	}
 
-	result = vdo_adjust_reference_count_for_rebuild(depot,
-							pbn,
+	result = vdo_adjust_reference_count_for_rebuild(depot, pbn,
 							VDO_JOURNAL_BLOCK_MAP_REMAPPING);
 	if (result != VDO_SUCCESS) {
 		return uds_log_error_strerror(result,
@@ -686,8 +676,8 @@ static void increment_recovery_point(struct recovery_point *point)
  * @repair: The repair_completion whose points are to be advanced.
  * @entries_per_block: The number of entries in a recovery journal block.
  */
-static void
-advance_points(struct repair_completion *repair, journal_entry_count_t entries_per_block)
+static void advance_points(struct repair_completion *repair,
+			   journal_entry_count_t entries_per_block)
 {
 	if (!repair->next_recovery_point.increment_applied) {
 		repair->next_recovery_point.increment_applied	= true;
@@ -706,8 +696,8 @@ advance_points(struct repair_completion *repair, journal_entry_count_t entries_p
  *
  * Return: true if the first point precedes the second point.
  */
-static bool __must_check
-before_recovery_point(const struct recovery_point *first, const struct recovery_point *second)
+static bool __must_check before_recovery_point(const struct recovery_point *first,
+					       const struct recovery_point *second)
 {
 	if (first->sequence_number < second->sequence_number)
 		return true;
@@ -722,11 +712,10 @@ before_recovery_point(const struct recovery_point *first, const struct recovery_
 		(first->entry_count < second->entry_count));
 }
 
-static struct packed_journal_sector * __must_check
-get_sector(struct recovery_journal *journal,
-	   char *journal_data,
-	   sequence_number_t sequence,
-	   u8 sector_number)
+static struct packed_journal_sector * __must_check get_sector(struct recovery_journal *journal,
+							      char *journal_data,
+							      sequence_number_t sequence,
+							      u8 sector_number)
 {
 	off_t offset;
 
@@ -742,14 +731,13 @@ get_sector(struct recovery_journal *journal,
  *
  * Return: The unpacked contents of the matching recovery journal entry.
  */
-static struct recovery_journal_entry
-get_entry(const struct repair_completion *repair, const struct recovery_point *point)
+static struct recovery_journal_entry get_entry(const struct repair_completion *repair,
+					       const struct recovery_point *point)
 {
 	struct packed_journal_sector *sector;
 
 	sector = get_sector(repair->completion.vdo->recovery_journal,
-			    repair->journal_data,
-			    point->sequence_number,
+			    repair->journal_data, point->sequence_number,
 			    point->sector_count);
 	return vdo_unpack_recovery_journal_entry(&sector->entries[point->entry_count]);
 }
@@ -761,8 +749,8 @@ get_entry(const struct repair_completion *repair, const struct recovery_point *p
  *
  * Return: VDO_SUCCESS or an error.
  */
-static int
-validate_recovery_journal_entry(const struct vdo *vdo, const struct recovery_journal_entry *entry)
+static int validate_recovery_journal_entry(const struct vdo *vdo,
+					   const struct recovery_journal_entry *entry)
 {
 	if ((entry->slot.pbn >= vdo->states.vdo.config.physical_blocks) ||
 	    (entry->slot.slot >= VDO_BLOCK_MAP_ENTRIES_PER_PAGE) ||
@@ -812,11 +800,9 @@ static void add_slab_journal_entries(struct vdo_completion *completion)
 	struct block_allocator *allocator = vdo_as_block_allocator(completion);
 
 	/* Get ready in case we need to enqueue again. */
-	vdo_prepare_completion(completion,
-			       add_slab_journal_entries,
+	vdo_prepare_completion(completion, add_slab_journal_entries,
 			       vdo_notify_slab_journals_are_recovered,
-			       completion->callback_thread_id,
-			       repair);
+			       completion->callback_thread_id, repair);
 	for (recovery_point = &repair->next_recovery_point;
 	     before_recovery_point(recovery_point, &repair->tail_recovery_point);
 	     advance_points(repair, journal->entries_per_block)) {
@@ -846,10 +832,7 @@ static void add_slab_journal_entries(struct vdo_completion *completion)
 		if (slab->allocator != allocator)
 			continue;
 
-		if (!vdo_attempt_replay_into_slab(slab,
-						  pbn,
-						  entry.operation,
-						  increment,
+		if (!vdo_attempt_replay_into_slab(slab, pbn, entry.operation, increment,
 						  &repair->next_journal_point,
 						  completion))
 			return;
@@ -892,7 +875,8 @@ void vdo_replay_into_slab_journals(struct block_allocator *allocator, void *cont
 		.entry_count = 0,
 	};
 
-	uds_log_info("Replaying entries into slab journals for zone %u", allocator->zone_number);
+	uds_log_info("Replaying entries into slab journals for zone %u",
+		     allocator->zone_number);
 	completion->parent = repair;
 	add_slab_journal_entries(completion);
 }
@@ -905,7 +889,8 @@ static void load_slab_depot(struct vdo_completion *completion)
 	vdo_assert_on_admin_thread(completion->vdo, __func__);
 
 	if (vdo_state_requires_read_only_rebuild(completion->vdo->load_state)) {
-		prepare_repair_completion(repair, rebuild_reference_counts, VDO_ZONE_TYPE_LOGICAL);
+		prepare_repair_completion(repair, rebuild_reference_counts,
+					  VDO_ZONE_TYPE_LOGICAL);
 		operation = VDO_ADMIN_STATE_LOADING_FOR_REBUILD;
 	} else {
 		prepare_repair_completion(repair, drain_slab_depot, VDO_ZONE_TYPE_ADMIN);
@@ -975,8 +960,7 @@ static void abort_block_map_recovery(struct repair_completion *repair, int resul
  */
 static struct numbered_block_mapping *
 find_entry_starting_next_page(struct repair_completion *repair,
-			      struct numbered_block_mapping *current_entry,
-			      bool needs_sort)
+			      struct numbered_block_mapping *current_entry, bool needs_sort)
 {
 	size_t current_page;
 
@@ -1050,20 +1034,17 @@ static void fetch_block_map_page(struct repair_completion *repair,
 	/* Fetch the next page we haven't yet requested. */
 	pbn = repair->current_unfetched_entry->block_map_slot.pbn;
 	repair->current_unfetched_entry =
-		find_entry_starting_next_page(repair, repair->current_unfetched_entry, true);
+		find_entry_starting_next_page(repair, repair->current_unfetched_entry,
+					      true);
 	repair->outstanding++;
 	vdo_get_page(((struct vdo_page_completion *) completion),
-		     &repair->completion.vdo->block_map->zones[0],
-		     pbn,
-		     true,
-		     &repair->completion,
-		     block_map_page_loaded,
-		     handle_block_map_page_load_error,
-		     false);
+		     &repair->completion.vdo->block_map->zones[0], pbn, true,
+		     &repair->completion, block_map_page_loaded,
+		     handle_block_map_page_load_error, false);
 }
 
-static struct vdo_page_completion *
-get_next_page_completion(struct repair_completion *repair, struct vdo_page_completion *completion)
+static struct vdo_page_completion *get_next_page_completion(struct repair_completion *repair,
+							    struct vdo_page_completion *completion)
 {
 	completion++;
 	if (completion == (&repair->page_completions[repair->page_count]))
@@ -1094,8 +1075,10 @@ static void recover_ready_pages(struct repair_completion *repair,
 		}
 
 		start_of_next_page =
-			find_entry_starting_next_page(repair, repair->current_entry, false);
-		apply_journal_entries_to_page(page, repair->current_entry, start_of_next_page);
+			find_entry_starting_next_page(repair, repair->current_entry,
+						      false);
+		apply_journal_entries_to_page(page, repair->current_entry,
+					      start_of_next_page);
 		repair->current_entry = start_of_next_page;
 		vdo_request_page_write(completion);
 		vdo_release_page_completion(completion);
@@ -1175,8 +1158,7 @@ static void recover_block_map(struct vdo_completion *completion)
  * Return: The unpacked header.
  */
 static struct recovery_block_header __must_check
-get_recovery_journal_block_header(struct recovery_journal *journal,
-				  char *data,
+get_recovery_journal_block_header(struct recovery_journal *journal, char *data,
 				  sequence_number_t sequence)
 {
 	physical_block_number_t pbn =
@@ -1198,10 +1180,9 @@ get_recovery_journal_block_header(struct recovery_journal *journal,
  *
  * Return: True if the header is valid.
  */
-static bool __must_check
-is_valid_recovery_journal_block(const struct recovery_journal *journal,
-				const struct recovery_block_header *header,
-				bool old_ok)
+static bool __must_check is_valid_recovery_journal_block(const struct recovery_journal *journal,
+							 const struct recovery_block_header *header,
+							 bool old_ok)
 {
 	if ((header->nonce != journal->nonce) ||
 	    (header->recovery_count != journal->recovery_count))
@@ -1225,11 +1206,10 @@ is_valid_recovery_journal_block(const struct recovery_journal *journal,
  *
  * Return: True if the block matches.
  */
-static bool __must_check
-is_exact_recovery_journal_block(const struct recovery_journal *journal,
-				const struct recovery_block_header *header,
-				sequence_number_t sequence,
-				enum vdo_metadata_type type)
+static bool __must_check is_exact_recovery_journal_block(const struct recovery_journal *journal,
+							 const struct recovery_block_header *header,
+							 sequence_number_t sequence,
+							 enum vdo_metadata_type type)
 {
 	return ((header->metadata_type == type) &&
 		(header->sequence_number == sequence) &&
@@ -1294,9 +1274,7 @@ static bool find_recovery_journal_head_and_tail(struct repair_completion *repair
  *
  * Return: true if the entry should be applied.3
  */
-static bool unpack_entry(struct vdo *vdo,
-			 char *packed,
-			 enum vdo_metadata_type format,
+static bool unpack_entry(struct vdo *vdo, char *packed, enum vdo_metadata_type format,
 			 struct recovery_journal_entry *entry)
 {
 	if (format == VDO_METADATA_RECOVERY_JOURNAL_2) {
@@ -1342,8 +1320,7 @@ static bool unpack_entry(struct vdo *vdo,
  * @format: The format of the sector.
  * @entry_count: The number of entries to append.
  */
-static void append_sector_entries(struct repair_completion *repair,
-				  char *entries,
+static void append_sector_entries(struct repair_completion *repair, char *entries,
 				  enum vdo_metadata_type format,
 				  journal_entry_count_t entry_count)
 {
@@ -1371,7 +1348,8 @@ static void append_sector_entries(struct repair_completion *repair,
 	}
 }
 
-static journal_entry_count_t entries_per_sector(enum vdo_metadata_type format, u8 sector_number)
+static journal_entry_count_t entries_per_sector(enum vdo_metadata_type format,
+						u8 sector_number)
 {
 	if (format == VDO_METADATA_RECOVERY_JOURNAL_2)
 		return RECOVERY_JOURNAL_ENTRIES_PER_SECTOR;
@@ -1389,7 +1367,8 @@ static void extract_entries_from_block(struct repair_completion *repair,
 {
 	sector_count_t i;
 	struct recovery_block_header header =
-		get_recovery_journal_block_header(journal, repair->journal_data, sequence);
+		get_recovery_journal_block_header(journal, repair->journal_data,
+						  sequence);
 
 	if (!is_exact_recovery_journal_block(journal, &header, sequence, format)) {
 		/* This block is invalid, so skip it. */
@@ -1400,13 +1379,12 @@ static void extract_entries_from_block(struct repair_completion *repair,
 	for (i = 1; i < VDO_SECTORS_PER_BLOCK; i++) {
 		struct packed_journal_sector *sector =
 			get_sector(journal, repair->journal_data, sequence, i);
-		journal_entry_count_t sector_entries = min(entries, entries_per_sector(format, i));
+		journal_entry_count_t sector_entries =
+			min(entries, entries_per_sector(format, i));
 
 		if (vdo_is_valid_recovery_journal_sector(&header, sector, i)) {
 			/* Only extract as many as the block header calls for. */
-			append_sector_entries(repair,
-					      (char *) sector->entries,
-					      format,
+			append_sector_entries(repair, (char *) sector->entries, format,
 					      min_t(journal_entry_count_t,
 						    sector->entry_count,
 						    sector_entries));
@@ -1430,8 +1408,7 @@ static int parse_journal_for_rebuild(struct repair_completion *repair)
 	struct recovery_journal *journal = vdo->recovery_journal;
 	journal_entry_count_t entries_per_block = journal->entries_per_block;
 
-	format = get_recovery_journal_block_header(journal,
-						   repair->journal_data,
+	format = get_recovery_journal_block_header(journal, repair->journal_data,
 						   repair->highest_tail).metadata_type;
 	if (format == VDO_METADATA_RECOVERY_JOURNAL)
 		entries_per_block = RECOVERY_JOURNAL_1_ENTRIES_PER_BLOCK;
@@ -1441,7 +1418,8 @@ static int parse_journal_for_rebuild(struct repair_completion *repair)
 	 * packed_recovery_journal_entry from every valid journal block.
 	 */
 	count = ((repair->highest_tail - repair->block_map_head + 1) * entries_per_block);
-	result = uds_allocate(count, struct numbered_block_mapping, __func__, &repair->entries);
+	result = uds_allocate(count, struct numbered_block_mapping, __func__,
+			      &repair->entries);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -1486,10 +1464,8 @@ static int extract_new_mappings(struct repair_completion *repair)
 	 * Allocate an array of numbered_block_mapping structs just large enough to transcribe
 	 * every packed_recovery_journal_entry from every valid journal block.
 	 */
-	result = uds_allocate(repair->entry_count,
-			      struct numbered_block_mapping,
-			      __func__,
-			      &repair->entries);
+	result = uds_allocate(repair->entry_count, struct numbered_block_mapping,
+			      __func__, &repair->entries);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -1540,7 +1516,8 @@ static noinline int compute_usages(struct repair_completion *repair)
 	struct vdo *vdo = repair->completion.vdo;
 	struct recovery_journal *journal = vdo->recovery_journal;
 	struct recovery_block_header header =
-		get_recovery_journal_block_header(journal, repair->journal_data, repair->tail);
+		get_recovery_journal_block_header(journal, repair->journal_data,
+						  repair->tail);
 
 	repair->logical_blocks_used = header.logical_blocks_used;
 	repair->block_map_data_blocks = header.block_map_data_blocks;
@@ -1596,13 +1573,12 @@ static int parse_journal_for_recovery(struct repair_completion *repair)
 			/* This is an old format block, so we need to upgrade */
 			uds_log_error_strerror(VDO_UNSUPPORTED_VERSION,
 					       "Recovery journal is in the old format, a read-only rebuild is required.");
-			vdo_enter_read_only_mode(repair->completion.vdo, VDO_UNSUPPORTED_VERSION);
+			vdo_enter_read_only_mode(repair->completion.vdo,
+						 VDO_UNSUPPORTED_VERSION);
 			return VDO_UNSUPPORTED_VERSION;
 		}
 
-		if (!is_exact_recovery_journal_block(journal,
-						     &header,
-						     i,
+		if (!is_exact_recovery_journal_block(journal, &header, i,
 						     VDO_METADATA_RECOVERY_JOURNAL_2)) {
 			/* A bad block header was found so this must be the end of the journal. */
 			break;
@@ -1615,7 +1591,8 @@ static int parse_journal_for_recovery(struct repair_completion *repair)
 			struct packed_journal_sector *sector =
 				get_sector(journal, repair->journal_data, i, j);
 			journal_entry_count_t sector_entries =
-				min_t(journal_entry_count_t, sector->entry_count, block_entries);
+				min_t(journal_entry_count_t, sector->entry_count,
+				      block_entries);
 
 			/* A bad sector means that this block was torn. */
 			if (!vdo_is_valid_recovery_journal_sector(&header, sector, j))
@@ -1732,10 +1709,8 @@ void vdo_repair(struct vdo_completion *parent)
 		uds_log_warning("Device was dirty, rebuilding reference counts");
 	}
 
-	result = uds_allocate_extended(struct repair_completion,
-				       page_count,
-				       struct vdo_page_completion,
-				       __func__,
+	result = uds_allocate_extended(struct repair_completion, page_count,
+				       struct vdo_page_completion, __func__,
 				       &repair);
 	if (result != VDO_SUCCESS) {
 		vdo_fail_completion(parent, result);
@@ -1748,7 +1723,8 @@ void vdo_repair(struct vdo_completion *parent)
 	prepare_repair_completion(repair, finish_repair, VDO_ZONE_TYPE_ADMIN);
 	repair->page_count = page_count;
 
-	result = uds_allocate(remaining * VDO_BLOCK_SIZE, char, __func__, &repair->journal_data);
+	result = uds_allocate(remaining * VDO_BLOCK_SIZE, char, __func__,
+			      &repair->journal_data);
 	if (abort_on_error(result, repair))
 		return;
 
@@ -1758,14 +1734,12 @@ void vdo_repair(struct vdo_completion *parent)
 
 	ptr = repair->journal_data;
 	for (repair->vio_count = 0; repair->vio_count < vio_count; repair->vio_count++) {
-		block_count_t blocks = min_t(block_count_t, remaining, MAX_BLOCKS_PER_VIO);
+		block_count_t blocks = min_t(block_count_t, remaining,
+					     MAX_BLOCKS_PER_VIO);
 
-		result = allocate_vio_components(vdo,
-						 VIO_TYPE_RECOVERY_JOURNAL,
+		result = allocate_vio_components(vdo, VIO_TYPE_RECOVERY_JOURNAL,
 						 VIO_PRIORITY_METADATA,
-						 repair,
-						 blocks,
-						 ptr,
+						 repair, blocks, ptr,
 						 &repair->vios[repair->vio_count]);
 		if (abort_on_error(result, repair))
 			return;
@@ -1777,10 +1751,7 @@ void vdo_repair(struct vdo_completion *parent)
 	for (vio_count = 0;
 	     vio_count < repair->vio_count;
 	     vio_count++, pbn += MAX_BLOCKS_PER_VIO) {
-		submit_metadata_vio(&repair->vios[vio_count],
-				    pbn,
-				    read_journal_endio,
-				    handle_journal_load_error,
-				    REQ_OP_READ);
+		submit_metadata_vio(&repair->vios[vio_count], pbn, read_journal_endio,
+				    handle_journal_load_error, REQ_OP_READ);
 	}
 }

--- a/drivers/md/dm-vdo/repair.c
+++ b/drivers/md/dm-vdo/repair.c
@@ -598,12 +598,13 @@ static void rebuild_from_leaves(struct vdo_completion *completion)
 		repair->last_slot.slot = VDO_BLOCK_MAP_ENTRIES_PER_PAGE;
 
 	for (i = 0; i < repair->page_count; i++) {
-		if (fetch_page(repair, &repair->page_completions[i].completion))
+		if (fetch_page(repair, &repair->page_completions[i].completion)) {
 			/*
 			 * The rebuild has already moved on, so it isn't safe nor is there a need
 			 * to launch any more fetches.
 			 */
 			return;
+		}
 	}
 }
 
@@ -622,18 +623,20 @@ static int process_entry(physical_block_number_t pbn, struct vdo_completion *com
 	struct slab_depot *depot = completion->vdo->depot;
 	int result;
 
-	if ((pbn == VDO_ZERO_BLOCK) || !vdo_is_physical_data_block(depot, pbn))
+	if ((pbn == VDO_ZERO_BLOCK) || !vdo_is_physical_data_block(depot, pbn)) {
 		return uds_log_error_strerror(VDO_BAD_CONFIGURATION,
 					      "PBN %llu out of range",
 					      (unsigned long long) pbn);
+	}
 
 	result = vdo_adjust_reference_count_for_rebuild(depot,
 							pbn,
 							VDO_JOURNAL_BLOCK_MAP_REMAPPING);
-	if (result != VDO_SUCCESS)
+	if (result != VDO_SUCCESS) {
 		return uds_log_error_strerror(result,
 					      "Could not adjust reference count for block map tree PBN %llu",
 					      (unsigned long long) pbn);
+	}
 
 	repair->block_map_data_blocks++;
 	return VDO_SUCCESS;
@@ -766,7 +769,7 @@ validate_recovery_journal_entry(const struct vdo *vdo, const struct recovery_jou
 	    !vdo_is_valid_location(&entry->mapping) ||
 	    !vdo_is_valid_location(&entry->unmapping) ||
 	    !vdo_is_physical_data_block(vdo->depot, entry->mapping.pbn) ||
-	    !vdo_is_physical_data_block(vdo->depot, entry->unmapping.pbn))
+	    !vdo_is_physical_data_block(vdo->depot, entry->unmapping.pbn)) {
 		return uds_log_error_strerror(VDO_CORRUPT_JOURNAL,
 					      "Invalid entry: %s (%llu, %u) from %llu to %llu is not within bounds",
 					      vdo_get_journal_operation_name(entry->operation),
@@ -774,12 +777,13 @@ validate_recovery_journal_entry(const struct vdo *vdo, const struct recovery_jou
 					      entry->slot.slot,
 					      (unsigned long long) entry->unmapping.pbn,
 					      (unsigned long long) entry->mapping.pbn);
+	}
 
 	if ((entry->operation == VDO_JOURNAL_BLOCK_MAP_REMAPPING) &&
 	    (vdo_is_state_compressed(entry->mapping.state) ||
 	     (entry->mapping.pbn == VDO_ZERO_BLOCK) ||
 	     (entry->unmapping.state != VDO_MAPPING_STATE_UNMAPPED) ||
-	     (entry->unmapping.pbn != VDO_ZERO_BLOCK)))
+	     (entry->unmapping.pbn != VDO_ZERO_BLOCK))) {
 		return uds_log_error_strerror(VDO_CORRUPT_JOURNAL,
 					      "Invalid entry: %s (%llu, %u) from %llu to %llu is not a valid tree mapping",
 					      vdo_get_journal_operation_name(entry->operation),
@@ -787,6 +791,7 @@ validate_recovery_journal_entry(const struct vdo *vdo, const struct recovery_jou
 					      entry->slot.slot,
 					      (unsigned long long) entry->unmapping.pbn,
 					      (unsigned long long) entry->mapping.pbn);
+	}
 
 	return VDO_SUCCESS;
 }
@@ -1174,7 +1179,8 @@ get_recovery_journal_block_header(struct recovery_journal *journal,
 				  char *data,
 				  sequence_number_t sequence)
 {
-	physical_block_number_t pbn = vdo_get_recovery_journal_block_number(journal, sequence);
+	physical_block_number_t pbn =
+		vdo_get_recovery_journal_block_number(journal, sequence);
 	char *header = &data[pbn * VDO_BLOCK_SIZE];
 
 	return vdo_unpack_recovery_block_header((struct packed_journal_header *) header);
@@ -1251,13 +1257,15 @@ static bool find_recovery_journal_head_and_tail(struct repair_completion *repair
 		struct recovery_block_header header =
 			get_recovery_journal_block_header(journal, repair->journal_data, i);
 
-		if (!is_valid_recovery_journal_block(journal, &header, true))
+		if (!is_valid_recovery_journal_block(journal, &header, true)) {
 			/* This block is old or incorrectly formatted */
 			continue;
+		}
 
-		if (vdo_get_recovery_journal_block_number(journal, header.sequence_number) != i)
+		if (vdo_get_recovery_journal_block_number(journal, header.sequence_number) != i) {
 			/* This block is in the wrong location */
 			continue;
+		}
 
 		if (header.sequence_number >= repair->highest_tail) {
 			found_entries = true;
@@ -1383,9 +1391,10 @@ static void extract_entries_from_block(struct repair_completion *repair,
 	struct recovery_block_header header =
 		get_recovery_journal_block_header(journal, repair->journal_data, sequence);
 
-	if (!is_exact_recovery_journal_block(journal, &header, sequence, format))
+	if (!is_exact_recovery_journal_block(journal, &header, sequence, format)) {
 		/* This block is invalid, so skip it. */
 		return;
+	}
 
 	entries = min(entries, header.entry_count);
 	for (i = 1; i < VDO_SECTORS_PER_BLOCK; i++) {
@@ -1594,9 +1603,10 @@ static int parse_journal_for_recovery(struct repair_completion *repair)
 		if (!is_exact_recovery_journal_block(journal,
 						     &header,
 						     i,
-						     VDO_METADATA_RECOVERY_JOURNAL_2))
+						     VDO_METADATA_RECOVERY_JOURNAL_2)) {
 			/* A bad block header was found so this must be the end of the journal. */
 			break;
+		}
 
 		block_entries = header.entry_count;
 
@@ -1766,10 +1776,11 @@ void vdo_repair(struct vdo_completion *parent)
 
 	for (vio_count = 0;
 	     vio_count < repair->vio_count;
-	     vio_count++, pbn += MAX_BLOCKS_PER_VIO)
+	     vio_count++, pbn += MAX_BLOCKS_PER_VIO) {
 		submit_metadata_vio(&repair->vios[vio_count],
 				    pbn,
 				    read_journal_endio,
 				    handle_journal_load_error,
 				    REQ_OP_READ);
+	}
 }

--- a/drivers/md/dm-vdo/slab-depot.c
+++ b/drivers/md/dm-vdo/slab-depot.c
@@ -37,13 +37,6 @@
 static const u64 BYTES_PER_WORD = sizeof(u64);
 static const bool NORMAL_OPERATION = true;
 
-struct slab_journal_eraser {
-	struct vdo_completion *parent;
-	struct dm_kcopyd_client *client;
-	block_count_t blocks;
-	struct slab_iterator slabs;
-};
-
 /**
  * get_lock() - Get the lock object for a slab journal block by sequence number.
  * @journal: vdo_slab journal to retrieve from.

--- a/drivers/md/dm-vdo/slab-depot.c
+++ b/drivers/md/dm-vdo/slab-depot.c
@@ -59,7 +59,8 @@ get_lock(struct slab_journal *journal, sequence_number_t sequence_number)
 
 static bool is_slab_open(struct vdo_slab *slab)
 {
-	return (!vdo_is_state_quiescing(&slab->state) && !vdo_is_state_quiescent(&slab->state));
+	return (!vdo_is_state_quiescing(&slab->state) &&
+		!vdo_is_state_quiescent(&slab->state));
 }
 
 /**
@@ -139,7 +140,8 @@ static void release_journal_locks(struct waiter *waiter, void *context);
  */
 static bool is_slab_journal_blank(const struct vdo_slab *slab)
 {
-	return ((slab->journal.tail == 1) && (slab->journal.tail_header.entry_count == 0));
+	return ((slab->journal.tail == 1) &&
+		(slab->journal.tail_header.entry_count == 0));
 }
 
 /**
@@ -194,7 +196,8 @@ static void check_if_slab_drained(struct vdo_slab *slab)
 	    (code != VDO_ADMIN_STATE_RECOVERING))
 		return;
 
-	vdo_finish_draining_with_result(&slab->state, (read_only ? VDO_READ_ONLY : VDO_SUCCESS));
+	vdo_finish_draining_with_result(&slab->state,
+					(read_only ? VDO_READ_ONLY : VDO_SUCCESS));
 }
 
 /* FULLNESS HINT COMPUTATION */
@@ -302,7 +305,8 @@ static void handle_write_error(struct vdo_completion *completion)
 static void write_slab_summary_endio(struct bio *bio)
 {
 	struct vio *vio = bio->bi_private;
-	struct slab_summary_block *block = container_of(vio, struct slab_summary_block, vio);
+	struct slab_summary_block *block =
+		container_of(vio, struct slab_summary_block, vio);
 
 	continue_vio_after_io(vio, finish_update, block->allocator->thread_id);
 }
@@ -466,17 +470,19 @@ static void reap_slab_journal(struct slab_journal *journal)
 {
 	bool reaped = false;
 
-	if (is_reaping(journal))
+	if (is_reaping(journal)) {
 		/* We already have a reap in progress so wait for it to finish. */
 		return;
+	}
 
 	if ((journal->slab->status != VDO_SLAB_REBUILT) ||
 	    !vdo_is_state_normal(&journal->slab->state) ||
-	    vdo_is_read_only(journal->slab->allocator->depot->vdo))
+	    vdo_is_read_only(journal->slab->allocator->depot->vdo)) {
 		/*
 		 * We must not reap in the first two cases, and there's no point in read-only mode.
 		 */
 		return;
+	}
 
 	/*
 	 * Start reclaiming blocks only when the journal head has no references. Then stop when a
@@ -526,18 +532,20 @@ adjust_slab_journal_block_reference(struct slab_journal *journal,
 	if (sequence_number == 0)
 		return;
 
-	if (journal->slab->status == VDO_SLAB_REPLAYING)
+	if (journal->slab->status == VDO_SLAB_REPLAYING) {
 		/* Locks should not be used during offline replay. */
 		return;
+	}
 
 	ASSERT_LOG_ONLY((adjustment != 0), "adjustment must be non-zero");
 	lock = get_lock(journal, sequence_number);
-	if (adjustment < 0)
+	if (adjustment < 0) {
 		ASSERT_LOG_ONLY((-adjustment <= lock->count),
 				"adjustment %d of lock count %u for slab journal block %llu must not underflow",
 				adjustment,
 				lock->count,
 				(unsigned long long) sequence_number);
+	}
 
 	lock->count += adjustment;
 	if (lock->count == 0)
@@ -561,7 +569,7 @@ static void release_journal_locks(struct waiter *waiter, void *context)
 	int result = *((int *)context);
 
 	if (result != VDO_SUCCESS) {
-		if (result != VDO_READ_ONLY)
+		if (result != VDO_READ_ONLY) {
 			/*
 			 * Don't bother logging what might be lots of errors if we are already in
 			 * read-only mode.
@@ -569,6 +577,7 @@ static void release_journal_locks(struct waiter *waiter, void *context)
 			uds_log_error_strerror(result,
 					       "failed slab summary update %llu",
 					       (unsigned long long) journal->summarized);
+		}
 
 		journal->updating_slab_summary = false;
 		vdo_enter_read_only_mode(journal->slab->allocator->depot->vdo, result);
@@ -668,10 +677,11 @@ static void reopen_slab_journal(struct vdo_slab *slab)
 	initialize_journal_state(journal);
 
 	/* Ensure no locks are spuriously held on an empty journal. */
-	for (block = 1; block <= journal->size; block++)
+	for (block = 1; block <= journal->size; block++) {
 		ASSERT_LOG_ONLY((get_lock(journal, block)->count == 0),
 				"Scrubbed journal's block %llu is not locked",
 				(unsigned long long) block);
+	}
 
 	add_entries(journal);
 }
@@ -745,7 +755,8 @@ static void write_slab_journal_block(struct waiter *waiter, void *context)
 {
 	struct pooled_vio *pooled = context;
 	struct vio *vio = &pooled->vio;
-	struct slab_journal *journal = container_of(waiter, struct slab_journal, resource_waiter);
+	struct slab_journal *journal =
+		container_of(waiter, struct slab_journal, resource_waiter);
 	struct slab_journal_block_header *header = &journal->tail_header;
 	int unused_entries = journal->entries_per_block - header->entry_count;
 	physical_block_number_t block_number;
@@ -770,7 +781,8 @@ static void write_slab_journal_block(struct waiter *waiter, void *context)
 		journal->partial_write_in_progress = !block_is_full(journal);
 	}
 
-	block_number = journal->slab->journal_origin + (header->sequence_number % journal->size);
+	block_number = journal->slab->journal_origin +
+		(header->sequence_number % journal->size);
 	vio->completion.parent = journal;
 
 	/*
@@ -806,21 +818,23 @@ static void write_slab_journal_block(struct waiter *waiter, void *context)
  */
 static void commit_tail(struct slab_journal *journal)
 {
-	if ((journal->tail_header.entry_count == 0) && must_make_entries_to_flush(journal))
+	if ((journal->tail_header.entry_count == 0) && must_make_entries_to_flush(journal)) {
 		/*
 		 * There are no entries at the moment, but there are some waiters, so defer
 		 * initiating the flush until those entries are ready to write.
 		 */
 		return;
+	}
 
 	if (vdo_is_read_only(journal->slab->allocator->depot->vdo) ||
 	    journal->waiting_to_commit ||
-	    (journal->tail_header.entry_count == 0))
+	    (journal->tail_header.entry_count == 0)) {
 		/*
 		 * There is nothing to do since the tail block is empty, or writing, or the journal
 		 * is in read-only mode.
 		 */
 		return;
+	}
 
 	/*
 	 * Since we are about to commit the tail block, this journal no longer needs to be on the
@@ -977,12 +991,13 @@ bool vdo_attempt_replay_into_slab(struct vdo_slab *slab,
 		return true;
 
 	if ((header->entry_count >= journal->full_entries_per_block) &&
-	    (header->has_block_map_increments || (operation == VDO_JOURNAL_BLOCK_MAP_REMAPPING)))
+	    (header->has_block_map_increments || (operation == VDO_JOURNAL_BLOCK_MAP_REMAPPING))) {
 		/*
 		 * The tail block does not have room for the entry we are attempting to add so
 		 * commit the tail block now.
 		 */
 		commit_tail(journal);
+	}
 
 	if (journal->waiting_to_commit) {
 		vdo_start_operation_with_waiter(&journal->slab->state,
@@ -1101,9 +1116,10 @@ static void finish_reference_block_write(struct vdo_completion *completion)
 	/* Re-queue the block if it was re-dirtied while it was writing. */
 	if (block->is_dirty) {
 		vdo_enqueue_waiter(&block->slab->dirty_blocks, &block->waiter);
-		if (vdo_is_state_draining(&slab->state))
+		if (vdo_is_state_draining(&slab->state)) {
 			/* We must be saving, and this block will otherwise not be relaunched. */
 			save_dirty_reference_blocks(slab);
+		}
 
 		return;
 	}
@@ -1244,11 +1260,12 @@ static void reclaim_journal_space(struct slab_journal *journal)
 
 	/* The slab journal is over the first threshold, schedule some reference block writes. */
 	WRITE_ONCE(journal->events->flush_count, journal->events->flush_count + 1);
-	if (length < journal->flushing_deadline)
+	if (length < journal->flushing_deadline) {
 		/* Schedule more writes the closer to the deadline we get. */
 		write_count = max_t(block_count_t,
 				    write_count / (journal->flushing_deadline - length + 1),
 				    1);
+	}
 
 	for (written = 0; written < write_count; written++)
 		vdo_notify_next_waiter(&slab->dirty_blocks, launch_reference_block_write, slab);
@@ -1458,11 +1475,12 @@ static int increment_for_data(struct vdo_slab *slab,
 
 	default:
 		/* Single or shared */
-		if (*counter_ptr >= MAXIMUM_REFERENCE_COUNT)
+		if (*counter_ptr >= MAXIMUM_REFERENCE_COUNT) {
 			return uds_log_error_strerror(VDO_REF_COUNT_INVALID,
 						      "Incrementing a block already having 254 references (slab %u, offset %u)",
 						      slab->slab_number,
 						      block_number);
+		}
 		(*counter_ptr)++;
 	}
 
@@ -1561,11 +1579,12 @@ static int increment_for_block_map(struct vdo_slab *slab,
 {
 	switch (old_status) {
 	case RS_FREE:
-		if (normal_operation)
+		if (normal_operation) {
 			return uds_log_error_strerror(VDO_REF_COUNT_INVALID,
 						      "Incrementing unallocated block map block (slab %u, offset %u)",
 						      slab->slab_number,
 						      block_number);
+		}
 
 		*counter_ptr = MAXIMUM_REFERENCE_COUNT;
 		block->allocated_count++;
@@ -1740,7 +1759,8 @@ adjust_reference_count(struct vdo_slab *slab,
 static void add_entry_from_waiter(struct waiter *waiter, void *context)
 {
 	int result;
-	struct reference_updater *updater = container_of(waiter, struct reference_updater, waiter);
+	struct reference_updater *updater =
+		container_of(waiter, struct reference_updater, waiter);
 	struct data_vio *data_vio = data_vio_from_reference_updater(updater);
 	struct slab_journal *journal = context;
 	struct slab_journal_block_header *header = &journal->tail_header;
@@ -1819,21 +1839,23 @@ static inline bool is_next_entry_a_block_map_increment(struct slab_journal *jour
  */
 static void add_entries(struct slab_journal *journal)
 {
-	if (journal->adding_entries)
+	if (journal->adding_entries) {
 		/* Protect against re-entrancy. */
 		return;
+	}
 
 	journal->adding_entries = true;
 	while (vdo_has_waiters(&journal->entry_waiters)) {
 		struct slab_journal_block_header *header = &journal->tail_header;
 
 		if (journal->partial_write_in_progress ||
-		    (journal->slab->status == VDO_SLAB_REBUILDING))
+		    (journal->slab->status == VDO_SLAB_REBUILDING)) {
 			/*
 			 * Don't add entries while rebuilding or while a partial write is
 			 * outstanding (VDO-2399).
 			 */
 			break;
+		}
 
 		if (journal->waiting_to_commit) {
 			/*
@@ -1866,7 +1888,8 @@ static void add_entries(struct slab_journal *journal)
 		}
 
 		if (header->entry_count == 0) {
-			struct journal_lock *lock = get_lock(journal, header->sequence_number);
+			struct journal_lock *lock =
+				get_lock(journal, header->sequence_number);
 
 			/*
 			 * Check if the on disk slab journal is full. Because of the blocking and
@@ -1971,11 +1994,13 @@ static bool advance_search_cursor(struct vdo_slab *slab)
 	cursor->block++;
 	cursor->index = cursor->end_index;
 
-	if (cursor->block == cursor->last_block)
+	if (cursor->block == cursor->last_block) {
 		/* The last reference block will usually be a runt. */
 		cursor->end_index = slab->block_count;
-	else
+	} else {
 		cursor->end_index += COUNTS_PER_BLOCK;
+	}
+
 	return true;
 }
 
@@ -2041,9 +2066,10 @@ replay_reference_count_change(struct vdo_slab *slab,
 		.increment = entry.increment,
 	};
 
-	if (!vdo_before_journal_point(&block->commit_points[sector], entry_point))
+	if (!vdo_before_journal_point(&block->commit_points[sector], entry_point)) {
 		/* This entry is already reflected in the existing counts, so do nothing. */
 		return VDO_SUCCESS;
+	}
 
 	/* This entry is not yet counted in the reference counts. */
 	result = update_reference_count(slab,
@@ -2188,9 +2214,10 @@ search_reference_blocks(struct vdo_slab *slab, slab_block_number *free_index_ptr
 		return true;
 
 	/* Search each reference block up to the end of the slab. */
-	while (advance_search_cursor(slab))
+	while (advance_search_cursor(slab)) {
 		if (search_current_reference_block(slab, free_index_ptr))
 			return true;
+	}
 
 	return false;
 }
@@ -2284,9 +2311,10 @@ unpack_reference_block(struct packed_reference_block *packed, struct reference_b
 	}
 
 	block->allocated_count = 0;
-	for (index = 0; index < COUNTS_PER_BLOCK; index++)
+	for (index = 0; index < COUNTS_PER_BLOCK; index++) {
 		if (counters[index] != EMPTY_REFERENCE_COUNT)
 			block->allocated_count++;
+	}
 }
 
 /**
@@ -2327,7 +2355,8 @@ static void load_reference_block(struct waiter *waiter, void *context)
 {
 	struct pooled_vio *pooled = context;
 	struct vio *vio = &pooled->vio;
-	struct reference_block *block = container_of(waiter, struct reference_block, waiter);
+	struct reference_block *block =
+		container_of(waiter, struct reference_block, waiter);
 	size_t block_offset = (block - block->slab->reference_blocks);
 
 	vio->completion.parent = block;
@@ -2371,7 +2400,8 @@ static void drain_slab(struct vdo_slab *slab)
 	if (state == VDO_ADMIN_STATE_SUSPENDING)
 		return;
 
-	if ((state != VDO_ADMIN_STATE_REBUILDING) && (state != VDO_ADMIN_STATE_SAVE_FOR_SCRUBBING))
+	if ((state != VDO_ADMIN_STATE_REBUILDING) &&
+	    (state != VDO_ADMIN_STATE_SAVE_FOR_SCRUBBING))
 		commit_tail(&slab->journal);
 
 	if ((state == VDO_ADMIN_STATE_RECOVERING) || (slab->counters == NULL))
@@ -2385,10 +2415,10 @@ static void drain_slab(struct vdo_slab *slab)
 			return;
 		}
 	} else if (state == VDO_ADMIN_STATE_SAVE_FOR_SCRUBBING) {
-		if (!load)
+		if (!load) {
 			/* These reference counts were never written, so mark them all dirty. */
 			dirty_all_reference_blocks(slab);
-
+		}
 		save = true;
 	} else if (state == VDO_ADMIN_STATE_REBUILDING) {
 		/*
@@ -2397,8 +2427,7 @@ static void drain_slab(struct vdo_slab *slab)
 		 */
 		block_count_t data_blocks = slab->allocator->depot->slab_config.data_blocks;
 
-		if (load ||
-		    (slab->free_blocks != data_blocks) ||
+		if (load || (slab->free_blocks != data_blocks) ||
 		    !is_slab_journal_blank(slab)) {
 			dirty_all_reference_blocks(slab);
 			save = true;
@@ -2484,8 +2513,7 @@ static void finish_loading_journal(struct vdo_completion *completion)
 		 * head appropriately.
 		 */
 		journal->head = (slab->allocator->summary_entries[slab->slab_number].is_dirty ?
-				 header.head :
-				 journal->tail);
+				 header.head : journal->tail);
 		journal->tail_header = header;
 		initialize_journal_state(journal);
 	}
@@ -2634,9 +2662,10 @@ static void queue_slab(struct vdo_slab *slab)
 		 * FIXME: under what situation would the slab be resuming here?
 		 */
 		WRITE_ONCE(allocator->allocated_blocks, allocator->allocated_blocks - free_blocks);
-		if (!is_slab_journal_blank(slab))
+		if (!is_slab_journal_blank(slab)) {
 			WRITE_ONCE(allocator->statistics.slabs_opened,
 				   allocator->statistics.slabs_opened + 1);
+		}
 	}
 
 	if (allocator->depot->vdo->suspend_type == VDO_ADMIN_STATE_SAVING)
@@ -2843,7 +2872,7 @@ static int apply_block_entries(struct packed_slab_journal_block *block,
 		struct slab_journal_entry entry =
 			vdo_decode_slab_journal_entry(block, entry_point.entry_count);
 
-		if (entry.sbn > max_sbn)
+		if (entry.sbn > max_sbn) {
 			/* This entry is out of bounds. */
 			return uds_log_error_strerror(VDO_CORRUPT_JOURNAL,
 						      "vdo_slab journal entry (%llu, %u) had invalid offset %u in slab (size %u blocks)",
@@ -2851,6 +2880,7 @@ static int apply_block_entries(struct packed_slab_journal_block *block,
 						      entry_point.entry_count,
 						      entry.sbn,
 						      max_sbn);
+		}
 
 		result = replay_reference_count_change(slab, &entry_point, entry);
 		if (result != VDO_SUCCESS) {
@@ -3130,7 +3160,8 @@ static struct vdo_slab *next_slab(struct slab_iterator *iterator)
  */
 static void abort_waiter(struct waiter *waiter, void *context __always_unused)
 {
-	struct reference_updater *updater = container_of(waiter, struct reference_updater, waiter);
+	struct reference_updater *updater =
+		container_of(waiter, struct reference_updater, waiter);
 	struct data_vio *data_vio = data_vio_from_reference_updater(updater);
 
 	if (updater->increment) {
@@ -3446,13 +3477,15 @@ static void apply_to_slabs(struct block_allocator *allocator, vdo_action *callba
 static void finish_loading_allocator(struct vdo_completion *completion)
 {
 	struct block_allocator *allocator = vdo_as_block_allocator(completion);
-	const struct admin_state_code *operation = vdo_get_admin_state_code(&allocator->state);
+	const struct admin_state_code *operation =
+		vdo_get_admin_state_code(&allocator->state);
 
 	if (allocator->eraser != NULL)
 		dm_kcopyd_client_destroy(uds_forget(allocator->eraser));
 
 	if (operation == VDO_ADMIN_STATE_LOADING_FOR_RECOVERY) {
-		void *context = vdo_get_current_action_context(allocator->depot->action_manager);
+		void *context =
+			vdo_get_current_action_context(allocator->depot->action_manager);
 
 		vdo_replay_into_slab_journals(allocator, context);
 		return;
@@ -3503,7 +3536,8 @@ static void erase_next_slab_journal(struct block_allocator *allocator)
 /* Implements vdo_admin_initiator. */
 static void initiate_load(struct admin_state *state)
 {
-	struct block_allocator *allocator = container_of(state, struct block_allocator, state);
+	struct block_allocator *allocator =
+		container_of(state, struct block_allocator, state);
 	const struct admin_state_code *operation = vdo_get_admin_state_code(state);
 
 	if (operation == VDO_ADMIN_STATE_LOADING_FOR_REBUILD) {
@@ -3649,16 +3683,17 @@ void vdo_dump_block_allocator(const struct block_allocator *allocator)
 		struct vdo_slab *slab = next_slab(&iterator);
 		struct slab_journal *journal = &slab->journal;
 
-		if (slab->reference_blocks != NULL)
+		if (slab->reference_blocks != NULL) {
 			/* Terse because there are a lot of slabs to dump and syslog is lossy. */
 			uds_log_info("slab %u: P%u, %llu free",
 				     slab->slab_number,
 				     slab->priority,
 				     (unsigned long long) slab->free_blocks);
-		else
+		} else {
 			uds_log_info("slab %u: status %s",
 				     slab->slab_number,
 				     status_to_string(slab->status));
+		}
 
 		uds_log_info("  slab journal: entry_waiters=%zu waiting_to_commit=%s updating_slab_summary=%s head=%llu unreapable=%llu tail=%llu next_commit=%llu summarized=%llu last_summarized=%llu recovery_lock=%llu dirty=%s",
 			     vdo_count_waiters(&journal->entry_waiters),
@@ -3677,7 +3712,7 @@ void vdo_dump_block_allocator(const struct block_allocator *allocator)
 		 * worth dumping all the locks, but that might be too much logging.
 		 */
 
-		if (slab->counters != NULL)
+		if (slab->counters != NULL) {
 			/* Terse because there are a lot of slabs to dump and syslog is lossy. */
 			uds_log_info("  slab: free=%u/%u blocks=%u dirty=%zu active=%zu journal@(%llu,%u)",
 				     slab->free_blocks,
@@ -3687,8 +3722,9 @@ void vdo_dump_block_allocator(const struct block_allocator *allocator)
 				     slab->active_count,
 				     (unsigned long long) slab->slab_journal_point.sequence_number,
 				     slab->slab_journal_point.entry_count);
-		else
+		} else {
 			uds_log_info("  no counters");
+		}
 
 		/*
 		 * Wait for a while after each batch of 32 slabs dumped, an arbitrary number,
@@ -3803,7 +3839,8 @@ make_slab(physical_block_number_t slab_origin,
 		.end = slab_origin + slab_config->slab_blocks,
 		.slab_number = slab_number,
 		.ref_counts_origin = slab_origin + slab_config->data_blocks,
-		.journal_origin = vdo_get_slab_journal_start_block(slab_config, slab_origin),
+		.journal_origin =
+			vdo_get_slab_journal_start_block(slab_config, slab_origin),
 		.block_count = slab_config->data_blocks,
 		.free_blocks = slab_config->data_blocks,
 		.reference_block_count =
@@ -4006,7 +4043,8 @@ static bool schedule_tail_block_commit(void *context)
 static int initialize_slab_scrubber(struct block_allocator *allocator)
 {
 	struct slab_scrubber *scrubber = &allocator->scrubber;
-	block_count_t slab_journal_size = allocator->depot->slab_config.slab_journal_blocks;
+	block_count_t slab_journal_size =
+		allocator->depot->slab_config.slab_journal_blocks;
 	char *journal_data;
 	int result;
 
@@ -4201,11 +4239,12 @@ static int allocate_components(struct slab_depot *depot,
 	slab_count = vdo_compute_slab_count(depot->first_block,
 					    depot->last_block,
 					    depot->slab_size_shift);
-	if (thread_config->physical_zone_count > slab_count)
+	if (thread_config->physical_zone_count > slab_count) {
 		return uds_log_error_strerror(VDO_BAD_CONFIGURATION,
 					      "%u physical zones exceeds slab count %u",
 					      thread_config->physical_zone_count,
 					      slab_count);
+	}
 
 	/* Initialize the block allocators. */
 	for (zone = 0; zone < depot->zone_count; zone++) {
@@ -4259,9 +4298,10 @@ int vdo_decode_slab_depot(struct slab_depot_state_2_0 state,
 	 */
 	block_count_t slab_size = state.slab_config.slab_blocks;
 
-	if (!is_power_of_2(slab_size))
+	if (!is_power_of_2(slab_size)) {
 		return uds_log_error_strerror(UDS_INVALID_ARGUMENT,
 					      "slab size must be a power of two");
+	}
 	slab_size_shift = ilog2(slab_size);
 
 	result = uds_allocate_extended(struct slab_depot,
@@ -4508,9 +4548,11 @@ block_count_t vdo_get_slab_depot_allocated_blocks(const struct slab_depot *depot
 	block_count_t total = 0;
 	zone_count_t zone;
 
-	for (zone = 0; zone < depot->zone_count; zone++)
+	for (zone = 0; zone < depot->zone_count; zone++) {
 		/* The allocators are responsible for thread safety. */
 		total += READ_ONCE(depot->allocators[zone].allocated_blocks);
+	}
+
 	return total;
 }
 
@@ -4573,10 +4615,12 @@ static void combine_summaries(struct slab_depot *depot)
 		slab_count_t entry_number;
 
 		for (entry_number = 0; entry_number < MAX_VDO_SLABS; entry_number++) {
-			if (zone != 0)
+			if (zone != 0) {
 				memcpy(entries + entry_number,
 				       entries + (zone * MAX_VDO_SLABS) + entry_number,
 				       sizeof(struct slab_summary_entry));
+			}
+
 			zone++;
 			if (zone == depot->old_zone_count)
 				zone = 0;
@@ -4584,10 +4628,11 @@ static void combine_summaries(struct slab_depot *depot)
 	}
 
 	/* Copy the combined data to each zones's region of the buffer. */
-	for (zone = 1; zone < MAX_VDO_PHYSICAL_ZONES; zone++)
+	for (zone = 1; zone < MAX_VDO_PHYSICAL_ZONES; zone++) {
 		memcpy(entries + (zone * MAX_VDO_SLABS),
 		       entries,
 		       MAX_VDO_SLABS * sizeof(struct slab_summary_entry));
+	}
 }
 
 /**
@@ -4685,14 +4730,12 @@ void vdo_load_slab_depot(struct slab_depot *depot,
 			 struct vdo_completion *parent,
 			 void *context)
 {
-	if (vdo_assert_load_operation(operation, parent))
-		vdo_schedule_operation_with_context(depot->action_manager,
-						    operation,
-						    load_slab_summary,
-						    load_allocator,
-						    NULL,
-						    context,
-						    parent);
+	if (!vdo_assert_load_operation(operation, parent))
+		return;
+
+	vdo_schedule_operation_with_context(depot->action_manager, operation,
+					    load_slab_summary, load_allocator,
+					    NULL, context, parent);
 }
 
 /* Implements vdo_zone_action. */
@@ -4775,9 +4818,10 @@ int vdo_prepare_to_grow_slab_depot(struct slab_depot *depot, const struct partit
 						depot->slab_size_shift);
 	if (new_slab_count <= depot->slab_count)
 		return uds_log_error_strerror(VDO_INCREMENT_TOO_SMALL, "Depot can only grow");
-	if (new_slab_count == depot->new_slab_count)
+	if (new_slab_count == depot->new_slab_count) {
 		/* Check it out, we've already got all the new slabs allocated! */
 		return VDO_SUCCESS;
+	}
 
 	vdo_abandon_new_slabs(depot);
 	result = allocate_slabs(depot, new_slab_count);
@@ -4856,13 +4900,14 @@ static void stop_scrubbing(struct block_allocator *allocator)
 {
 	struct slab_scrubber *scrubber = &allocator->scrubber;
 
-	if (vdo_is_state_quiescent(&scrubber->admin_state))
+	if (vdo_is_state_quiescent(&scrubber->admin_state)) {
 		vdo_finish_completion(&allocator->completion);
-	else
+	} else {
 		vdo_start_draining(&scrubber->admin_state,
 				   VDO_ADMIN_STATE_SUSPENDING,
 				   &allocator->completion,
 				   NULL);
+	}
 }
 
 /* Implements vdo_admin_initiator. */
@@ -4909,7 +4954,8 @@ static void do_drain_step(struct vdo_completion *completion)
 /* Implements vdo_admin_initiator. */
 static void initiate_drain(struct admin_state *state)
 {
-	struct block_allocator *allocator = container_of(state, struct block_allocator, state);
+	struct block_allocator *allocator =
+		container_of(state, struct block_allocator, state);
 
 	allocator->drain_step = VDO_DRAIN_ALLOCATOR_START;
 	do_drain_step(&allocator->completion);
@@ -5011,7 +5057,8 @@ static void do_resume_step(struct vdo_completion *completion)
 /* Implements vdo_admin_initiator. */
 static void initiate_resume(struct admin_state *state)
 {
-	struct block_allocator *allocator = container_of(state, struct block_allocator, state);
+	struct block_allocator *allocator =
+		container_of(state, struct block_allocator, state);
 
 	allocator->drain_step = VDO_DRAIN_ALLOCATOR_STEP_FINISHED;
 	do_resume_step(&allocator->completion);

--- a/drivers/md/dm-vdo/slab-depot.c
+++ b/drivers/md/dm-vdo/slab-depot.c
@@ -44,8 +44,8 @@ static const bool NORMAL_OPERATION = true;
  *
  * Return: The lock object for the given sequence number.
  */
-static inline struct journal_lock * __must_check
-get_lock(struct slab_journal *journal, sequence_number_t sequence_number)
+static inline struct journal_lock * __must_check get_lock(struct slab_journal *journal,
+							  sequence_number_t sequence_number)
 {
 	return &journal->locks[sequence_number % journal->size];
 }
@@ -210,7 +210,8 @@ static void check_if_slab_drained(struct vdo_slab *slab)
  *
  * Return: A fullness hint, which can be stored in 7 bits.
  */
-static u8 __must_check compute_fullness_hint(struct slab_depot *depot, block_count_t free_blocks)
+static u8 __must_check compute_fullness_hint(struct slab_depot *depot,
+					     block_count_t free_blocks)
 {
 	block_count_t hint;
 
@@ -243,7 +244,8 @@ static void check_summary_drain_complete(struct block_allocator *allocator)
  * @allocator: The block allocator summary which owns the queue.
  * @queue: The queue to notify.
  */
-static void notify_summary_waiters(struct block_allocator *allocator, struct wait_queue *queue)
+static void notify_summary_waiters(struct block_allocator *allocator,
+				   struct wait_queue *queue)
 {
 	int result = (vdo_is_read_only(allocator->depot->vdo) ? VDO_READ_ONLY : VDO_SUCCESS);
 
@@ -318,7 +320,8 @@ static void launch_write(struct slab_summary_block *block)
 		return;
 
 	allocator->summary_write_count++;
-	vdo_transfer_all_waiters(&block->next_update_waiters, &block->current_update_waiters);
+	vdo_transfer_all_waiters(&block->next_update_waiters,
+				 &block->current_update_waiters);
 	block->writing = true;
 
 	if (vdo_is_read_only(depot->vdo)) {
@@ -335,11 +338,8 @@ static void launch_write(struct slab_summary_block *block)
 	pbn = (depot->summary_origin +
 	       (VDO_SLAB_SUMMARY_BLOCKS_PER_ZONE * allocator->zone_number) +
 	       block->index);
-	submit_metadata_vio(&block->vio,
-			    pbn,
-			    write_slab_summary_endio,
-			    handle_write_error,
-			    REQ_OP_WRITE | REQ_PREFLUSH);
+	submit_metadata_vio(&block->vio, pbn, write_slab_summary_endio,
+			    handle_write_error, REQ_OP_WRITE | REQ_PREFLUSH);
 }
 
 /**
@@ -351,13 +351,10 @@ static void launch_write(struct slab_summary_block *block)
  * @is_clean: Whether the slab is clean.
  * @free_blocks: The number of free blocks.
  */
-static void
-update_slab_summary_entry(struct vdo_slab *slab,
-			  struct waiter *waiter,
-			  tail_block_offset_t tail_block_offset,
-			  bool load_ref_counts,
-			  bool is_clean,
-			  block_count_t free_blocks)
+static void update_slab_summary_entry(struct vdo_slab *slab, struct waiter *waiter,
+				      tail_block_offset_t tail_block_offset,
+				      bool load_ref_counts, bool is_clean,
+				      block_count_t free_blocks)
 {
 	u8 index = slab->slab_number / VDO_SLAB_SUMMARY_ENTRIES_PER_BLOCK;
 	struct block_allocator *allocator = slab->allocator;
@@ -434,8 +431,7 @@ static void flush_endio(struct bio *bio)
 	struct vio *vio = bio->bi_private;
 	struct slab_journal *journal = vio->completion.parent;
 
-	continue_vio_after_io(vio,
-			      complete_reaping,
+	continue_vio_after_io(vio, complete_reaping,
 			      journal->slab->allocator->thread_id);
 }
 
@@ -447,7 +443,8 @@ static void flush_endio(struct bio *bio)
  */
 static void flush_for_reaping(struct waiter *waiter, void *context)
 {
-	struct slab_journal *journal = container_of(waiter, struct slab_journal, flush_waiter);
+	struct slab_journal *journal =
+		container_of(waiter, struct slab_journal, flush_waiter);
 	struct pooled_vio *pooled = context;
 	struct vio *vio = &pooled->vio;
 
@@ -504,7 +501,8 @@ static void reap_slab_journal(struct slab_journal *journal)
 	 * resulting in a loss of reference count updates (VDO-2912).
 	 */
 	journal->flush_waiter.callback = flush_for_reaping;
-	acquire_vio_from_pool(journal->slab->allocator->vio_pool, &journal->flush_waiter);
+	acquire_vio_from_pool(journal->slab->allocator->vio_pool,
+			      &journal->flush_waiter);
 }
 
 /**
@@ -515,10 +513,9 @@ static void reap_slab_journal(struct slab_journal *journal)
  *
  * Note that when the adjustment is negative, the slab journal will be reaped.
  */
-static void
-adjust_slab_journal_block_reference(struct slab_journal *journal,
-				    sequence_number_t sequence_number,
-				    int adjustment)
+static void adjust_slab_journal_block_reference(struct slab_journal *journal,
+						sequence_number_t sequence_number,
+						int adjustment)
 {
 	struct journal_lock *lock;
 
@@ -535,8 +532,7 @@ adjust_slab_journal_block_reference(struct slab_journal *journal,
 	if (adjustment < 0) {
 		ASSERT_LOG_ONLY((-adjustment <= lock->count),
 				"adjustment %d of lock count %u for slab journal block %llu must not underflow",
-				adjustment,
-				lock->count,
+				adjustment, lock->count,
 				(unsigned long long) sequence_number);
 	}
 
@@ -567,8 +563,7 @@ static void release_journal_locks(struct waiter *waiter, void *context)
 			 * Don't bother logging what might be lots of errors if we are already in
 			 * read-only mode.
 			 */
-			uds_log_error_strerror(result,
-					       "failed slab summary update %llu",
+			uds_log_error_strerror(result, "failed slab summary update %llu",
 					       (unsigned long long) journal->summarized);
 		}
 
@@ -648,12 +643,9 @@ static void update_tail_block_location(struct slab_journal *journal)
 	 * slab have been written to the layer. Therefore, indicate that the ref counts must be
 	 * loaded when the journal head has reaped past sequence number 1.
 	 */
-	update_slab_summary_entry(slab,
-				  &journal->slab_summary_waiter,
+	update_slab_summary_entry(slab, &journal->slab_summary_waiter,
 				  journal->summarized % journal->size,
-				  (journal->head > 1),
-				  false,
-				  free_block_count);
+				  (journal->head > 1), false, free_block_count);
 }
 
 /**
@@ -705,8 +697,7 @@ static void complete_write(struct vdo_completion *completion)
 
 	if (result != VDO_SUCCESS) {
 		vio_record_metadata_io_error(as_vio(completion));
-		uds_log_error_strerror(result,
-				       "cannot write slab journal block %llu",
+		uds_log_error_strerror(result, "cannot write slab journal block %llu",
 				       (unsigned long long) committed);
 		vdo_enter_read_only_mode(journal->slab->allocator->depot->vdo, result);
 		check_if_slab_drained(journal->slab);
@@ -721,8 +712,7 @@ static void complete_write(struct vdo_completion *completion)
 	} else {
 		/* The commit point is always the beginning of the oldest incomplete block. */
 		pooled = container_of(journal->uncommitted_blocks.next,
-				      struct pooled_vio,
-				      list_entry);
+				      struct pooled_vio, list_entry);
 		journal->next_commit = get_committing_sequence_number(pooled);
 	}
 
@@ -768,8 +758,7 @@ static void write_slab_journal_block(struct waiter *waiter, void *context)
 		 * Release the per-entry locks for any unused entries in the block we are about to
 		 * write.
 		 */
-		adjust_slab_journal_block_reference(journal,
-						    header->sequence_number,
+		adjust_slab_journal_block_reference(journal, header->sequence_number,
 						    -unused_entries);
 		journal->partial_write_in_progress = !block_is_full(journal);
 	}
@@ -782,11 +771,8 @@ static void write_slab_journal_block(struct waiter *waiter, void *context)
 	 * This block won't be read in recovery until the slab summary is updated to refer to it.
 	 * The slab summary update does a flush which is sufficient to protect us from VDO-2331.
 	 */
-	submit_metadata_vio(uds_forget(vio),
-			    block_number,
-			    write_slab_journal_endio,
-			    complete_write,
-			    REQ_OP_WRITE);
+	submit_metadata_vio(uds_forget(vio), block_number, write_slab_journal_endio,
+			    complete_write, REQ_OP_WRITE);
 
 	/* Since the write is submitted, the tail block structure can be reused. */
 	journal->tail++;
@@ -797,8 +783,7 @@ static void write_slab_journal_block(struct waiter *waiter, void *context)
 	if (operation == VDO_ADMIN_STATE_WAITING_FOR_RECOVERY) {
 		vdo_finish_operation(&journal->slab->state,
 				     (vdo_is_read_only(journal->slab->allocator->depot->vdo) ?
-				      VDO_READ_ONLY :
-				      VDO_SUCCESS));
+				      VDO_READ_ONLY : VDO_SUCCESS));
 		return;
 	}
 
@@ -838,7 +823,8 @@ static void commit_tail(struct slab_journal *journal)
 	journal->waiting_to_commit = true;
 
 	journal->resource_waiter.callback = write_slab_journal_block;
-	acquire_vio_from_pool(journal->slab->allocator->vio_pool, &journal->resource_waiter);
+	acquire_vio_from_pool(journal->slab->allocator->vio_pool,
+			      &journal->resource_waiter);
 }
 
 /**
@@ -851,19 +837,17 @@ static void commit_tail(struct slab_journal *journal)
  *
  * Exposed for unit tests.
  */
-static void
-encode_slab_journal_entry(struct slab_journal_block_header *tail_header,
-			  slab_journal_payload *payload,
-			  slab_block_number sbn,
-			  enum journal_operation operation,
-			  bool increment)
+static void encode_slab_journal_entry(struct slab_journal_block_header *tail_header,
+				      slab_journal_payload *payload,
+				      slab_block_number sbn,
+				      enum journal_operation operation,
+				      bool increment)
 {
 	journal_entry_count_t entry_number = tail_header->entry_count++;
 
 	if (operation == VDO_JOURNAL_BLOCK_MAP_REMAPPING) {
 		if (!tail_header->has_block_map_increments) {
-			memset(payload->full_entries.entry_types,
-			       0,
+			memset(payload->full_entries.entry_types, 0,
 			       VDO_SLAB_JOURNAL_ENTRY_TYPES_SIZE);
 			tail_header->has_block_map_increments = true;
 		}
@@ -889,8 +873,8 @@ encode_slab_journal_entry(struct slab_journal_block_header *tail_header,
  * entries, the entry count of the expanded journal point is twice the actual recovery journal
  * entry count for increments, and one more than that for decrements.
  */
-static struct journal_point
-expand_journal_point(struct journal_point recovery_point, bool increment)
+static struct journal_point expand_journal_point(struct journal_point recovery_point,
+						 bool increment)
 {
 	recovery_point.entry_count *= 2;
 	if (!increment)
@@ -910,10 +894,8 @@ expand_journal_point(struct journal_point recovery_point, bool increment)
  *
  * This function is synchronous.
  */
-static void add_entry(struct slab_journal *journal,
-		      physical_block_number_t pbn,
-		      enum journal_operation operation,
-		      bool increment,
+static void add_entry(struct slab_journal *journal, physical_block_number_t pbn,
+		      enum journal_operation operation, bool increment,
 		      struct journal_point recovery_point)
 {
 	struct packed_slab_journal_block *block = journal->block;
@@ -936,16 +918,14 @@ static void add_entry(struct slab_journal *journal,
 				 journal->full_entries_per_block),
 				"block has room for full entries");
 		if (result != VDO_SUCCESS) {
-			vdo_enter_read_only_mode(journal->slab->allocator->depot->vdo, result);
+			vdo_enter_read_only_mode(journal->slab->allocator->depot->vdo,
+						 result);
 			return;
 		}
 	}
 
-	encode_slab_journal_entry(&journal->tail_header,
-				  &block->payload,
-				  pbn - journal->slab->start,
-				  operation,
-				  increment);
+	encode_slab_journal_entry(&journal->tail_header, &block->payload,
+				  pbn - journal->slab->start, operation, increment);
 	journal->tail_header.recovery_point = recovery_point;
 	if (block_is_full(journal))
 		commit_tail(journal);
@@ -968,10 +948,8 @@ static inline block_count_t journal_length(const struct slab_journal *journal)
  *
  * Return: true if the entry was added immediately.
  */
-bool vdo_attempt_replay_into_slab(struct vdo_slab *slab,
-				  physical_block_number_t pbn,
-				  enum journal_operation operation,
-				  bool increment,
+bool vdo_attempt_replay_into_slab(struct vdo_slab *slab, physical_block_number_t pbn,
+				  enum journal_operation operation, bool increment,
 				  struct journal_point *recovery_point,
 				  struct vdo_completion *parent)
 {
@@ -995,8 +973,7 @@ bool vdo_attempt_replay_into_slab(struct vdo_slab *slab,
 	if (journal->waiting_to_commit) {
 		vdo_start_operation_with_waiter(&journal->slab->state,
 						VDO_ADMIN_STATE_WAITING_FOR_RECOVERY,
-						parent,
-						NULL);
+						parent, NULL);
 		return false;
 	}
 
@@ -1091,8 +1068,7 @@ static void finish_reference_block_write(struct vdo_completion *completion)
 
 	/* Release the slab journal lock. */
 	adjust_slab_journal_block_reference(&slab->journal,
-					    block->slab_journal_lock_to_release,
-					    -1);
+					    block->slab_journal_lock_to_release, -1);
 	return_vio_to_pool(slab->allocator->vio_pool, pooled);
 
 	/*
@@ -1129,12 +1105,8 @@ static void finish_reference_block_write(struct vdo_completion *completion)
 	offset = slab->allocator->summary_entries[slab->slab_number].tail_block_offset;
 	slab->active_count++;
 	slab->summary_waiter.callback = finish_summary_update;
-	update_slab_summary_entry(slab,
-				  &slab->summary_waiter,
-				  offset,
-				  true,
-				  true,
-				  slab->free_blocks);
+	update_slab_summary_entry(slab, &slab->summary_waiter, offset,
+				  true, true, slab->free_blocks);
 }
 
 /**
@@ -1143,8 +1115,7 @@ static void finish_reference_block_write(struct vdo_completion *completion)
  *
  * Return: A pointer to the reference counters for this block.
  */
-static vdo_refcount_t * __must_check
-get_reference_counters_for_block(struct reference_block *block)
+static vdo_refcount_t * __must_check get_reference_counters_for_block(struct reference_block *block)
 {
 	size_t block_index = block - block->slab->reference_blocks;
 
@@ -1167,8 +1138,7 @@ static void pack_reference_block(struct reference_block *block, void *buffer)
 
 	for (i = 0; i < VDO_SECTORS_PER_BLOCK; i++) {
 		packed->sectors[i].commit_point = commit_point;
-		memcpy(packed->sectors[i].counts,
-		       counters + (i * COUNTS_PER_SECTOR),
+		memcpy(packed->sectors[i].counts, counters + (i * COUNTS_PER_SECTOR),
 		       (sizeof(vdo_refcount_t) * COUNTS_PER_SECTOR));
 	}
 }
@@ -1211,7 +1181,8 @@ static void write_reference_block(struct waiter *waiter, void *context)
 	physical_block_number_t pbn;
 	struct pooled_vio *pooled = context;
 	struct vdo_completion *completion = &pooled->vio.completion;
-	struct reference_block *block = container_of(waiter, struct reference_block, waiter);
+	struct reference_block *block = container_of(waiter, struct reference_block,
+						     waiter);
 
 	pack_reference_block(block, pooled->vio.data);
 	block_offset = (block - block->slab->reference_blocks);
@@ -1234,11 +1205,8 @@ static void write_reference_block(struct waiter *waiter, void *context)
 		   block->slab->allocator->ref_counts_statistics.blocks_written + 1);
 
 	completion->callback_thread_id = ((struct block_allocator *) pooled->context)->thread_id;
-	submit_metadata_vio(&pooled->vio,
-			    pbn,
-			    write_reference_block_endio,
-			    handle_io_error,
-			    REQ_OP_WRITE | REQ_PREFLUSH);
+	submit_metadata_vio(&pooled->vio, pbn, write_reference_block_endio,
+			    handle_io_error, REQ_OP_WRITE | REQ_PREFLUSH);
 }
 
 static void reclaim_journal_space(struct slab_journal *journal)
@@ -1255,13 +1223,14 @@ static void reclaim_journal_space(struct slab_journal *journal)
 	WRITE_ONCE(journal->events->flush_count, journal->events->flush_count + 1);
 	if (length < journal->flushing_deadline) {
 		/* Schedule more writes the closer to the deadline we get. */
-		write_count = max_t(block_count_t,
-				    write_count / (journal->flushing_deadline - length + 1),
-				    1);
+		write_count /= journal->flushing_deadline - length + 1;
+		write_count = max_t(block_count_t, write_count, 1);
 	}
 
-	for (written = 0; written < write_count; written++)
-		vdo_notify_next_waiter(&slab->dirty_blocks, launch_reference_block_write, slab);
+	for (written = 0; written < write_count; written++) {
+		vdo_notify_next_waiter(&slab->dirty_blocks,
+				       launch_reference_block_write, slab);
+	}
 }
 
 /**
@@ -1270,8 +1239,7 @@ static void reclaim_journal_space(struct slab_journal *journal)
  *
  * Return: The appropriate reference status.
  */
-static enum reference_status __must_check
-reference_count_to_status(vdo_refcount_t count)
+static enum reference_status __must_check reference_count_to_status(vdo_refcount_t count)
 {
 	if (count == EMPTY_REFERENCE_COUNT)
 		return RS_FREE;
@@ -1301,8 +1269,8 @@ static void dirty_block(struct reference_block *block)
 /**
  * get_reference_block() - Get the reference block that covers the given block index.
  */
-static struct reference_block * __must_check
-get_reference_block(struct vdo_slab *slab, slab_block_number index)
+static struct reference_block * __must_check get_reference_block(struct vdo_slab *slab,
+								 slab_block_number index)
 {
 	return &slab->reference_blocks[index / COUNTS_PER_BLOCK];
 }
@@ -1316,17 +1284,16 @@ get_reference_block(struct vdo_slab *slab, slab_block_number index)
  *
  * Return: VDO_SUCCESS or an error code.
  */
-static int __must_check
-slab_block_number_from_pbn(struct vdo_slab *slab,
-			   physical_block_number_t physical_block_number,
-			   slab_block_number *slab_block_number_ptr)
+static int __must_check slab_block_number_from_pbn(struct vdo_slab *slab,
+						   physical_block_number_t pbn,
+						   slab_block_number *slab_block_number_ptr)
 {
 	u64 slab_block_number;
 
-	if (physical_block_number < slab->start)
+	if (pbn < slab->start)
 		return VDO_OUT_OF_RANGE;
 
-	slab_block_number = physical_block_number - slab->start;
+	slab_block_number = pbn - slab->start;
 	if (slab_block_number >= slab->allocator->depot->slab_config.data_blocks)
 		return VDO_OUT_OF_RANGE;
 
@@ -1340,10 +1307,9 @@ slab_block_number_from_pbn(struct vdo_slab *slab,
  * @pbn: The physical block number.
  * @counter_ptr: A pointer to the reference counter.
  */
-static int __must_check
-get_reference_counter(struct vdo_slab *slab,
-		      physical_block_number_t pbn,
-		      vdo_refcount_t **counter_ptr)
+static int __must_check get_reference_counter(struct vdo_slab *slab,
+					      physical_block_number_t pbn,
+					      vdo_refcount_t **counter_ptr)
 {
 	slab_block_number index;
 	int result = slab_block_number_from_pbn(slab, pbn, &index);
@@ -1401,8 +1367,7 @@ static void prioritize_slab(struct vdo_slab *slab)
 			"a slab must not already be on a ring when prioritizing");
 	slab->priority = calculate_slab_priority(slab);
 	vdo_priority_table_enqueue(slab->allocator->prioritized_slabs,
-				   slab->priority,
-				   &slab->allocq_entry);
+				   slab->priority, &slab->allocq_entry);
 }
 
 /**
@@ -1444,12 +1409,10 @@ static void adjust_free_block_count(struct vdo_slab *slab, bool increment)
  *
  * Return: VDO_SUCCESS or an error.
  */
-static int increment_for_data(struct vdo_slab *slab,
-			      struct reference_block *block,
+static int increment_for_data(struct vdo_slab *slab, struct reference_block *block,
 			      slab_block_number block_number,
 			      enum reference_status old_status,
-			      struct pbn_lock *lock,
-			      vdo_refcount_t *counter_ptr,
+			      struct pbn_lock *lock, vdo_refcount_t *counter_ptr,
 			      bool adjust_block_count)
 {
 	switch (old_status) {
@@ -1471,8 +1434,7 @@ static int increment_for_data(struct vdo_slab *slab,
 		if (*counter_ptr >= MAXIMUM_REFERENCE_COUNT) {
 			return uds_log_error_strerror(VDO_REF_COUNT_INVALID,
 						      "Incrementing a block already having 254 references (slab %u, offset %u)",
-						      slab->slab_number,
-						      block_number);
+						      slab->slab_number, block_number);
 		}
 		(*counter_ptr)++;
 	}
@@ -1495,20 +1457,17 @@ static int increment_for_data(struct vdo_slab *slab,
  *
  * Return: VDO_SUCCESS or an error.
  */
-static int decrement_for_data(struct vdo_slab *slab,
-			      struct reference_block *block,
+static int decrement_for_data(struct vdo_slab *slab, struct reference_block *block,
 			      slab_block_number block_number,
 			      enum reference_status old_status,
 			      struct reference_updater *updater,
-			      vdo_refcount_t *counter_ptr,
-			      bool adjust_block_count)
+			      vdo_refcount_t *counter_ptr, bool adjust_block_count)
 {
 	switch (old_status) {
 	case RS_FREE:
 		return uds_log_error_strerror(VDO_REF_COUNT_INVALID,
 					      "Decrementing free block at offset %u in slab %u",
-					      block_number,
-					      slab->slab_number);
+					      block_number, slab->slab_number);
 
 	case RS_PROVISIONAL:
 	case RS_SINGLE:
@@ -1561,22 +1520,18 @@ static int decrement_for_data(struct vdo_slab *slab,
  *
  * Return: VDO_SUCCESS or an error.
  */
-static int increment_for_block_map(struct vdo_slab *slab,
-				   struct reference_block *block,
+static int increment_for_block_map(struct vdo_slab *slab, struct reference_block *block,
 				   slab_block_number block_number,
 				   enum reference_status old_status,
-				   struct pbn_lock *lock,
-				   bool normal_operation,
-				   vdo_refcount_t *counter_ptr,
-				   bool adjust_block_count)
+				   struct pbn_lock *lock, bool normal_operation,
+				   vdo_refcount_t *counter_ptr, bool adjust_block_count)
 {
 	switch (old_status) {
 	case RS_FREE:
 		if (normal_operation) {
 			return uds_log_error_strerror(VDO_REF_COUNT_INVALID,
 						      "Incrementing unallocated block map block (slab %u, offset %u)",
-						      slab->slab_number,
-						      block_number);
+						      slab->slab_number, block_number);
 		}
 
 		*counter_ptr = MAXIMUM_REFERENCE_COUNT;
@@ -1591,8 +1546,7 @@ static int increment_for_block_map(struct vdo_slab *slab,
 		if (!normal_operation)
 			return uds_log_error_strerror(VDO_REF_COUNT_INVALID,
 						      "Block map block had provisional reference during replay (slab %u, offset %u)",
-						      slab->slab_number,
-						      block_number);
+						      slab->slab_number, block_number);
 
 		*counter_ptr = MAXIMUM_REFERENCE_COUNT;
 		if (lock != NULL)
@@ -1602,8 +1556,7 @@ static int increment_for_block_map(struct vdo_slab *slab,
 	default:
 		return uds_log_error_strerror(VDO_REF_COUNT_INVALID,
 					      "Incrementing a block map block which is already referenced %u times (slab %u, offset %u)",
-					      *counter_ptr,
-					      slab->slab_number,
+					      *counter_ptr, slab->slab_number,
 					      block_number);
 	}
 }
@@ -1627,50 +1580,32 @@ static bool __must_check is_valid_journal_point(const struct journal_point *poin
  *
  * Return: VDO_SUCCESS or an error.
  */
-static int
-update_reference_count(struct vdo_slab *slab,
-		       struct reference_block *block,
-		       slab_block_number block_number,
-		       const struct journal_point *slab_journal_point,
-		       struct reference_updater *updater,
-		       bool normal_operation,
-		       bool adjust_block_count,
-		       bool *provisional_decrement_ptr)
+static int update_reference_count(struct vdo_slab *slab, struct reference_block *block,
+				  slab_block_number block_number,
+				  const struct journal_point *slab_journal_point,
+				  struct reference_updater *updater,
+				  bool normal_operation, bool adjust_block_count,
+				  bool *provisional_decrement_ptr)
 {
 	vdo_refcount_t *counter_ptr = &slab->counters[block_number];
 	enum reference_status old_status = reference_count_to_status(*counter_ptr);
 	int result;
 
 	if (!updater->increment) {
-		result = decrement_for_data(slab,
-					    block,
-					    block_number,
-					    old_status,
-					    updater,
-					    counter_ptr,
-					    adjust_block_count);
+		result = decrement_for_data(slab, block, block_number, old_status,
+					    updater, counter_ptr, adjust_block_count);
 		if ((result == VDO_SUCCESS) && (old_status == RS_PROVISIONAL)) {
 			if (provisional_decrement_ptr != NULL)
 				*provisional_decrement_ptr = true;
 			return VDO_SUCCESS;
 		}
 	} else if (updater->operation == VDO_JOURNAL_DATA_REMAPPING) {
-		result = increment_for_data(slab,
-					    block,
-					    block_number,
-					    old_status,
-					    updater->lock,
-					    counter_ptr,
-					    adjust_block_count);
+		result = increment_for_data(slab, block, block_number, old_status,
+					    updater->lock, counter_ptr, adjust_block_count);
 	} else {
-		result = increment_for_block_map(slab,
-						 block,
-						 block_number,
-						 old_status,
-						 updater->lock,
-						 normal_operation,
-						 counter_ptr,
-						 adjust_block_count);
+		result = increment_for_block_map(slab, block, block_number, old_status,
+						 updater->lock, normal_operation,
+						 counter_ptr, adjust_block_count);
 	}
 
 	if (result != VDO_SUCCESS)
@@ -1682,10 +1617,9 @@ update_reference_count(struct vdo_slab *slab,
 	return VDO_SUCCESS;
 }
 
-static int __must_check
-adjust_reference_count(struct vdo_slab *slab,
-		       struct reference_updater *updater,
-		       const struct journal_point *slab_journal_point)
+static int __must_check adjust_reference_count(struct vdo_slab *slab,
+					       struct reference_updater *updater,
+					       const struct journal_point *slab_journal_point)
 {
 	slab_block_number block_number;
 	int result;
@@ -1700,13 +1634,8 @@ adjust_reference_count(struct vdo_slab *slab,
 		return result;
 
 	block = get_reference_block(slab, block_number);
-	result = update_reference_count(slab,
-					block,
-					block_number,
-					slab_journal_point,
-					updater,
-					NORMAL_OPERATION,
-					true,
+	result = update_reference_count(slab, block, block_number, slab_journal_point,
+					updater, NORMAL_OPERATION, true,
 					&provisional_decrement);
 	if ((result != VDO_SUCCESS) || provisional_decrement)
 		return result;
@@ -1782,11 +1711,9 @@ static void add_entry_from_waiter(struct waiter *waiter, void *context)
 		reclaim_journal_space(journal);
 	}
 
-	add_entry(journal,
-		  updater->zpbn.pbn,
-		  updater->operation,
-		  updater->increment,
-		  expand_journal_point(data_vio->recovery_journal_point, updater->increment));
+	add_entry(journal, updater->zpbn.pbn, updater->operation, updater->increment,
+		  expand_journal_point(data_vio->recovery_journal_point,
+				       updater->increment));
 
 	if (journal->slab->status != VDO_SLAB_REBUILT) {
 		/*
@@ -1794,12 +1721,12 @@ static void add_entry_from_waiter(struct waiter *waiter, void *context)
 		 * update is now recorded in the journal.
 		 */
 		adjust_slab_journal_block_reference(journal,
-						    slab_journal_point.sequence_number,
-						    -1);
+						    slab_journal_point.sequence_number, -1);
 		result = VDO_SUCCESS;
 	} else {
 		/* Now that an entry has been made in the slab journal, update the counter. */
-		result = adjust_reference_count(journal->slab, updater, &slab_journal_point);
+		result = adjust_reference_count(journal->slab, updater,
+						&slab_journal_point);
 	}
 
 	if (updater->increment)
@@ -1818,7 +1745,9 @@ static void add_entry_from_waiter(struct waiter *waiter, void *context)
 static inline bool is_next_entry_a_block_map_increment(struct slab_journal *journal)
 {
 	struct waiter *waiter = vdo_get_first_waiter(&journal->entry_waiters);
-	struct reference_updater *updater = container_of(waiter, struct reference_updater, waiter);
+	struct reference_updater *updater = container_of(waiter,
+							 struct reference_updater,
+							 waiter);
 
 	return (updater->operation == VDO_JOURNAL_BLOCK_MAP_REMAPPING);
 }
@@ -1930,13 +1859,13 @@ static void add_entries(struct slab_journal *journal)
 					dirty_block(&slab->reference_blocks[i]);
 				}
 
-				adjust_slab_journal_block_reference(journal,
-								    1,
+				adjust_slab_journal_block_reference(journal, 1,
 								    slab->reference_block_count);
 			}
 		}
 
-		vdo_notify_next_waiter(&journal->entry_waiters, add_entry_from_waiter, journal);
+		vdo_notify_next_waiter(&journal->entry_waiters,
+				       add_entry_from_waiter, journal);
 	}
 
 	journal->adding_entries = false;
@@ -2020,14 +1949,8 @@ int vdo_adjust_reference_count_for_rebuild(struct slab_depot *depot,
 		return result;
 
 	block = get_reference_block(slab, block_number);
-	result = update_reference_count(slab,
-					block,
-					block_number,
-					NULL,
-					&updater,
-					!NORMAL_OPERATION,
-					false,
-					NULL);
+	result = update_reference_count(slab, block, block_number, NULL,
+					&updater, !NORMAL_OPERATION, false, NULL);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -2046,10 +1969,9 @@ int vdo_adjust_reference_count_for_rebuild(struct slab_depot *depot,
  *
  * Return: VDO_SUCCESS or an error code.
  */
-static int
-replay_reference_count_change(struct vdo_slab *slab,
-			      const struct journal_point *entry_point,
-			      struct slab_journal_entry entry)
+static int replay_reference_count_change(struct vdo_slab *slab,
+					 const struct journal_point *entry_point,
+					 struct slab_journal_entry entry)
 {
 	int result;
 	struct reference_block *block = get_reference_block(slab, entry.sbn);
@@ -2065,14 +1987,8 @@ replay_reference_count_change(struct vdo_slab *slab,
 	}
 
 	/* This entry is not yet counted in the reference counts. */
-	result = update_reference_count(slab,
-					block,
-					entry.sbn,
-					entry_point,
-					&updater,
-					!NORMAL_OPERATION,
-					false,
-					NULL);
+	result = update_reference_count(slab, block, entry.sbn, entry_point,
+					&updater, !NORMAL_OPERATION, false, NULL);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -2092,10 +2008,9 @@ replay_reference_count_change(struct vdo_slab *slab,
  * Return: The array index of the first zero byte in the word, or the value passed as fail_index if
  *         no zero byte was found.
  */
-static inline slab_block_number
-find_zero_byte_in_word(const u8 *word_ptr,
-		       slab_block_number start_index,
-		       slab_block_number fail_index)
+static inline slab_block_number find_zero_byte_in_word(const u8 *word_ptr,
+						       slab_block_number start_index,
+						       slab_block_number fail_index)
 {
 	u64 word = get_unaligned_le64(word_ptr);
 
@@ -2122,8 +2037,7 @@ find_zero_byte_in_word(const u8 *word_ptr,
  *
  * Return: true if a free block was found in the specified range.
  */
-static bool
-find_free_block(const struct vdo_slab *slab, slab_block_number *index_ptr)
+static bool find_free_block(const struct vdo_slab *slab, slab_block_number *index_ptr)
 {
 	slab_block_number zero_index;
 	slab_block_number next_index = slab->search_cursor.index;
@@ -2199,8 +2113,8 @@ static bool search_current_reference_block(const struct vdo_slab *slab,
  *
  * Return: true if an unreferenced counter was found.
  */
-static bool
-search_reference_blocks(struct vdo_slab *slab, slab_block_number *free_index_ptr)
+static bool search_reference_blocks(struct vdo_slab *slab,
+				    slab_block_number *free_index_ptr)
 {
 	/* Start searching at the saved search position in the current block. */
 	if (search_current_reference_block(slab, free_index_ptr))
@@ -2218,8 +2132,8 @@ search_reference_blocks(struct vdo_slab *slab, slab_block_number *free_index_ptr
 /**
  * make_provisional_reference() - Do the bookkeeping for making a provisional reference.
  */
-static void
-make_provisional_reference(struct vdo_slab *slab, slab_block_number block_number)
+static void make_provisional_reference(struct vdo_slab *slab,
+				       slab_block_number block_number)
 {
 	struct reference_block *block = get_reference_block(slab, block_number);
 
@@ -2262,7 +2176,8 @@ static void clear_provisional_references(struct reference_block *block)
 	}
 }
 
-static inline bool journal_points_equal(struct journal_point first, struct journal_point second)
+static inline bool journal_points_equal(struct journal_point first,
+					struct journal_point second)
 {
 	return ((first.sequence_number == second.sequence_number) &&
 		(first.entry_count == second.entry_count));
@@ -2273,8 +2188,8 @@ static inline bool journal_points_equal(struct journal_point first, struct journ
  * @packed: The written reference block to be unpacked.
  * @block: The internal reference block to be loaded.
  */
-static void
-unpack_reference_block(struct packed_reference_block *packed, struct reference_block *block)
+static void unpack_reference_block(struct packed_reference_block *packed,
+				   struct reference_block *block)
 {
 	block_count_t index;
 	sector_count_t i;
@@ -2285,21 +2200,20 @@ unpack_reference_block(struct packed_reference_block *packed, struct reference_b
 		struct packed_reference_sector *sector = &packed->sectors[i];
 
 		vdo_unpack_journal_point(&sector->commit_point, &block->commit_points[i]);
-		memcpy(counters + (i * COUNTS_PER_SECTOR),
-		       sector->counts,
+		memcpy(counters + (i * COUNTS_PER_SECTOR), sector->counts,
 		       (sizeof(vdo_refcount_t) * COUNTS_PER_SECTOR));
 		/* The slab_journal_point must be the latest point found in any sector. */
-		if (vdo_before_journal_point(&slab->slab_journal_point, &block->commit_points[i]))
+		if (vdo_before_journal_point(&slab->slab_journal_point,
+					     &block->commit_points[i]))
 			slab->slab_journal_point = block->commit_points[i];
 
 		if ((i > 0) &&
-		    !journal_points_equal(block->commit_points[0], block->commit_points[i])) {
+		    !journal_points_equal(block->commit_points[0],
+					  block->commit_points[i])) {
 			size_t block_index = block - block->slab->reference_blocks;
 
 			uds_log_warning("Torn write detected in sector %u of reference block %zu of slab %u",
-					i,
-					block_index,
-					block->slab->slab_number);
+					i, block_index, block->slab->slab_number);
 		}
 	}
 
@@ -2335,7 +2249,8 @@ static void load_reference_block_endio(struct bio *bio)
 	struct vio *vio = bio->bi_private;
 	struct reference_block *block = vio->completion.parent;
 
-	continue_vio_after_io(vio, finish_reference_block_load, block->slab->allocator->thread_id);
+	continue_vio_after_io(vio, finish_reference_block_load,
+			      block->slab->allocator->thread_id);
 }
 
 /**
@@ -2353,10 +2268,8 @@ static void load_reference_block(struct waiter *waiter, void *context)
 	size_t block_offset = (block - block->slab->reference_blocks);
 
 	vio->completion.parent = block;
-	submit_metadata_vio(vio,
-			    block->slab->ref_counts_origin + block_offset,
-			    load_reference_block_endio,
-			    handle_io_error,
+	submit_metadata_vio(vio, block->slab->ref_counts_origin + block_offset,
+			    load_reference_block_endio, handle_io_error,
 			    REQ_OP_READ);
 }
 
@@ -2447,10 +2360,8 @@ static int allocate_slab_counters(struct vdo_slab *slab)
 	if (result != VDO_SUCCESS)
 		return result;
 
-	result = uds_allocate(slab->reference_block_count,
-			      struct reference_block,
-			      __func__,
-			      &slab->reference_blocks);
+	result = uds_allocate(slab->reference_block_count, struct reference_block,
+			      __func__, &slab->reference_blocks);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -2459,7 +2370,8 @@ static int allocate_slab_counters(struct vdo_slab *slab)
 	 * so we can word-search even at the very end.
 	 */
 	bytes = (slab->reference_block_count * COUNTS_PER_BLOCK) + (2 * BYTES_PER_WORD);
-	result = uds_allocate(bytes, vdo_refcount_t, "ref counts array", &slab->counters);
+	result = uds_allocate(bytes, vdo_refcount_t, "ref counts array",
+			      &slab->counters);
 	if (result != UDS_SUCCESS) {
 		uds_free(uds_forget(slab->reference_blocks));
 		return result;
@@ -2520,7 +2432,8 @@ static void read_slab_journal_tail_endio(struct bio *bio)
 	struct vio *vio = bio->bi_private;
 	struct slab_journal *journal = vio->completion.parent;
 
-	continue_vio_after_io(vio, finish_loading_journal, journal->slab->allocator->thread_id);
+	continue_vio_after_io(vio, finish_loading_journal,
+			      journal->slab->allocator->thread_id);
 }
 
 static void handle_load_error(struct vdo_completion *completion)
@@ -2544,7 +2457,8 @@ static void handle_load_error(struct vdo_completion *completion)
  */
 static void read_slab_journal_tail(struct waiter *waiter, void *context)
 {
-	struct slab_journal *journal = container_of(waiter, struct slab_journal, resource_waiter);
+	struct slab_journal *journal =
+		container_of(waiter, struct slab_journal, resource_waiter);
 	struct vdo_slab *slab = journal->slab;
 	struct pooled_vio *pooled = context;
 	struct vio *vio = &pooled->vio;
@@ -2561,10 +2475,8 @@ static void read_slab_journal_tail(struct waiter *waiter, void *context)
 
 	vio->completion.parent = journal;
 	vio->completion.callback_thread_id = slab->allocator->thread_id;
-	submit_metadata_vio(vio,
-			    slab->journal_origin + tail_block,
-			    read_slab_journal_tail_endio,
-			    handle_load_error,
+	submit_metadata_vio(vio, slab->journal_origin + tail_block,
+			    read_slab_journal_tail_endio, handle_load_error,
 			    REQ_OP_READ);
 }
 
@@ -2587,7 +2499,8 @@ static void load_slab_journal(struct vdo_slab *slab)
 		ASSERT_LOG_ONLY(((journal->size < 16) ||
 				 (journal->scrubbing_threshold < (journal->size - 1))),
 				"Scrubbing threshold protects against reads of unwritten slab journal blocks");
-		vdo_finish_loading_with_result(&slab->state, allocate_counters_if_clean(slab));
+		vdo_finish_loading_with_result(&slab->state,
+					       allocate_counters_if_clean(slab));
 		return;
 	}
 
@@ -2599,7 +2512,8 @@ static void register_slab_for_scrubbing(struct vdo_slab *slab, bool high_priorit
 {
 	struct slab_scrubber *scrubber = &slab->allocator->scrubber;
 
-	ASSERT_LOG_ONLY((slab->status != VDO_SLAB_REBUILT), "slab to be scrubbed is unrecovered");
+	ASSERT_LOG_ONLY((slab->status != VDO_SLAB_REBUILT),
+			"slab to be scrubbed is unrecovered");
 
 	if (slab->status != VDO_SLAB_REQUIRES_SCRUBBING)
 		return;
@@ -2635,8 +2549,7 @@ static void queue_slab(struct vdo_slab *slab)
 	free_blocks = slab->free_blocks;
 	result = ASSERT((free_blocks <= allocator->depot->slab_config.data_blocks),
 			"rebuilt slab %u must have a valid free block count (has %llu, expected maximum %llu)",
-			slab->slab_number,
-			(unsigned long long) free_blocks,
+			slab->slab_number, (unsigned long long) free_blocks,
 			(unsigned long long) allocator->depot->slab_config.data_blocks);
 	if (result != VDO_SUCCESS) {
 		vdo_enter_read_only_mode(allocator->depot->vdo, result);
@@ -2654,7 +2567,8 @@ static void queue_slab(struct vdo_slab *slab)
 		 * again.
 		 * FIXME: under what situation would the slab be resuming here?
 		 */
-		WRITE_ONCE(allocator->allocated_blocks, allocator->allocated_blocks - free_blocks);
+		WRITE_ONCE(allocator->allocated_blocks,
+			   allocator->allocated_blocks - free_blocks);
 		if (!is_slab_journal_blank(slab)) {
 			WRITE_ONCE(allocator->statistics.slabs_opened,
 				   allocator->statistics.slabs_opened + 1);
@@ -2712,12 +2626,12 @@ static struct vdo_slab *get_next_slab(struct slab_scrubber *scrubber)
 	struct vdo_slab *slab;
 
 	slab = list_first_entry_or_null(&scrubber->high_priority_slabs,
-					struct vdo_slab,
-					allocq_entry);
+					struct vdo_slab, allocq_entry);
 	if (slab != NULL)
 		return slab;
 
-	return list_first_entry_or_null(&scrubber->slabs, struct vdo_slab, allocq_entry);
+	return list_first_entry_or_null(&scrubber->slabs, struct vdo_slab,
+					allocq_entry);
 }
 
 /**
@@ -2762,7 +2676,8 @@ static void finish_scrubbing(struct slab_scrubber *scrubber, int result)
 	} else if (done && (atomic_add_return(-1, &allocator->depot->zones_to_scrub) == 0)) {
 		/* All of our slabs were scrubbed, and we're the last allocator to finish. */
 		enum vdo_state prior_state =
-			atomic_cmpxchg(&allocator->depot->vdo->state, VDO_RECOVERING, VDO_DIRTY);
+			atomic_cmpxchg(&allocator->depot->vdo->state, VDO_RECOVERING,
+				       VDO_DIRTY);
 
 		/*
 		 * To be safe, even if the CAS failed, ensure anything that follows is ordered with
@@ -2786,7 +2701,8 @@ static void finish_scrubbing(struct slab_scrubber *scrubber, int result)
 	 * happen.
 	 */
 	if (!vdo_finish_draining(&scrubber->admin_state))
-		WRITE_ONCE(scrubber->admin_state.current_state, VDO_ADMIN_STATE_SUSPENDED);
+		WRITE_ONCE(scrubber->admin_state.current_state,
+			   VDO_ADMIN_STATE_SUSPENDED);
 
 	/*
 	 * We can't notify waiters until after we've finished draining or they'll just requeue.
@@ -2837,7 +2753,8 @@ static void handle_scrubber_error(struct vdo_completion *completion)
 	struct vio *vio = as_vio(completion);
 
 	vio_record_metadata_io_error(vio);
-	abort_scrubbing(container_of(vio, struct slab_scrubber, vio), completion->result);
+	abort_scrubbing(container_of(vio, struct slab_scrubber, vio),
+			completion->result);
 }
 
 /**
@@ -2851,8 +2768,7 @@ static void handle_scrubber_error(struct vdo_completion *completion)
  */
 static int apply_block_entries(struct packed_slab_journal_block *block,
 			       journal_entry_count_t entry_count,
-			       sequence_number_t block_number,
-			       struct vdo_slab *slab)
+			       sequence_number_t block_number, struct vdo_slab *slab)
 {
 	struct journal_point entry_point = {
 		.sequence_number = block_number,
@@ -2871,8 +2787,7 @@ static int apply_block_entries(struct packed_slab_journal_block *block,
 						      "vdo_slab journal entry (%llu, %u) had invalid offset %u in slab (size %u blocks)",
 						      (unsigned long long) block_number,
 						      entry_point.entry_count,
-						      entry.sbn,
-						      max_sbn);
+						      entry.sbn, max_sbn);
 		}
 
 		result = replay_reference_count_change(slab, &entry_point, entry);
@@ -2882,8 +2797,7 @@ static int apply_block_entries(struct packed_slab_journal_block *block,
 					       (unsigned long long) block_number,
 					       entry_point.entry_count,
 					       vdo_get_journal_operation_name(entry.operation),
-					       entry.sbn,
-					       slab->slab_number);
+					       entry.sbn, slab->slab_number);
 			return result;
 		}
 		entry_point.entry_count++;
@@ -2959,7 +2873,8 @@ static void apply_journal_entries(struct vdo_completion *completion)
 	 * At the end of rebuild, the reference counters should be accurate to the end of the
 	 * journal we just applied.
 	 */
-	result = ASSERT(!vdo_before_journal_point(&last_entry_applied, &ref_counts_point),
+	result = ASSERT(!vdo_before_journal_point(&last_entry_applied,
+						  &ref_counts_point),
 			"Refcounts are not more accurate than the slab journal");
 	if (result != VDO_SUCCESS) {
 		abort_scrubbing(scrubber, result);
@@ -2967,15 +2882,11 @@ static void apply_journal_entries(struct vdo_completion *completion)
 	}
 
 	/* Save out the rebuilt reference blocks. */
-	vdo_prepare_completion(completion,
-			       slab_scrubbed,
-			       handle_scrubber_error,
-			       slab->allocator->thread_id,
-			       completion->parent);
+	vdo_prepare_completion(completion, slab_scrubbed, handle_scrubber_error,
+			       slab->allocator->thread_id, completion->parent);
 	vdo_start_operation_with_waiter(&slab->state,
 					VDO_ADMIN_STATE_SAVE_FOR_SCRUBBING,
-					completion,
-					initiate_slab_action);
+					completion, initiate_slab_action);
 }
 
 static void read_slab_journal_endio(struct bio *bio)
@@ -2983,8 +2894,7 @@ static void read_slab_journal_endio(struct bio *bio)
 	struct vio *vio = bio->bi_private;
 	struct slab_scrubber *scrubber = container_of(vio, struct slab_scrubber, vio);
 
-	continue_vio_after_io(bio->bi_private,
-			      apply_journal_entries,
+	continue_vio_after_io(bio->bi_private, apply_journal_entries,
 			      scrubber->slab->allocator->thread_id);
 }
 
@@ -3005,10 +2915,8 @@ static void start_scrubbing(struct vdo_completion *completion)
 		return;
 	}
 
-	submit_metadata_vio(&scrubber->vio,
-			    slab->journal_origin,
-			    read_slab_journal_endio,
-			    handle_scrubber_error,
+	submit_metadata_vio(&scrubber->vio, slab->journal_origin,
+			    read_slab_journal_endio, handle_scrubber_error,
 			    REQ_OP_READ);
 }
 
@@ -3044,15 +2952,10 @@ static void scrub_next_slab(struct slab_scrubber *scrubber)
 
 	list_del_init(&slab->allocq_entry);
 	scrubber->slab = slab;
-	vdo_prepare_completion(completion,
-			       start_scrubbing,
-			       handle_scrubber_error,
-			       slab->allocator->thread_id,
-			       completion->parent);
-	vdo_start_operation_with_waiter(&slab->state,
-					VDO_ADMIN_STATE_SCRUBBING,
-					completion,
-					initiate_slab_action);
+	vdo_prepare_completion(completion, start_scrubbing, handle_scrubber_error,
+			       slab->allocator->thread_id, completion->parent);
+	vdo_start_operation_with_waiter(&slab->state, VDO_ADMIN_STATE_SCRUBBING,
+					completion, initiate_slab_action);
 }
 
 /**
@@ -3080,14 +2983,15 @@ static void scrub_slabs(struct block_allocator *allocator, struct vdo_completion
 	scrub_next_slab(scrubber);
 }
 
-static inline void assert_on_allocator_thread(thread_id_t thread_id, const char *function_name)
+static inline void assert_on_allocator_thread(thread_id_t thread_id,
+					      const char *function_name)
 {
 	ASSERT_LOG_ONLY((vdo_get_callback_thread_id() == thread_id),
-			"%s called on correct thread",
-			function_name);
+			"%s called on correct thread", function_name);
 }
 
-static void register_slab_with_allocator(struct block_allocator *allocator, struct vdo_slab *slab)
+static void register_slab_with_allocator(struct block_allocator *allocator,
+					 struct vdo_slab *slab)
 {
 	allocator->slab_count++;
 	allocator->last_slab = slab->slab_number;
@@ -3105,8 +3009,7 @@ static void register_slab_with_allocator(struct block_allocator *allocator, stru
  * Return: An initialized iterator structure.
  */
 static struct slab_iterator get_depot_slab_iterator(struct slab_depot *depot,
-						    slab_count_t start,
-						    slab_count_t end,
+						    slab_count_t start, slab_count_t end,
 						    slab_count_t stride)
 {
 	struct vdo_slab **slabs = depot->slabs;
@@ -3121,8 +3024,7 @@ static struct slab_iterator get_depot_slab_iterator(struct slab_depot *depot,
 
 static struct slab_iterator get_slab_iterator(const struct block_allocator *allocator)
 {
-	return get_depot_slab_iterator(allocator->depot,
-				       allocator->last_slab,
+	return get_depot_slab_iterator(allocator->depot, allocator->last_slab,
 				       allocator->zone_number,
 				       allocator->depot->zone_count);
 }
@@ -3166,7 +3068,8 @@ static void abort_waiter(struct waiter *waiter, void *context __always_unused)
 }
 
 /* Implements vdo_read_only_notification. */
-static void notify_block_allocator_of_read_only_mode(void *listener, struct vdo_completion *parent)
+static void notify_block_allocator_of_read_only_mode(void *listener,
+						     struct vdo_completion *parent)
 {
 	struct block_allocator *allocator = listener;
 	struct slab_iterator iterator;
@@ -3176,7 +3079,8 @@ static void notify_block_allocator_of_read_only_mode(void *listener, struct vdo_
 	while (iterator.next != NULL) {
 		struct vdo_slab *slab = next_slab(&iterator);
 
-		vdo_notify_all_waiters(&slab->journal.entry_waiters, abort_waiter, &slab->journal);
+		vdo_notify_all_waiters(&slab->journal.entry_waiters,
+				       abort_waiter, &slab->journal);
 		check_if_slab_drained(slab);
 	}
 
@@ -3192,8 +3096,7 @@ static void notify_block_allocator_of_read_only_mode(void *listener, struct vdo_
  *
  * Return: VDO_SUCCESS or an error.
  */
-int vdo_acquire_provisional_reference(struct vdo_slab *slab,
-				      physical_block_number_t pbn,
+int vdo_acquire_provisional_reference(struct vdo_slab *slab, physical_block_number_t pbn,
 				      struct pbn_lock *lock)
 {
 	slab_block_number block_number;
@@ -3221,8 +3124,8 @@ int vdo_acquire_provisional_reference(struct vdo_slab *slab,
 	return VDO_SUCCESS;
 }
 
-static int __must_check
-allocate_slab_block(struct vdo_slab *slab, physical_block_number_t *block_number_ptr)
+static int __must_check allocate_slab_block(struct vdo_slab *slab,
+					    physical_block_number_t *block_number_ptr)
 {
 	slab_block_number free_index;
 
@@ -3289,8 +3192,7 @@ int vdo_allocate_block(struct block_allocator *allocator,
 
 	/* Remove the highest priority slab from the priority table and make it the open slab. */
 	open_slab(list_entry(vdo_priority_table_dequeue(allocator->prioritized_slabs),
-			     struct vdo_slab,
-			     allocq_entry));
+			     struct vdo_slab, allocq_entry));
 
 	/*
 	 * Try allocating again. If we're out of space immediately after opening a slab, then every
@@ -3307,7 +3209,8 @@ int vdo_allocate_block(struct block_allocator *allocator,
  * Return: VDO_SUCCESS if the waiter was queued, VDO_NO_SPACE if there are no slabs to scrub, and
  *         some other error otherwise.
  */
-int vdo_enqueue_clean_slab_waiter(struct block_allocator *allocator, struct waiter *waiter)
+int vdo_enqueue_clean_slab_waiter(struct block_allocator *allocator,
+				  struct waiter *waiter)
 {
 	if (vdo_is_read_only(allocator->depot->vdo))
 		return VDO_READ_ONLY;
@@ -3349,7 +3252,8 @@ void vdo_modify_reference_count(struct vdo_completion *completion,
 }
 
 /* Release an unused provisional reference. */
-int vdo_release_block_reference(struct block_allocator *allocator, physical_block_number_t pbn)
+int vdo_release_block_reference(struct block_allocator *allocator,
+				physical_block_number_t pbn)
 {
 	struct reference_updater updater;
 
@@ -3364,7 +3268,8 @@ int vdo_release_block_reference(struct block_allocator *allocator, physical_bloc
 		},
 	};
 
-	return adjust_reference_count(vdo_get_slab(allocator->depot, pbn), &updater, NULL);
+	return adjust_reference_count(vdo_get_slab(allocator->depot, pbn),
+				      &updater, NULL);
 }
 
 /*
@@ -3431,11 +3336,8 @@ static void apply_to_slabs(struct block_allocator *allocator, vdo_action *callba
 {
 	struct slab_iterator iterator;
 
-	vdo_prepare_completion(&allocator->completion,
-			       slab_action_callback,
-			       handle_operation_error,
-			       allocator->thread_id,
-			       NULL);
+	vdo_prepare_completion(&allocator->completion, slab_action_callback,
+			       handle_operation_error, allocator->thread_id, NULL);
 	allocator->completion.requeue = false;
 
 	/*
@@ -3458,8 +3360,7 @@ static void apply_to_slabs(struct block_allocator *allocator, vdo_action *callba
 
 		list_del_init(&slab->allocq_entry);
 		allocator->slab_actor.slab_action_count++;
-		vdo_start_operation_with_waiter(&slab->state,
-						operation,
+		vdo_start_operation_with_waiter(&slab->state, operation,
 						&allocator->completion,
 						initiate_slab_action);
 	}
@@ -3541,8 +3442,7 @@ static void initiate_load(struct admin_state *state)
 		vdo_prepare_completion_for_requeue(&allocator->completion,
 						   finish_loading_allocator,
 						   handle_operation_error,
-						   allocator->thread_id,
-						   NULL);
+						   allocator->thread_id, NULL);
 		allocator->eraser = dm_kcopyd_client_create(NULL);
 		if (allocator->eraser == NULL) {
 			vdo_fail_completion(&allocator->completion, -ENOMEM);
@@ -3569,14 +3469,15 @@ void vdo_notify_slab_journals_are_recovered(struct vdo_completion *completion)
 	vdo_finish_loading_with_result(&allocator->state, completion->result);
 }
 
-static int
-get_slab_statuses(struct block_allocator *allocator, struct slab_status **statuses_ptr)
+static int get_slab_statuses(struct block_allocator *allocator,
+			     struct slab_status **statuses_ptr)
 {
 	int result;
 	struct slab_status *statuses;
 	struct slab_iterator iterator = get_slab_iterator(allocator);
 
-	result = uds_allocate(allocator->slab_count, struct slab_status, __func__, &statuses);
+	result = uds_allocate(allocator->slab_count, struct slab_status, __func__,
+			      &statuses);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -3596,8 +3497,7 @@ get_slab_statuses(struct block_allocator *allocator, struct slab_status **status
 }
 
 /* Prepare slabs for allocation or scrubbing. */
-static int __must_check
-vdo_prepare_slabs_for_allocation(struct block_allocator *allocator)
+static int __must_check vdo_prepare_slabs_for_allocation(struct block_allocator *allocator)
 {
 	struct slab_status current_slab_status;
 	struct min_heap heap;
@@ -3678,13 +3578,11 @@ void vdo_dump_block_allocator(const struct block_allocator *allocator)
 
 		if (slab->reference_blocks != NULL) {
 			/* Terse because there are a lot of slabs to dump and syslog is lossy. */
-			uds_log_info("slab %u: P%u, %llu free",
-				     slab->slab_number,
+			uds_log_info("slab %u: P%u, %llu free", slab->slab_number,
 				     slab->priority,
 				     (unsigned long long) slab->free_blocks);
 		} else {
-			uds_log_info("slab %u: status %s",
-				     slab->slab_number,
+			uds_log_info("slab %u: status %s", slab->slab_number,
 				     status_to_string(slab->status));
 		}
 
@@ -3708,8 +3606,7 @@ void vdo_dump_block_allocator(const struct block_allocator *allocator)
 		if (slab->counters != NULL) {
 			/* Terse because there are a lot of slabs to dump and syslog is lossy. */
 			uds_log_info("  slab: free=%u/%u blocks=%u dirty=%zu active=%zu journal@(%llu,%u)",
-				     slab->free_blocks,
-				     slab->block_count,
+				     slab->free_blocks, slab->block_count,
 				     slab->reference_block_count,
 				     vdo_count_waiters(&slab->dirty_blocks),
 				     slab->active_count,
@@ -3755,16 +3652,12 @@ static int initialize_slab_journal(struct vdo_slab *slab)
 	const struct slab_config *slab_config = &slab->allocator->depot->slab_config;
 	int result;
 
-	result = uds_allocate(slab_config->slab_journal_blocks,
-			      struct journal_lock,
-			      __func__,
-			      &journal->locks);
+	result = uds_allocate(slab_config->slab_journal_blocks, struct journal_lock,
+			      __func__, &journal->locks);
 	if (result != VDO_SUCCESS)
 		return result;
 
-	result = uds_allocate(VDO_BLOCK_SIZE,
-			      char,
-			      "struct packed_slab_journal_block",
+	result = uds_allocate(VDO_BLOCK_SIZE, char, "struct packed_slab_journal_block",
 			      (char **) &journal->block);
 	if (result != VDO_SUCCESS)
 		return result;
@@ -3811,12 +3704,10 @@ static int initialize_slab_journal(struct vdo_slab *slab)
  *
  * Return: VDO_SUCCESS or an error code.
  */
-static int __must_check
-make_slab(physical_block_number_t slab_origin,
-	  struct block_allocator *allocator,
-	  slab_count_t slab_number,
-	  bool is_new,
-	  struct vdo_slab **slab_ptr)
+static int __must_check make_slab(physical_block_number_t slab_origin,
+				  struct block_allocator *allocator,
+				  slab_count_t slab_number, bool is_new,
+				  struct vdo_slab **slab_ptr)
 {
 	const struct slab_config *slab_config = &allocator->depot->slab_config;
 	struct vdo_slab *slab;
@@ -3879,16 +3770,13 @@ static int allocate_slabs(struct slab_depot *depot, slab_count_t slab_count)
 	physical_block_number_t slab_origin;
 	int result;
 
-	result = uds_allocate(slab_count,
-			      struct vdo_slab *,
-			      "slab pointer array",
-			      &depot->new_slabs);
+	result = uds_allocate(slab_count, struct vdo_slab *,
+			      "slab pointer array", &depot->new_slabs);
 	if (result != VDO_SUCCESS)
 		return result;
 
 	if (depot->slabs != NULL) {
-		memcpy(depot->new_slabs,
-		       depot->slabs,
+		memcpy(depot->new_slabs, depot->slabs,
 		       depot->slab_count * sizeof(struct vdo_slab *));
 		resizing = true;
 	}
@@ -3903,11 +3791,8 @@ static int allocate_slabs(struct slab_depot *depot, slab_count_t slab_count)
 			&depot->allocators[depot->new_slab_count % depot->zone_count];
 		struct vdo_slab **slab_ptr = &depot->new_slabs[depot->new_slab_count];
 
-		result = make_slab(slab_origin,
-				   allocator,
-				   depot->new_slab_count,
-				   resizing,
-				   slab_ptr);
+		result = make_slab(slab_origin, allocator, depot->new_slab_count,
+				   resizing, slab_ptr);
 		if (result != VDO_SUCCESS)
 			return result;
 	}
@@ -3952,8 +3837,8 @@ static thread_id_t get_allocator_thread_id(void *context, zone_count_t zone_numb
  *
  * Return: true if the journal does hold a lock on the specified block (which it will release).
  */
-static bool __must_check
-release_recovery_journal_lock(struct slab_journal *journal, sequence_number_t recovery_lock)
+static bool __must_check release_recovery_journal_lock(struct slab_journal *journal,
+						       sequence_number_t recovery_lock)
 {
 	if (recovery_lock > journal->recovery_lock) {
 		ASSERT_LOG_ONLY((recovery_lock < journal->recovery_lock),
@@ -3976,8 +3861,7 @@ release_recovery_journal_lock(struct slab_journal *journal, sequence_number_t re
  *
  * Implements vdo_zone_action.
  */
-static void release_tail_block_locks(void *context,
-				     zone_count_t zone_number,
+static void release_tail_block_locks(void *context, zone_count_t zone_number,
 				     struct vdo_completion *parent)
 {
 	struct slab_journal *journal, *tmp;
@@ -3985,7 +3869,8 @@ static void release_tail_block_locks(void *context,
 	struct list_head *list = &depot->allocators[zone_number].dirty_slab_journals;
 
 	list_for_each_entry_safe(journal, tmp, list, dirty_entry) {
-		if (!release_recovery_journal_lock(journal, depot->active_release_request))
+		if (!release_recovery_journal_lock(journal,
+						   depot->active_release_request))
 			break;
 	}
 
@@ -4023,8 +3908,7 @@ static bool schedule_tail_block_commit(void *context)
 	return vdo_schedule_action(depot->action_manager,
 				   prepare_for_tail_block_commit,
 				   release_tail_block_locks,
-				   NULL,
-				   NULL);
+				   NULL, NULL);
 }
 
 /**
@@ -4041,17 +3925,16 @@ static int initialize_slab_scrubber(struct block_allocator *allocator)
 	char *journal_data;
 	int result;
 
-	result = uds_allocate(VDO_BLOCK_SIZE * slab_journal_size, char, __func__, &journal_data);
+	result = uds_allocate(VDO_BLOCK_SIZE * slab_journal_size,
+			      char, __func__, &journal_data);
 	if (result != VDO_SUCCESS)
 		return result;
 
 	result = allocate_vio_components(allocator->completion.vdo,
 					 VIO_TYPE_SLAB_JOURNAL,
 					 VIO_PRIORITY_METADATA,
-					 allocator,
-					 slab_journal_size,
-					 journal_data,
-					 &scrubber->vio);
+					 allocator, slab_journal_size,
+					 journal_data, &scrubber->vio);
 	if (result != VDO_SUCCESS) {
 		uds_free(journal_data);
 		return result;
@@ -4070,8 +3953,8 @@ static int initialize_slab_scrubber(struct block_allocator *allocator)
  *
  * Return: VDO_SUCCESS or an error.
  */
-static int __must_check
-initialize_slab_summary_block(struct block_allocator *allocator, block_count_t index)
+static int __must_check initialize_slab_summary_block(struct block_allocator *allocator,
+						      block_count_t index)
 {
 	struct slab_summary_block *block = &allocator->summary_blocks[index];
 	int result;
@@ -4080,13 +3963,9 @@ initialize_slab_summary_block(struct block_allocator *allocator, block_count_t i
 	if (result != VDO_SUCCESS)
 		return result;
 
-	result = allocate_vio_components(allocator->depot->vdo,
-					 VIO_TYPE_SLAB_SUMMARY,
-					 VIO_PRIORITY_METADATA,
-					 NULL,
-					 1,
-					 block->outgoing_entries,
-					 &block->vio);
+	result = allocate_vio_components(allocator->depot->vdo, VIO_TYPE_SLAB_SUMMARY,
+					 VIO_PRIORITY_METADATA, NULL, 1,
+					 block->outgoing_entries, &block->vio);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -4096,7 +3975,8 @@ initialize_slab_summary_block(struct block_allocator *allocator, block_count_t i
 	return VDO_SUCCESS;
 }
 
-static int __must_check initialize_block_allocator(struct slab_depot *depot, zone_count_t zone)
+static int __must_check initialize_block_allocator(struct slab_depot *depot,
+						   zone_count_t zone)
 {
 	int result;
 	block_count_t i;
@@ -4114,21 +3994,16 @@ static int __must_check initialize_block_allocator(struct slab_depot *depot, zon
 
 	INIT_LIST_HEAD(&allocator->dirty_slab_journals);
 	vdo_set_admin_state_code(&allocator->state, VDO_ADMIN_STATE_NORMAL_OPERATION);
-	result = vdo_register_read_only_listener(vdo,
-						 allocator,
+	result = vdo_register_read_only_listener(vdo, allocator,
 						 notify_block_allocator_of_read_only_mode,
 						 allocator->thread_id);
 	if (result != VDO_SUCCESS)
 		return result;
 
 	vdo_initialize_completion(&allocator->completion, vdo, VDO_BLOCK_ALLOCATOR_COMPLETION);
-	result = make_vio_pool(vdo,
-			       BLOCK_ALLOCATOR_VIO_POOL_SIZE,
-			       allocator->thread_id,
-			       VIO_TYPE_SLAB_JOURNAL,
-			       VIO_PRIORITY_METADATA,
-			       allocator,
-			       &allocator->vio_pool);
+	result = make_vio_pool(vdo, BLOCK_ALLOCATOR_VIO_POOL_SIZE, allocator->thread_id,
+			       VIO_TYPE_SLAB_JOURNAL, VIO_PRIORITY_METADATA,
+			       allocator, &allocator->vio_pool);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -4141,13 +4016,13 @@ static int __must_check initialize_block_allocator(struct slab_depot *depot, zon
 		return result;
 
 	result = uds_allocate(VDO_SLAB_SUMMARY_BLOCKS_PER_ZONE,
-			      struct slab_summary_block,
-			      __func__,
+			      struct slab_summary_block, __func__,
 			      &allocator->summary_blocks);
 	if (result != VDO_SUCCESS)
 		return result;
 
-	vdo_set_admin_state_code(&allocator->summary_state, VDO_ADMIN_STATE_NORMAL_OPERATION);
+	vdo_set_admin_state_code(&allocator->summary_state,
+				 VDO_ADMIN_STATE_NORMAL_OPERATION);
 	allocator->summary_entries = depot->summary_entries + (MAX_VDO_SLABS * zone);
 
 	/* Initialize each summary block. */
@@ -4186,13 +4061,10 @@ static int allocate_components(struct slab_depot *depot,
 	u32 i;
 	const struct thread_config *thread_config = &depot->vdo->thread_config;
 
-	result = vdo_make_action_manager(depot->zone_count,
-					 get_allocator_thread_id,
-					 thread_config->journal_thread,
-					 depot,
+	result = vdo_make_action_manager(depot->zone_count, get_allocator_thread_id,
+					 thread_config->journal_thread, depot,
 					 schedule_tail_block_commit,
-					 depot->vdo,
-					 &depot->action_manager);
+					 depot->vdo, &depot->action_manager);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -4204,8 +4076,7 @@ static int allocate_components(struct slab_depot *depot,
 	depot->summary_origin = summary_partition->offset;
 	depot->hint_shift = vdo_get_slab_summary_hint_shift(depot->slab_size_shift);
 	result = uds_allocate(MAXIMUM_VDO_SLAB_SUMMARY_ENTRIES,
-			      struct slab_summary_entry,
-			      __func__,
+			      struct slab_summary_entry, __func__,
 			      &depot->summary_entries);
 	if (result != VDO_SUCCESS)
 		return result;
@@ -4229,8 +4100,7 @@ static int allocate_components(struct slab_depot *depot,
 	if (result != VDO_SUCCESS)
 		return result;
 
-	slab_count = vdo_compute_slab_count(depot->first_block,
-					    depot->last_block,
+	slab_count = vdo_compute_slab_count(depot->first_block, depot->last_block,
 					    depot->slab_size_shift);
 	if (thread_config->physical_zone_count > slab_count) {
 		return uds_log_error_strerror(VDO_BAD_CONFIGURATION,
@@ -4276,8 +4146,7 @@ static int allocate_components(struct slab_depot *depot,
  *
  * Return: A success or error code.
  */
-int vdo_decode_slab_depot(struct slab_depot_state_2_0 state,
-			  struct vdo *vdo,
+int vdo_decode_slab_depot(struct slab_depot_state_2_0 state, struct vdo *vdo,
 			  struct partition *summary_partition,
 			  struct slab_depot **depot_ptr)
 {
@@ -4299,9 +4168,7 @@ int vdo_decode_slab_depot(struct slab_depot_state_2_0 state,
 
 	result = uds_allocate_extended(struct slab_depot,
 				       vdo->thread_config.physical_zone_count,
-				       struct block_allocator,
-				       __func__,
-				       &depot);
+				       struct block_allocator, __func__, &depot);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -4462,7 +4329,8 @@ static int __must_check get_slab_number(const struct slab_depot *depot,
  * Return: The slab containing the block, or NULL if the block number is the zero block or
  * otherwise out of range.
  */
-struct vdo_slab *vdo_get_slab(const struct slab_depot *depot, physical_block_number_t pbn)
+struct vdo_slab *vdo_get_slab(const struct slab_depot *depot,
+			      physical_block_number_t pbn)
 {
 	slab_count_t slab_number;
 	int result;
@@ -4514,7 +4382,8 @@ u8 vdo_get_increment_limit(struct slab_depot *depot, physical_block_number_t pbn
  *
  * Return: True if the PBN corresponds to a data block.
  */
-bool vdo_is_physical_data_block(const struct slab_depot *depot, physical_block_number_t pbn)
+bool vdo_is_physical_data_block(const struct slab_depot *depot,
+				physical_block_number_t pbn)
 {
 	slab_count_t slab_number;
 	slab_block_number sbn;
@@ -4587,7 +4456,8 @@ static void write_summary_endio(struct bio *bio)
 	struct vio *vio = bio->bi_private;
 	struct vdo *vdo = vio->completion.vdo;
 
-	continue_vio_after_io(vio, finish_combining_zones, vdo->thread_config.admin_thread);
+	continue_vio_after_io(vio, finish_combining_zones,
+			      vdo->thread_config.admin_thread);
 }
 
 /**
@@ -4622,8 +4492,7 @@ static void combine_summaries(struct slab_depot *depot)
 
 	/* Copy the combined data to each zones's region of the buffer. */
 	for (zone = 1; zone < MAX_VDO_PHYSICAL_ZONES; zone++) {
-		memcpy(entries + (zone * MAX_VDO_SLABS),
-		       entries,
+		memcpy(entries + (zone * MAX_VDO_SLABS), entries,
 		       MAX_VDO_SLABS * sizeof(struct slab_summary_entry));
 	}
 }
@@ -4644,10 +4513,8 @@ static void finish_loading_summary(struct vdo_completion *completion)
 	combine_summaries(depot);
 
 	/* Write the combined summary back out. */
-	submit_metadata_vio(as_vio(completion),
-			    depot->summary_origin,
-			    write_summary_endio,
-			    handle_combining_error,
+	submit_metadata_vio(as_vio(completion), depot->summary_origin,
+			    write_summary_endio, handle_combining_error,
 			    REQ_OP_WRITE);
 }
 
@@ -4656,7 +4523,8 @@ static void load_summary_endio(struct bio *bio)
 	struct vio *vio = bio->bi_private;
 	struct vdo *vdo = vio->completion.vdo;
 
-	continue_vio_after_io(vio, finish_loading_summary, vdo->thread_config.admin_thread);
+	continue_vio_after_io(vio, finish_loading_summary,
+			      vdo->thread_config.admin_thread);
 }
 
 /**
@@ -4672,13 +4540,10 @@ static void load_slab_summary(void *context, struct vdo_completion *parent)
 	const struct admin_state_code *operation =
 		vdo_get_current_manager_operation(depot->action_manager);
 
-	result = create_multi_block_metadata_vio(depot->vdo,
-						 VIO_TYPE_SLAB_SUMMARY,
-						 VIO_PRIORITY_METADATA,
-						 parent,
+	result = create_multi_block_metadata_vio(depot->vdo, VIO_TYPE_SLAB_SUMMARY,
+						 VIO_PRIORITY_METADATA, parent,
 						 VDO_SLAB_SUMMARY_BLOCKS,
-						 (char *) depot->summary_entries,
-						 &vio);
+						 (char *) depot->summary_entries, &vio);
 	if (result != VDO_SUCCESS) {
 		vdo_fail_completion(parent, result);
 		return;
@@ -4690,22 +4555,19 @@ static void load_slab_summary(void *context, struct vdo_completion *parent)
 		return;
 	}
 
-	submit_metadata_vio(vio,
-			    depot->summary_origin,
-			    load_summary_endio,
-			    handle_combining_error,
-			    REQ_OP_READ);
+	submit_metadata_vio(vio, depot->summary_origin, load_summary_endio,
+			    handle_combining_error, REQ_OP_READ);
 }
 
 /* Implements vdo_zone_action. */
-static void load_allocator(void *context, zone_count_t zone_number, struct vdo_completion *parent)
+static void load_allocator(void *context, zone_count_t zone_number,
+			   struct vdo_completion *parent)
 {
 	struct slab_depot *depot = context;
 
 	vdo_start_loading(&depot->allocators[zone_number].state,
 			  vdo_get_current_manager_operation(depot->action_manager),
-			  parent,
-			  initiate_load);
+			  parent, initiate_load);
 }
 
 /**
@@ -4720,8 +4582,7 @@ static void load_allocator(void *context, zone_count_t zone_number, struct vdo_c
  */
 void vdo_load_slab_depot(struct slab_depot *depot,
 			 const struct admin_state_code *operation,
-			 struct vdo_completion *parent,
-			 void *context)
+			 struct vdo_completion *parent, void *context)
 {
 	if (!vdo_assert_load_operation(operation, parent))
 		return;
@@ -4732,8 +4593,7 @@ void vdo_load_slab_depot(struct slab_depot *depot,
 }
 
 /* Implements vdo_zone_action. */
-static void prepare_to_allocate(void *context,
-				zone_count_t zone_number,
+static void prepare_to_allocate(void *context, zone_count_t zone_number,
 				struct vdo_completion *parent)
 {
 	struct slab_depot *depot = context;
@@ -4765,7 +4625,8 @@ void vdo_prepare_slab_depot_to_allocate(struct slab_depot *depot,
 {
 	depot->load_type = load_type;
 	atomic_set(&depot->zones_to_scrub, depot->zone_count);
-	vdo_schedule_action(depot->action_manager, NULL, prepare_to_allocate, NULL, parent);
+	vdo_schedule_action(depot->action_manager, NULL,
+			    prepare_to_allocate, NULL, parent);
 }
 
 /**
@@ -4787,7 +4648,8 @@ void vdo_update_slab_depot_size(struct slab_depot *depot)
  *
  * Return: VDO_SUCCESS or an error.
  */
-int vdo_prepare_to_grow_slab_depot(struct slab_depot *depot, const struct partition *partition)
+int vdo_prepare_to_grow_slab_depot(struct slab_depot *depot,
+				   const struct partition *partition)
 {
 	struct slab_depot_state_2_0 new_state;
 	int result;
@@ -4799,10 +4661,8 @@ int vdo_prepare_to_grow_slab_depot(struct slab_depot *depot, const struct partit
 	/* Generate the depot configuration for the new block count. */
 	ASSERT_LOG_ONLY(depot->first_block == partition->offset,
 			"New slab depot partition doesn't change origin");
-	result = vdo_configure_slab_depot(partition,
-					  depot->slab_config,
-					  depot->zone_count,
-					  &new_state);
+	result = vdo_configure_slab_depot(partition, depot->slab_config,
+					  depot->zone_count, &new_state);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -4810,7 +4670,8 @@ int vdo_prepare_to_grow_slab_depot(struct slab_depot *depot, const struct partit
 						new_state.last_block,
 						depot->slab_size_shift);
 	if (new_slab_count <= depot->slab_count)
-		return uds_log_error_strerror(VDO_INCREMENT_TOO_SMALL, "Depot can only grow");
+		return uds_log_error_strerror(VDO_INCREMENT_TOO_SMALL,
+					      "Depot can only grow");
 	if (new_slab_count == depot->new_slab_count) {
 		/* Check it out, we've already got all the new slabs allocated! */
 		return VDO_SUCCESS;
@@ -4849,8 +4710,7 @@ static int finish_registration(void *context)
 }
 
 /* Implements vdo_zone_action. */
-static void register_new_slabs(void *context,
-			       zone_count_t zone_number,
+static void register_new_slabs(void *context, zone_count_t zone_number,
 			       struct vdo_completion *parent)
 {
 	struct slab_depot *depot = context;
@@ -4877,10 +4737,8 @@ void vdo_use_new_slabs(struct slab_depot *depot, struct vdo_completion *parent)
 	ASSERT_LOG_ONLY(depot->new_slabs != NULL, "Must have new slabs to use");
 	vdo_schedule_operation(depot->action_manager,
 			       VDO_ADMIN_STATE_SUSPENDED_OPERATION,
-			       NULL,
-			       register_new_slabs,
-			       finish_registration,
-			       parent);
+			       NULL, register_new_slabs,
+			       finish_registration, parent);
 }
 
 /**
@@ -4898,25 +4756,23 @@ static void stop_scrubbing(struct block_allocator *allocator)
 	} else {
 		vdo_start_draining(&scrubber->admin_state,
 				   VDO_ADMIN_STATE_SUSPENDING,
-				   &allocator->completion,
-				   NULL);
+				   &allocator->completion, NULL);
 	}
 }
 
 /* Implements vdo_admin_initiator. */
 static void initiate_summary_drain(struct admin_state *state)
 {
-	check_summary_drain_complete(container_of(state, struct block_allocator, summary_state));
+	check_summary_drain_complete(container_of(state, struct block_allocator,
+						  summary_state));
 }
 
 static void do_drain_step(struct vdo_completion *completion)
 {
 	struct block_allocator *allocator = vdo_as_block_allocator(completion);
 
-	vdo_prepare_completion_for_requeue(&allocator->completion,
-					   do_drain_step,
-					   handle_operation_error,
-					   allocator->thread_id,
+	vdo_prepare_completion_for_requeue(&allocator->completion, do_drain_step,
+					   handle_operation_error, allocator->thread_id,
 					   NULL);
 	switch (++allocator->drain_step) {
 	case VDO_DRAIN_ALLOCATOR_STEP_SCRUBBER:
@@ -4930,12 +4786,12 @@ static void do_drain_step(struct vdo_completion *completion)
 	case VDO_DRAIN_ALLOCATOR_STEP_SUMMARY:
 		vdo_start_draining(&allocator->summary_state,
 				   vdo_get_admin_state_code(&allocator->state),
-				   completion,
-				   initiate_summary_drain);
+				   completion, initiate_summary_drain);
 		return;
 
 	case VDO_DRAIN_ALLOCATOR_STEP_FINISHED:
-		ASSERT_LOG_ONLY(!is_vio_pool_busy(allocator->vio_pool), "vio pool not busy");
+		ASSERT_LOG_ONLY(!is_vio_pool_busy(allocator->vio_pool),
+				"vio pool not busy");
 		vdo_finish_draining_with_result(&allocator->state, completion->result);
 		return;
 
@@ -4960,14 +4816,14 @@ static void initiate_drain(struct admin_state *state)
  *
  * Implements vdo_zone_action.
  */
-static void drain_allocator(void *context, zone_count_t zone_number, struct vdo_completion *parent)
+static void drain_allocator(void *context, zone_count_t zone_number,
+			    struct vdo_completion *parent)
 {
 	struct slab_depot *depot = context;
 
 	vdo_start_draining(&depot->allocators[zone_number].state,
 			   vdo_get_current_manager_operation(depot->action_manager),
-			   parent,
-			   initiate_drain);
+			   parent, initiate_drain);
 }
 
 /**
@@ -4983,12 +4839,8 @@ void vdo_drain_slab_depot(struct slab_depot *depot,
 			  const struct admin_state_code *operation,
 			  struct vdo_completion *parent)
 {
-	vdo_schedule_operation(depot->action_manager,
-			       operation,
-			       NULL,
-			       drain_allocator,
-			       NULL,
-			       parent);
+	vdo_schedule_operation(depot->action_manager, operation,
+			       NULL, drain_allocator, NULL, parent);
 }
 
 /**
@@ -5019,11 +4871,9 @@ static void do_resume_step(struct vdo_completion *completion)
 {
 	struct block_allocator *allocator = vdo_as_block_allocator(completion);
 
-	vdo_prepare_completion_for_requeue(&allocator->completion,
-					   do_resume_step,
+	vdo_prepare_completion_for_requeue(&allocator->completion, do_resume_step,
 					   handle_operation_error,
-					   allocator->thread_id,
-					   NULL);
+					   allocator->thread_id, NULL);
 	switch (--allocator->drain_step) {
 	case VDO_DRAIN_ALLOCATOR_STEP_SUMMARY:
 		vdo_fail_completion(completion,
@@ -5058,16 +4908,14 @@ static void initiate_resume(struct admin_state *state)
 }
 
 /* Implements vdo_zone_action. */
-static void resume_allocator(void *context,
-			     zone_count_t zone_number,
+static void resume_allocator(void *context, zone_count_t zone_number,
 			     struct vdo_completion *parent)
 {
 	struct slab_depot *depot = context;
 
 	vdo_start_resuming(&depot->allocators[zone_number].state,
 			   vdo_get_current_manager_operation(depot->action_manager),
-			   parent,
-			   initiate_resume);
+			   parent, initiate_resume);
 }
 
 /**
@@ -5082,12 +4930,8 @@ void vdo_resume_slab_depot(struct slab_depot *depot, struct vdo_completion *pare
 		return;
 	}
 
-	vdo_schedule_operation(depot->action_manager,
-			       VDO_ADMIN_STATE_RESUMING,
-			       NULL,
-			       resume_allocator,
-			       NULL,
-			       parent);
+	vdo_schedule_operation(depot->action_manager, VDO_ADMIN_STATE_RESUMING,
+			       NULL, resume_allocator, NULL, parent);
 }
 
 /**
@@ -5110,8 +4954,7 @@ void vdo_commit_oldest_slab_journal_tail_blocks(struct slab_depot *depot,
 }
 
 /* Implements vdo_zone_action. */
-static void scrub_all_unrecovered_slabs(void *context,
-					zone_count_t zone_number,
+static void scrub_all_unrecovered_slabs(void *context, zone_count_t zone_number,
 					struct vdo_completion *parent)
 {
 	struct slab_depot *depot = context;
@@ -5125,13 +4968,12 @@ static void scrub_all_unrecovered_slabs(void *context,
  * @depot: The depot to scrub.
  * @parent: The object to notify when scrubbing has been launched for all zones.
  */
-void vdo_scrub_all_unrecovered_slabs(struct slab_depot *depot, struct vdo_completion *parent)
+void vdo_scrub_all_unrecovered_slabs(struct slab_depot *depot,
+				     struct vdo_completion *parent)
 {
-	vdo_schedule_action(depot->action_manager,
-			    NULL,
+	vdo_schedule_action(depot->action_manager, NULL,
 			    scrub_all_unrecovered_slabs,
-			    NULL,
-			    parent);
+			    NULL, parent);
 }
 
 /**
@@ -5217,7 +5059,8 @@ get_slab_journal_statistics(const struct slab_depot *depot)
  * @depot: The slab depot.
  * @stats: The vdo statistics structure to partially fill.
  */
-void vdo_get_slab_depot_statistics(const struct slab_depot *depot, struct vdo_statistics *stats)
+void vdo_get_slab_depot_statistics(const struct slab_depot *depot,
+				   struct vdo_statistics *stats)
 {
 	slab_count_t slab_count = READ_ONCE(depot->slab_count);
 	slab_count_t unrecovered = 0;
@@ -5246,8 +5089,7 @@ void vdo_dump_slab_depot(const struct slab_depot *depot)
 	uds_log_info("vdo slab depot");
 	uds_log_info("  zone_count=%u old_zone_count=%u slabCount=%u active_release_request=%llu new_release_request=%llu",
 		     (unsigned int) depot->zone_count,
-		     (unsigned int) depot->old_zone_count,
-		     READ_ONCE(depot->slab_count),
+		     (unsigned int) depot->old_zone_count, READ_ONCE(depot->slab_count),
 		     (unsigned long long) depot->active_release_request,
 		     (unsigned long long) depot->new_release_request);
 }

--- a/drivers/md/dm-vdo/slab-depot.c
+++ b/drivers/md/dm-vdo/slab-depot.c
@@ -566,7 +566,7 @@ static void release_journal_locks(struct waiter *waiter, void *context)
 	sequence_number_t first, i;
 	struct slab_journal *journal =
 		container_of(waiter, struct slab_journal, slab_summary_waiter);
-	int result = *((int *)context);
+	int result = *((int *) context);
 
 	if (result != VDO_SUCCESS) {
 		if (result != VDO_READ_ONLY) {
@@ -3385,8 +3385,8 @@ int vdo_release_block_reference(struct block_allocator *allocator, physical_bloc
  */
 static bool slab_status_is_less_than(const void *item1, const void *item2)
 {
-	const struct slab_status *info1 = (const struct slab_status *) item1;
-	const struct slab_status *info2 = (const struct slab_status *) item2;
+	const struct slab_status *info1 = item1;
+	const struct slab_status *info2 = item2;
 
 	if (info1->is_clean != info2->is_clean)
 		return info1->is_clean;

--- a/drivers/md/dm-vdo/slab-depot.h
+++ b/drivers/md/dm-vdo/slab-depot.h
@@ -294,7 +294,7 @@ struct slab_actor {
 	/* The number of slabs performing a slab action */
 	slab_count_t slab_action_count;
 	/* The method to call when a slab action has been completed by all slabs */
-	vdo_action *callback;
+	vdo_action_fn callback;
 };
 
 /* A slab_iterator is a structure for iterating over a set of slabs. */

--- a/drivers/md/dm-vdo/slab-depot.h
+++ b/drivers/md/dm-vdo/slab-depot.h
@@ -497,18 +497,16 @@ struct slab_depot {
 
 struct reference_updater;
 
-bool __must_check
-vdo_attempt_replay_into_slab(struct vdo_slab *slab,
-			     physical_block_number_t pbn,
-			     enum journal_operation operation,
-			     bool increment,
-			     struct journal_point *recovery_point,
-			     struct vdo_completion *parent);
+bool __must_check vdo_attempt_replay_into_slab(struct vdo_slab *slab,
+					       physical_block_number_t pbn,
+					       enum journal_operation operation,
+					       bool increment,
+					       struct journal_point *recovery_point,
+					       struct vdo_completion *parent);
 
-int __must_check
-vdo_adjust_reference_count_for_rebuild(struct slab_depot *depot,
-				       physical_block_number_t pbn,
-				       enum journal_operation operation);
+int __must_check vdo_adjust_reference_count_for_rebuild(struct slab_depot *depot,
+							physical_block_number_t pbn,
+							enum journal_operation operation);
 
 static inline struct block_allocator *vdo_as_block_allocator(struct vdo_completion *completion)
 {
@@ -520,10 +518,11 @@ int __must_check vdo_acquire_provisional_reference(struct vdo_slab *slab,
 						   physical_block_number_t pbn,
 						   struct pbn_lock *lock);
 
-int __must_check
-vdo_allocate_block(struct block_allocator *allocator, physical_block_number_t *block_number_ptr);
+int __must_check vdo_allocate_block(struct block_allocator *allocator,
+				    physical_block_number_t *block_number_ptr);
 
-int vdo_enqueue_clean_slab_waiter(struct block_allocator *allocator, struct waiter *waiter);
+int vdo_enqueue_clean_slab_waiter(struct block_allocator *allocator,
+				  struct waiter *waiter);
 
 void vdo_modify_reference_count(struct vdo_completion *completion,
 				struct reference_updater *updater);
@@ -546,24 +545,25 @@ struct slab_depot_state_2_0 __must_check vdo_record_slab_depot(const struct slab
 
 int __must_check vdo_allocate_reference_counters(struct slab_depot *depot);
 
-struct vdo_slab * __must_check
-vdo_get_slab(const struct slab_depot *depot, physical_block_number_t pbn);
+struct vdo_slab * __must_check vdo_get_slab(const struct slab_depot *depot,
+					    physical_block_number_t pbn);
 
-u8 __must_check vdo_get_increment_limit(struct slab_depot *depot, physical_block_number_t pbn);
+u8 __must_check vdo_get_increment_limit(struct slab_depot *depot,
+					physical_block_number_t pbn);
 
-bool __must_check
-vdo_is_physical_data_block(const struct slab_depot *depot, physical_block_number_t pbn);
+bool __must_check vdo_is_physical_data_block(const struct slab_depot *depot,
+					     physical_block_number_t pbn);
 
 block_count_t __must_check vdo_get_slab_depot_allocated_blocks(const struct slab_depot *depot);
 
 block_count_t __must_check vdo_get_slab_depot_data_blocks(const struct slab_depot *depot);
 
-void vdo_get_slab_depot_statistics(const struct slab_depot *depot, struct vdo_statistics *stats);
+void vdo_get_slab_depot_statistics(const struct slab_depot *depot,
+				   struct vdo_statistics *stats);
 
 void vdo_load_slab_depot(struct slab_depot *depot,
 			 const struct admin_state_code *operation,
-			 struct vdo_completion *parent,
-			 void *context);
+			 struct vdo_completion *parent, void *context);
 
 void vdo_prepare_slab_depot_to_allocate(struct slab_depot *depot,
 					enum slab_depot_load_type load_type,
@@ -571,8 +571,8 @@ void vdo_prepare_slab_depot_to_allocate(struct slab_depot *depot,
 
 void vdo_update_slab_depot_size(struct slab_depot *depot);
 
-int __must_check
-vdo_prepare_to_grow_slab_depot(struct slab_depot *depot, const struct partition *partition);
+int __must_check vdo_prepare_to_grow_slab_depot(struct slab_depot *depot,
+						const struct partition *partition);
 
 void vdo_use_new_slabs(struct slab_depot *depot, struct vdo_completion *parent);
 
@@ -587,7 +587,8 @@ void vdo_resume_slab_depot(struct slab_depot *depot, struct vdo_completion *pare
 void vdo_commit_oldest_slab_journal_tail_blocks(struct slab_depot *depot,
 						sequence_number_t recovery_block_number);
 
-void vdo_scrub_all_unrecovered_slabs(struct slab_depot *depot, struct vdo_completion *parent);
+void vdo_scrub_all_unrecovered_slabs(struct slab_depot *depot,
+				     struct vdo_completion *parent);
 
 void vdo_dump_slab_depot(const struct slab_depot *depot);
 

--- a/drivers/md/dm-vdo/sparse-cache.c
+++ b/drivers/md/dm-vdo/sparse-cache.c
@@ -296,9 +296,10 @@ static void release_cached_chapter_index(struct cached_chapter_index *chapter)
 	if (chapter->page_buffers == NULL)
 		return;
 
-	for (i = 0; i < chapter->index_pages_count; i++)
+	for (i = 0; i < chapter->index_pages_count; i++) {
 		if (chapter->page_buffers[i] != NULL)
 			dm_bufio_release(uds_forget(chapter->page_buffers[i]));
+	}
 }
 
 void uds_free_sparse_cache(struct sparse_cache *cache)
@@ -531,9 +532,12 @@ search_cached_chapter_index(struct cached_chapter_index *chapter,
 			    const struct uds_record_name *name,
 			    u16 *record_page_ptr)
 {
-	u32 physical_chapter = uds_map_to_physical_chapter(geometry, chapter->virtual_chapter);
-	u32 index_page_number = uds_find_index_page_number(index_page_map, name, physical_chapter);
-	struct delta_index_page *index_page = &chapter->index_pages[index_page_number];
+	u32 physical_chapter =
+		uds_map_to_physical_chapter(geometry, chapter->virtual_chapter);
+	u32 index_page_number =
+		uds_find_index_page_number(index_page_map, name, physical_chapter);
+	struct delta_index_page *index_page =
+		&chapter->index_pages[index_page_number];
 
 	return uds_search_chapter_index_page(index_page, geometry, name, record_page_ptr);
 }

--- a/drivers/md/dm-vdo/sparse-cache.h
+++ b/drivers/md/dm-vdo/sparse-cache.h
@@ -27,14 +27,12 @@ struct index_zone;
 struct sparse_cache;
 
 int __must_check uds_make_sparse_cache(const struct geometry *geometry,
-				       unsigned int capacity,
-				       unsigned int zone_count,
+				       unsigned int capacity, unsigned int zone_count,
 				       struct sparse_cache **cache_ptr);
 
 void uds_free_sparse_cache(struct sparse_cache *cache);
 
-bool uds_sparse_cache_contains(struct sparse_cache *cache,
-			       u64 virtual_chapter,
+bool uds_sparse_cache_contains(struct sparse_cache *cache, u64 virtual_chapter,
 			       unsigned int zone_number);
 
 int __must_check uds_update_sparse_cache(struct index_zone *zone, u64 virtual_chapter);
@@ -43,7 +41,6 @@ void uds_invalidate_sparse_cache(struct sparse_cache *cache);
 
 int __must_check uds_search_sparse_cache(struct index_zone *zone,
 					 const struct uds_record_name *name,
-					 u64 *virtual_chapter_ptr,
-					 u16 *record_page_ptr);
+					 u64 *virtual_chapter_ptr, u16 *record_page_ptr);
 
 #endif /* UDS_SPARSE_CACHE_H */

--- a/drivers/md/dm-vdo/status-codes.c
+++ b/drivers/md/dm-vdo/status-codes.c
@@ -61,10 +61,8 @@ static void do_status_code_registration(void)
 	BUILD_BUG_ON((VDO_STATUS_CODE_LAST - VDO_STATUS_CODE_BASE) !=
 		     ARRAY_SIZE(vdo_status_list));
 
-	result = uds_register_error_block("VDO Status",
-					  VDO_STATUS_CODE_BASE,
-					  VDO_STATUS_CODE_BLOCK_END,
-					  vdo_status_list,
+	result = uds_register_error_block("VDO Status", VDO_STATUS_CODE_BASE,
+					  VDO_STATUS_CODE_BLOCK_END, vdo_status_list,
 					  sizeof(vdo_status_list));
 	/*
 	 * The following test handles cases where libvdo is statically linked against both the test
@@ -117,8 +115,7 @@ int vdo_map_to_system_error(int error)
 		return -EIO;
 	default:
 		uds_log_info("%s: mapping internal status code %d (%s: %s) to EIO",
-			     __func__,
-			     error,
+			     __func__, error,
 			     uds_string_error_name(error, error_name, sizeof(error_name)),
 			     uds_string_error(error, error_message, sizeof(error_message)));
 		return -EIO;

--- a/drivers/md/dm-vdo/sysfs.c
+++ b/drivers/md/dm-vdo/sysfs.c
@@ -34,7 +34,8 @@ static int vdo_log_level_store(const char *buf, const struct kernel_param *kp)
 }
 
 
-static int vdo_dedupe_timeout_interval_store(const char *buf, const struct kernel_param *kp)
+static int vdo_dedupe_timeout_interval_store(const char *buf,
+					     const struct kernel_param *kp)
 {
 	int result = param_set_uint(buf, kp);
 
@@ -44,7 +45,8 @@ static int vdo_dedupe_timeout_interval_store(const char *buf, const struct kerne
 	return 0;
 }
 
-static int vdo_min_dedupe_timer_interval_store(const char *buf, const struct kernel_param *kp)
+static int vdo_min_dedupe_timer_interval_store(const char *buf,
+					       const struct kernel_param *kp)
 {
 	int result = param_set_uint(buf, kp);
 
@@ -73,12 +75,8 @@ static const struct kernel_param_ops dedupe_timer_ops = {
 module_param_cb(log_level, &log_level_ops, NULL, 0644);
 
 
-module_param_cb(deduplication_timeout_interval,
-		&dedupe_timeout_ops,
-		&vdo_dedupe_index_timeout_interval,
-		0644);
+module_param_cb(deduplication_timeout_interval, &dedupe_timeout_ops,
+		&vdo_dedupe_index_timeout_interval, 0644);
 
-module_param_cb(min_deduplication_timer_interval,
-		&dedupe_timer_ops,
-		&vdo_dedupe_index_min_timer_interval,
-		0644);
+module_param_cb(min_deduplication_timer_interval, &dedupe_timer_ops,
+		&vdo_dedupe_index_min_timer_interval, 0644);

--- a/drivers/md/dm-vdo/thread-device.c
+++ b/drivers/md/dm-vdo/thread-device.c
@@ -11,7 +11,8 @@
 static struct thread_registry device_id_thread_registry;
 
 /* Any registered thread must be unregistered. */
-void uds_register_thread_device_id(struct registered_thread *new_thread, unsigned int *id_ptr)
+void uds_register_thread_device_id(struct registered_thread *new_thread,
+				   unsigned int *id_ptr)
 {
 	uds_register_thread(&device_id_thread_registry, new_thread, id_ptr);
 }

--- a/drivers/md/dm-vdo/thread-device.h
+++ b/drivers/md/dm-vdo/thread-device.h
@@ -8,7 +8,8 @@
 
 #include "thread-registry.h"
 
-void uds_register_thread_device_id(struct registered_thread *new_thread, unsigned int *id_ptr);
+void uds_register_thread_device_id(struct registered_thread *new_thread,
+				   unsigned int *id_ptr);
 
 void uds_unregister_thread_device_id(void);
 

--- a/drivers/md/dm-vdo/thread-registry.c
+++ b/drivers/md/dm-vdo/thread-registry.c
@@ -22,8 +22,7 @@ void uds_initialize_thread_registry(struct thread_registry *registry)
 
 /* Register the current thread and associate it with a data pointer. */
 void uds_register_thread(struct thread_registry *registry,
-			 struct registered_thread *new_thread,
-			 const void *pointer)
+			 struct registered_thread *new_thread, const void *pointer)
 {
 	struct registered_thread *thread;
 	bool found_it = false;

--- a/drivers/md/dm-vdo/thread-registry.h
+++ b/drivers/md/dm-vdo/thread-registry.h
@@ -23,8 +23,7 @@ struct registered_thread {
 void uds_initialize_thread_registry(struct thread_registry *registry);
 
 void uds_register_thread(struct thread_registry *registry,
-			 struct registered_thread *new_thread,
-			 const void *pointer);
+			 struct registered_thread *new_thread, const void *pointer);
 
 void uds_unregister_thread(struct thread_registry *registry);
 

--- a/drivers/md/dm-vdo/types.h
+++ b/drivers/md/dm-vdo/types.h
@@ -253,10 +253,10 @@ enum vdo_completion_type {
 struct vdo_completion;
 
 /**
- * typedef vdo_action - An asynchronous VDO operation.
+ * typedef vdo_action_fn - An asynchronous VDO operation.
  * @completion: The completion of the operation.
  */
-typedef void vdo_action(struct vdo_completion *completion);
+typedef void (*vdo_action_fn)(struct vdo_completion *completion);
 
 enum vdo_completion_priority {
 	BIO_ACK_Q_ACK_PRIORITY = 0,
@@ -314,10 +314,10 @@ struct vdo_completion {
 	struct vdo *vdo;
 
 	/* The callback which will be called once the operation is complete */
-	vdo_action *callback;
+	vdo_action_fn callback;
 
 	/* Callback which, if set, will be called if an error result is set */
-	vdo_action *error_handler;
+	vdo_action_fn error_handler;
 
 	/* The parent object, if any, that spawned this completion */
 	void *parent;

--- a/drivers/md/dm-vdo/uds-sysfs.c
+++ b/drivers/md/dm-vdo/uds-sysfs.c
@@ -59,8 +59,8 @@ static ssize_t empty_show(struct kobject *kobj, struct attribute *attr, char *bu
 	return 0;
 }
 
-static ssize_t
-empty_store(struct kobject *kobj, struct attribute *attr, const char *buf, size_t length)
+static ssize_t empty_store(struct kobject *kobj, struct attribute *attr, const char *buf,
+			   size_t length)
 {
 	return length;
 }
@@ -103,8 +103,8 @@ static ssize_t parameter_show(struct kobject *kobj, struct attribute *attr, char
 		return -EINVAL;
 }
 
-static ssize_t
-parameter_store(struct kobject *kobj, struct attribute *attr, const char *buf, size_t length)
+static ssize_t parameter_store(struct kobject *kobj, struct attribute *attr,
+			       const char *buf, size_t length)
 {
 	char *string;
 	struct parameter_attribute *pa;
@@ -164,7 +164,8 @@ int uds_init_sysfs(void)
 	if (result == 0) {
 		object_root.flag = true;
 		kobject_init(&object_root.parameter_kobj, &parameter_object_type);
-		result = kobject_add(&object_root.parameter_kobj, &object_root.kobj, "parameter");
+		result = kobject_add(&object_root.parameter_kobj, &object_root.kobj,
+				     "parameter");
 		if (result == 0)
 			object_root.parameter_flag = true;
 	}

--- a/drivers/md/dm-vdo/uds-threads.c
+++ b/drivers/md/dm-vdo/uds-threads.c
@@ -108,15 +108,16 @@ int uds_create_thread(void (*thread_function)(void *),
 	 *
 	 * Otherwise just use the name supplied. This should be a rare occurrence.
 	 */
-	if ((name_colon == NULL) && (my_name_colon != NULL))
+	if ((name_colon == NULL) && (my_name_colon != NULL)) {
 		task = kthread_run(thread_starter,
 				   thread,
 				   "%.*s:%s",
 				   (int) (my_name_colon - current->comm),
 				   current->comm,
 				   name);
-	else
+	} else {
 		task = kthread_run(thread_starter, thread, "%s", name);
+	}
 
 	if (IS_ERR(task)) {
 		uds_free(thread);
@@ -160,6 +161,7 @@ int uds_destroy_barrier(struct barrier *barrier)
 	result = uds_destroy_semaphore(&barrier->mutex);
 	if (result != UDS_SUCCESS)
 		return result;
+
 	return uds_destroy_semaphore(&barrier->wait);
 }
 

--- a/drivers/md/dm-vdo/uds-threads.c
+++ b/drivers/md/dm-vdo/uds-threads.c
@@ -74,10 +74,8 @@ static int thread_starter(void *arg)
 	return 0;
 }
 
-int uds_create_thread(void (*thread_function)(void *),
-		      void *thread_data,
-		      const char *name,
-		      struct thread **new_thread)
+int uds_create_thread(void (*thread_function)(void *), void *thread_data,
+		      const char *name, struct thread **new_thread)
 {
 	char *name_colon = strchr(name, ':');
 	char *my_name_colon = strchr(current->comm, ':');
@@ -109,11 +107,8 @@ int uds_create_thread(void (*thread_function)(void *),
 	 * Otherwise just use the name supplied. This should be a rare occurrence.
 	 */
 	if ((name_colon == NULL) && (my_name_colon != NULL)) {
-		task = kthread_run(thread_starter,
-				   thread,
-				   "%.*s:%s",
-				   (int) (my_name_colon - current->comm),
-				   current->comm,
+		task = kthread_run(thread_starter, thread, "%.*s:%s",
+				   (int) (my_name_colon - current->comm), current->comm,
 				   name);
 	} else {
 		task = kthread_run(thread_starter, thread, "%s", name);

--- a/drivers/md/dm-vdo/uds-threads.h
+++ b/drivers/md/dm-vdo/uds-threads.h
@@ -35,16 +35,15 @@ struct barrier {
 	int thread_count;
 };
 
-int __must_check uds_create_thread(void (*thread_function)(void *),
-				   void *thread_data,
-				   const char *name,
-				   struct thread **new_thread);
+int __must_check uds_create_thread(void (*thread_function)(void *), void *thread_data,
+				   const char *name, struct thread **new_thread);
 
 void uds_perform_once(atomic_t *once_state, void (*function) (void));
 
 int uds_join_threads(struct thread *thread);
 
-int __must_check uds_initialize_barrier(struct barrier *barrier, unsigned int thread_count);
+int __must_check uds_initialize_barrier(struct barrier *barrier,
+					unsigned int thread_count);
 int uds_destroy_barrier(struct barrier *barrier);
 int uds_enter_barrier(struct barrier *barrier);
 
@@ -75,8 +74,8 @@ static inline void uds_unlock_mutex(struct mutex *mutex)
 	mutex_unlock(mutex);
 }
 
-static inline int __must_check
-uds_initialize_semaphore(struct semaphore *semaphore, unsigned int value)
+static inline int __must_check uds_initialize_semaphore(struct semaphore *semaphore,
+							unsigned int value)
 {
 	sema_init(semaphore, value);
 	return UDS_SUCCESS;

--- a/drivers/md/dm-vdo/uds-threads.h
+++ b/drivers/md/dm-vdo/uds-threads.h
@@ -93,7 +93,7 @@ static inline void uds_acquire_semaphore(struct semaphore *semaphore)
 	 * Do not use down(semaphore). Instead use down_interruptible so that
 	 * we do not get 120 second stall messages in kern.log.
 	 */
-	while (down_interruptible(semaphore) != 0)
+	while (down_interruptible(semaphore) != 0) {
 		/*
 		 * If we're called from a user-mode process (e.g., "dmsetup
 		 * remove") while waiting for an operation that may take a
@@ -105,6 +105,7 @@ static inline void uds_acquire_semaphore(struct semaphore *semaphore)
 		 * trying to do computational work. [VDO-4980]
 		 */
 		fsleep(1000);
+	}
 }
 
 static inline void uds_release_semaphore(struct semaphore *semaphore)

--- a/drivers/md/dm-vdo/uds.h
+++ b/drivers/md/dm-vdo/uds.h
@@ -281,7 +281,8 @@ struct uds_request {
 };
 
 /* Compute the number of bytes needed to store an index. */
-int __must_check uds_compute_index_size(const struct uds_parameters *parameters, u64 *index_size);
+int __must_check uds_compute_index_size(const struct uds_parameters *parameters,
+					u64 *index_size);
 
 /* A session is required for most index operations. */
 int __must_check uds_create_index_session(struct uds_index_session **session);
@@ -319,8 +320,8 @@ int __must_check uds_flush_index_session(struct uds_index_session *session);
 int __must_check uds_close_index(struct uds_index_session *session);
 
 /* Get index statistics since the last time the index was opened. */
-int __must_check
-uds_get_index_session_stats(struct uds_index_session *session, struct uds_index_stats *stats);
+int __must_check uds_get_index_session_stats(struct uds_index_session *session,
+					     struct uds_index_stats *stats);
 
 /* This function will fail if any required field of the request is not set. */
 int __must_check uds_launch_request(struct uds_request *request);

--- a/drivers/md/dm-vdo/uds.h
+++ b/drivers/md/dm-vdo/uds.h
@@ -230,7 +230,7 @@ struct uds_index;
 struct uds_request;
 
 /* Once this callback has been invoked, the uds_request structure can be reused or freed. */
-typedef void uds_request_callback_t(struct uds_request *request);
+typedef void (*uds_request_callback_fn)(struct uds_request *request);
 
 struct uds_request {
 	/* These input fields must be set before launching a request. */
@@ -240,7 +240,7 @@ struct uds_request {
 	/* New data to associate with the record name, if applicable */
 	struct uds_record_data new_metadata;
 	/* A callback to invoke when the request is complete */
-	uds_request_callback_t *callback;
+	uds_request_callback_fn callback;
 	/* The index session that will manage this request */
 	struct uds_index_session *session;
 	/* The type of operation to perform, as describe above */

--- a/drivers/md/dm-vdo/vdo.c
+++ b/drivers/md/dm-vdo/vdo.c
@@ -1285,7 +1285,7 @@ static void make_thread_read_only(struct vdo_completion *completion)
 		 * We don't want to notify the dedupe thread since it may be
 		 * blocked rebuilding the index.
 		 */
-		++thread_id;
+		thread_id++;
 
 	if (thread_id >= vdo->thread_config.thread_count)
 		/* There are no more threads */

--- a/drivers/md/dm-vdo/vdo.c
+++ b/drivers/md/dm-vdo/vdo.c
@@ -92,7 +92,7 @@ void vdo_initialize_device_registry_once(void)
 /** vdo_is_equal() - Implements vdo_filter_t. */
 static bool vdo_is_equal(struct vdo *vdo, const void *context)
 {
-	return ((void *) vdo == context);
+	return (vdo == context);
 }
 
 /**

--- a/drivers/md/dm-vdo/vdo.c
+++ b/drivers/md/dm-vdo/vdo.c
@@ -104,7 +104,8 @@ static bool vdo_is_equal(struct vdo *vdo, const void *context)
  *
  * Return: the vdo object found, if any.
  */
-static struct vdo * __must_check filter_vdos_locked(vdo_filter_t *filter, const void *context)
+static struct vdo * __must_check filter_vdos_locked(vdo_filter_t *filter,
+						    const void *context)
 {
 	struct vdo *vdo;
 
@@ -181,8 +182,8 @@ static void uninitialize_thread_config(struct thread_config *config)
 	memset(config, 0, sizeof(struct thread_config));
 }
 
-static void
-assign_thread_ids(struct thread_config *config, thread_id_t thread_ids[], zone_count_t count)
+static void assign_thread_ids(struct thread_config *config,
+			      thread_id_t thread_ids[], zone_count_t count)
 {
 	zone_count_t zone;
 
@@ -199,8 +200,8 @@ assign_thread_ids(struct thread_config *config, thread_id_t thread_ids[], zone_c
  *
  * Return: VDO_SUCCESS or an error.
  */
-static int __must_check
-initialize_thread_config(struct thread_count_config counts, struct thread_config *config)
+static int __must_check initialize_thread_config(struct thread_count_config counts,
+						 struct thread_config *config)
 {
 	int result;
 	bool single = ((counts.logical_zones + counts.physical_zones + counts.hash_zones) == 0);
@@ -216,37 +217,29 @@ initialize_thread_config(struct thread_count_config counts, struct thread_config
 		config->hash_zone_count = counts.hash_zones;
 	}
 
-	result = uds_allocate(config->logical_zone_count,
-			      thread_id_t,
-			      "logical thread array",
-			      &config->logical_threads);
+	result = uds_allocate(config->logical_zone_count, thread_id_t,
+			      "logical thread array", &config->logical_threads);
 	if (result != VDO_SUCCESS) {
 		uninitialize_thread_config(config);
 		return result;
 	}
 
-	result = uds_allocate(config->physical_zone_count,
-			      thread_id_t,
-			      "physical thread array",
-			      &config->physical_threads);
+	result = uds_allocate(config->physical_zone_count, thread_id_t,
+			      "physical thread array", &config->physical_threads);
 	if (result != VDO_SUCCESS) {
 		uninitialize_thread_config(config);
 		return result;
 	}
 
-	result = uds_allocate(config->hash_zone_count,
-			      thread_id_t,
-			      "hash thread array",
-			      &config->hash_zone_threads);
+	result = uds_allocate(config->hash_zone_count, thread_id_t,
+			      "hash thread array", &config->hash_zone_threads);
 	if (result != VDO_SUCCESS) {
 		uninitialize_thread_config(config);
 		return result;
 	}
 
-	result = uds_allocate(config->bio_thread_count,
-			      thread_id_t,
-			      "bio thread array",
-			      &config->bio_threads);
+	result = uds_allocate(config->bio_thread_count, thread_id_t,
+			      "bio thread array", &config->bio_threads);
 	if (result != VDO_SUCCESS) {
 		uninitialize_thread_config(config);
 		return result;
@@ -290,7 +283,8 @@ static int __must_check read_geometry_block(struct vdo *vdo)
 	if (result != VDO_SUCCESS)
 		return result;
 
-	result = create_metadata_vio(vdo, VIO_TYPE_GEOMETRY, VIO_PRIORITY_HIGH, NULL, block, &vio);
+	result = create_metadata_vio(vdo, VIO_TYPE_GEOMETRY, VIO_PRIORITY_HIGH, NULL,
+				     block, &vio);
 	if (result != VDO_SUCCESS) {
 		uds_free(block);
 		return result;
@@ -301,7 +295,8 @@ static int __must_check read_geometry_block(struct vdo *vdo)
 	 * bio_offset field is 0, so the fact that vio_reset_bio() will subtract that offset from
 	 * the supplied pbn is not a problem.
 	 */
-	result = vio_reset_bio(vio, block, NULL, REQ_OP_READ, VDO_GEOMETRY_BLOCK_LOCATION);
+	result = vio_reset_bio(vio, block, NULL, REQ_OP_READ,
+			       VDO_GEOMETRY_BLOCK_LOCATION);
 	if (result != VDO_SUCCESS) {
 		free_vio(uds_forget(vio));
 		uds_free(block);
@@ -323,12 +318,9 @@ static int __must_check read_geometry_block(struct vdo *vdo)
 	return result;
 }
 
-static bool get_zone_thread_name(const thread_id_t thread_ids[],
-				 zone_count_t count,
-				 thread_id_t id,
-				 const char *prefix,
-				 char *buffer,
-				 size_t buffer_length)
+static bool get_zone_thread_name(const thread_id_t thread_ids[], zone_count_t count,
+				 thread_id_t id, const char *prefix,
+				 char *buffer, size_t buffer_length)
 {
 	if (id >= thread_ids[0]) {
 		thread_id_t index = id - thread_ids[0];
@@ -352,11 +344,8 @@ static bool get_zone_thread_name(const thread_id_t thread_ids[],
  * The physical layer may add a prefix identifying the product; the output from this function
  * should just identify the thread.
  */
-static void
-get_thread_name(const struct thread_config *thread_config,
-		thread_id_t thread_id,
-		char *buffer,
-		size_t buffer_length)
+static void get_thread_name(const struct thread_config *thread_config,
+			    thread_id_t thread_id, char *buffer, size_t buffer_length)
 {
 	if (thread_id == thread_config->journal_thread) {
 		if (thread_config->packer_thread == thread_id) {
@@ -391,34 +380,22 @@ get_thread_name(const struct thread_config *thread_config,
 
 	if (get_zone_thread_name(thread_config->logical_threads,
 				 thread_config->logical_zone_count,
-				 thread_id,
-				 "logQ",
-				 buffer,
-				 buffer_length))
+				 thread_id, "logQ", buffer, buffer_length))
 		return;
 
 	if (get_zone_thread_name(thread_config->physical_threads,
 				 thread_config->physical_zone_count,
-				 thread_id,
-				 "physQ",
-				 buffer,
-				 buffer_length))
+				 thread_id, "physQ", buffer, buffer_length))
 		return;
 
 	if (get_zone_thread_name(thread_config->hash_zone_threads,
 				 thread_config->hash_zone_count,
-				 thread_id,
-				 "hashQ",
-				 buffer,
-				 buffer_length))
+				 thread_id, "hashQ", buffer, buffer_length))
 		return;
 
 	if (get_zone_thread_name(thread_config->bio_threads,
 				 thread_config->bio_thread_count,
-				 thread_id,
-				 "bioQ",
-				 buffer,
-				 buffer_length))
+				 thread_id, "bioQ", buffer, buffer_length))
 		return;
 
 	/* Some sort of misconfiguration? */
@@ -440,11 +417,9 @@ get_thread_name(const struct thread_config *thread_config,
  *
  * Return: VDO_SUCCESS or an error.
  */
-int vdo_make_thread(struct vdo *vdo,
-		    thread_id_t thread_id,
+int vdo_make_thread(struct vdo *vdo, thread_id_t thread_id,
 		    const struct vdo_work_queue_type *type,
-		    unsigned int queue_count,
-		    void *contexts[])
+		    unsigned int queue_count, void *contexts[])
 {
 	struct vdo_thread *thread = &vdo->threads[thread_id];
 	char queue_name[MAX_VDO_WORK_QUEUE_NAME_LEN];
@@ -461,13 +436,8 @@ int vdo_make_thread(struct vdo *vdo,
 	thread->vdo = vdo;
 	thread->thread_id = thread_id;
 	get_thread_name(&vdo->thread_config, thread_id, queue_name, sizeof(queue_name));
-	return vdo_make_work_queue(vdo->thread_name_prefix,
-				   queue_name,
-				   thread,
-				   type,
-				   queue_count,
-				   contexts,
-				   &thread->queue);
+	return vdo_make_work_queue(vdo->thread_name_prefix, queue_name, thread,
+				   type, queue_count, contexts, &thread->queue);
 }
 
 /**
@@ -500,8 +470,8 @@ static int register_vdo(struct vdo *vdo)
  * @instance: The instance number of the vdo
  * @reason: The buffer to hold the failure reason on error
  */
-static int
-initialize_vdo(struct vdo *vdo, struct device_config *config, unsigned int instance, char **reason)
+static int initialize_vdo(struct vdo *vdo, struct device_config *config,
+			  unsigned int instance, char **reason)
 {
 	int result;
 	zone_count_t i;
@@ -530,13 +500,10 @@ initialize_vdo(struct vdo *vdo, struct device_config *config, unsigned int insta
 	uds_log_info("zones: %d logical, %d physical, %d hash; total threads: %d",
 		     config->thread_counts.logical_zones,
 		     config->thread_counts.physical_zones,
-		     config->thread_counts.hash_zones,
-		     vdo->thread_config.thread_count);
+		     config->thread_counts.hash_zones, vdo->thread_config.thread_count);
 
 	/* Compression context storage */
-	result = uds_allocate(config->thread_counts.cpu_threads,
-			      char *,
-			      "LZ4 context",
+	result = uds_allocate(config->thread_counts.cpu_threads, char *, "LZ4 context",
 			      &vdo->compression_context);
 	if (result != VDO_SUCCESS) {
 		*reason = "cannot allocate LZ4 context";
@@ -544,9 +511,7 @@ initialize_vdo(struct vdo *vdo, struct device_config *config, unsigned int insta
 	}
 
 	for (i = 0; i < config->thread_counts.cpu_threads; i++) {
-		result = uds_allocate(LZ4_MEM_COMPRESS,
-				      char,
-				      "LZ4 context",
+		result = uds_allocate(LZ4_MEM_COMPRESS, char, "LZ4 context",
 				      &vdo->compression_context[i]);
 		if (result != VDO_SUCCESS) {
 			*reason = "cannot allocate LZ4 context";
@@ -573,9 +538,7 @@ initialize_vdo(struct vdo *vdo, struct device_config *config, unsigned int insta
  *
  * Return: VDO_SUCCESS or an error.
  */
-int vdo_make(unsigned int instance,
-	     struct device_config *config,
-	     char **reason,
+int vdo_make(unsigned int instance, struct device_config *config, char **reason,
 	     struct vdo **vdo_ptr)
 {
 	int result;
@@ -599,26 +562,18 @@ int vdo_make(unsigned int instance,
 	/* From here on, the caller will clean up if there is an error. */
 	*vdo_ptr = vdo;
 
-	snprintf(vdo->thread_name_prefix,
-		 sizeof(vdo->thread_name_prefix),
-		 "%s%u",
-		 MODULE_NAME,
-		 instance);
+	snprintf(vdo->thread_name_prefix, sizeof(vdo->thread_name_prefix),
+		 "%s%u", MODULE_NAME, instance);
 	BUG_ON(vdo->thread_name_prefix[0] == '\0');
 	result = uds_allocate(vdo->thread_config.thread_count,
-			      struct vdo_thread,
-			      __func__,
-			      &vdo->threads);
+			      struct vdo_thread, __func__, &vdo->threads);
 	if (result != VDO_SUCCESS) {
 		*reason = "Cannot allocate thread structures";
 		return result;
 	}
 
-	result = vdo_make_thread(vdo,
-				 vdo->thread_config.admin_thread,
-				 &default_queue_type,
-				 1,
-				 NULL);
+	result = vdo_make_thread(vdo, vdo->thread_config.admin_thread,
+				 &default_queue_type, 1, NULL);
 	if (result != VDO_SUCCESS) {
 		*reason = "Cannot make admin thread";
 		return result;
@@ -638,8 +593,7 @@ int vdo_make(unsigned int instance,
 
 	BUG_ON(vdo->device_config->logical_block_size <= 0);
 	BUG_ON(vdo->device_config->owned_device == NULL);
-	result = make_data_vio_pool(vdo,
-				    MAXIMUM_VDO_USER_VIOS,
+	result = make_data_vio_pool(vdo, MAXIMUM_VDO_USER_VIOS,
 				    MAXIMUM_VDO_USER_VIOS * 3 / 4,
 				    &vdo->data_vio_pool);
 	if (result != VDO_SUCCESS) {
@@ -650,28 +604,23 @@ int vdo_make(unsigned int instance,
 	result = vdo_make_io_submitter(config->thread_counts.bio_threads,
 				       config->thread_counts.bio_rotation_interval,
 				       get_data_vio_pool_request_limit(vdo->data_vio_pool),
-				       vdo,
-				       &vdo->io_submitter);
+				       vdo, &vdo->io_submitter);
 	if (result != VDO_SUCCESS) {
 		*reason = "bio submission initialization failed";
 		return result;
 	}
 
 	if (vdo_uses_bio_ack_queue(vdo)) {
-		result = vdo_make_thread(vdo,
-					 vdo->thread_config.bio_ack_thread,
+		result = vdo_make_thread(vdo, vdo->thread_config.bio_ack_thread,
 					 &bio_ack_q_type,
-					 config->thread_counts.bio_ack_threads,
-					 NULL);
+					 config->thread_counts.bio_ack_threads, NULL);
 		if (result != VDO_SUCCESS) {
 			*reason = "bio ack queue initialization failed";
 			return result;
 		}
 	}
 
-	result = vdo_make_thread(vdo,
-				 vdo->thread_config.cpu_thread,
-				 &cpu_q_type,
+	result = vdo_make_thread(vdo, vdo->thread_config.cpu_thread, &cpu_q_type,
 				 config->thread_counts.cpu_threads,
 				 (void **) vdo->compression_context);
 	if (result != VDO_SUCCESS) {
@@ -801,18 +750,13 @@ static int initialize_super_block(struct vdo *vdo, struct vdo_super_block *super
 {
 	int result;
 
-	result = uds_allocate(VDO_BLOCK_SIZE,
-			      char,
-			      "encoded super block",
+	result = uds_allocate(VDO_BLOCK_SIZE, char, "encoded super block",
 			      (char **) &vdo->super_block.buffer);
 	if (result != VDO_SUCCESS)
 		return result;
 
-	return allocate_vio_components(vdo,
-				       VIO_TYPE_SUPER_BLOCK,
-				       VIO_PRIORITY_METADATA,
-				       NULL,
-				       1,
+	return allocate_vio_components(vdo, VIO_TYPE_SUPER_BLOCK,
+				       VIO_PRIORITY_METADATA, NULL, 1,
 				       (char *) super_block->buffer,
 				       &vdo->super_block.vio);
 }
@@ -849,7 +793,8 @@ static void read_super_block_endio(struct bio *bio)
 	struct vio *vio = bio->bi_private;
 	struct vdo_completion *parent = vio->completion.parent;
 
-	continue_vio_after_io(vio, finish_reading_super_block, parent->callback_thread_id);
+	continue_vio_after_io(vio, finish_reading_super_block,
+			      parent->callback_thread_id);
 }
 
 /**
@@ -944,8 +889,7 @@ int vdo_synchronous_flush(struct vdo *vdo)
 	int result;
 	struct bio bio;
 
-	bio_init(&bio, vdo_get_backing_device(vdo), 0, 0,
-		 REQ_OP_WRITE | REQ_PREFLUSH);
+	bio_init(&bio, vdo_get_backing_device(vdo), 0, 0, REQ_OP_WRITE | REQ_PREFLUSH);
 	submit_bio_wait(&bio);
 	result = blk_status_to_errno(bio.bi_status);
 
@@ -1056,7 +1000,8 @@ static void super_block_write_endio(struct bio *bio)
 	struct vio *vio = bio->bi_private;
 	struct vdo_completion *parent = vio->completion.parent;
 
-	continue_vio_after_io(vio, continue_super_block_parent, parent->callback_thread_id);
+	continue_vio_after_io(vio, continue_super_block_parent,
+			      parent->callback_thread_id);
 }
 
 /**
@@ -1085,8 +1030,7 @@ void vdo_save_components(struct vdo *vdo, struct vdo_completion *parent)
 	super_block->vio.completion.callback_thread_id = parent->callback_thread_id;
 	submit_metadata_vio(&super_block->vio,
 			    vdo_get_data_region_start(vdo->geometry),
-			    super_block_write_endio,
-			    handle_save_error,
+			    super_block_write_endio, handle_save_error,
 			    REQ_OP_WRITE | REQ_PREFLUSH | REQ_FUA);
 }
 
@@ -1100,8 +1044,7 @@ void vdo_save_components(struct vdo *vdo, struct vdo_completion *parent)
  *
  * Return: VDO_SUCCESS or an error.
  */
-int vdo_register_read_only_listener(struct vdo *vdo,
-				    void *listener,
+int vdo_register_read_only_listener(struct vdo *vdo, void *listener,
 				    vdo_read_only_notification *notification,
 				    thread_id_t thread_id)
 {
@@ -1114,7 +1057,8 @@ int vdo_register_read_only_listener(struct vdo *vdo,
 	if (result != VDO_SUCCESS)
 		return result;
 
-	result = uds_allocate(1, struct read_only_listener, __func__, &read_only_listener);
+	result = uds_allocate(1, struct read_only_listener, __func__,
+			      &read_only_listener);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -1168,14 +1112,13 @@ int vdo_enable_read_only_entry(struct vdo *vdo)
 	}
 
 	spin_lock_init(&notifier->lock);
-	vdo_initialize_completion(&notifier->completion, vdo, VDO_READ_ONLY_MODE_COMPLETION);
+	vdo_initialize_completion(&notifier->completion, vdo,
+				  VDO_READ_ONLY_MODE_COMPLETION);
 
 	for (id = 0; id < vdo->thread_config.thread_count; id++)
 		vdo->threads[id].is_read_only = is_read_only;
 
-	return vdo_register_read_only_listener(vdo,
-					       vdo,
-					       notify_vdo_of_read_only_mode,
+	return vdo_register_read_only_listener(vdo, vdo, notify_vdo_of_read_only_mode,
 					       vdo->thread_config.admin_thread);
 }
 
@@ -1243,7 +1186,8 @@ static void finish_entering_read_only_mode(struct vdo_completion *completion)
 	spin_unlock(&notifier->lock);
 
 	if (notifier->waiter != NULL)
-		vdo_continue_completion(uds_forget(notifier->waiter), completion->result);
+		vdo_continue_completion(uds_forget(notifier->waiter),
+					completion->result);
 }
 
 /**
@@ -1273,10 +1217,8 @@ static void make_thread_read_only(struct vdo_completion *completion)
 
 	if (listener != NULL) {
 		/* We have a listener to notify */
-		vdo_prepare_completion(completion,
-				       make_thread_read_only,
-				       make_thread_read_only,
-				       thread_id,
+		vdo_prepare_completion(completion, make_thread_read_only,
+				       make_thread_read_only, thread_id,
 				       listener);
 		listener->notify(listener->listener, completion);
 		return;
@@ -1293,17 +1235,12 @@ static void make_thread_read_only(struct vdo_completion *completion)
 
 	if (thread_id >= vdo->thread_config.thread_count) {
 		/* There are no more threads */
-		vdo_prepare_completion(completion,
+		vdo_prepare_completion(completion, finish_entering_read_only_mode,
 				       finish_entering_read_only_mode,
-				       finish_entering_read_only_mode,
-				       vdo->thread_config.admin_thread,
-				       NULL);
+				       vdo->thread_config.admin_thread, NULL);
 	} else {
-		vdo_prepare_completion(completion,
-				       make_thread_read_only,
-				       make_thread_read_only,
-				       thread_id,
-				       NULL);
+		vdo_prepare_completion(completion, make_thread_read_only,
+				       make_thread_read_only, thread_id, NULL);
 	}
 
 	vdo_launch_completion(completion);
@@ -1457,7 +1394,8 @@ void vdo_enter_recovery_mode(struct vdo *vdo)
 static void complete_synchronous_action(struct vdo_completion *completion)
 {
 	vdo_assert_completion_type(completion, VDO_SYNC_COMPLETION);
-	complete(&(container_of(completion, struct sync_completion, vdo_completion)->completion));
+	complete(&(container_of(completion, struct sync_completion,
+				vdo_completion)->completion));
 }
 
 /**
@@ -1467,10 +1405,8 @@ static void complete_synchronous_action(struct vdo_completion *completion)
  * @thread_id: The thread on which to run the action.
  * @parent: The parent of the sync completion (may be NULL).
  */
-static int perform_synchronous_action(struct vdo *vdo,
-				      vdo_action *action,
-				      thread_id_t thread_id,
-				      void *parent)
+static int perform_synchronous_action(struct vdo *vdo, vdo_action *action,
+				      thread_id_t thread_id, void *parent)
 {
 	struct sync_completion sync;
 
@@ -1514,8 +1450,7 @@ static void set_compression_callback(struct vdo_completion *completion)
  */
 bool vdo_set_compressing(struct vdo *vdo, bool enable)
 {
-	perform_synchronous_action(vdo,
-				   set_compression_callback,
+	perform_synchronous_action(vdo, set_compression_callback,
 				   vdo->thread_config.packer_thread,
 				   &enable);
 	return enable;
@@ -1563,7 +1498,8 @@ static void copy_bio_stat(struct bio_stats *b, const struct atomic_bio_stats *a)
 	b->fua = atomic64_read(&a->fua);
 }
 
-static struct bio_stats subtract_bio_stats(struct bio_stats minuend, struct bio_stats subtrahend)
+static struct bio_stats subtract_bio_stats(struct bio_stats minuend,
+					   struct bio_stats subtrahend)
 {
 	return (struct bio_stats) {
 		.read = minuend.read - subtrahend.read,
@@ -1679,8 +1615,10 @@ static void get_vdo_statistics(const struct vdo *vdo, struct vdo_statistics *sta
 	copy_bio_stat(&stats->bios_page_cache, &vdo->stats.bios_page_cache);
 	copy_bio_stat(&stats->bios_out_completed, &vdo->stats.bios_out_completed);
 	copy_bio_stat(&stats->bios_meta_completed, &vdo->stats.bios_meta_completed);
-	copy_bio_stat(&stats->bios_journal_completed, &vdo->stats.bios_journal_completed);
-	copy_bio_stat(&stats->bios_page_cache_completed, &vdo->stats.bios_page_cache_completed);
+	copy_bio_stat(&stats->bios_journal_completed,
+		      &vdo->stats.bios_journal_completed);
+	copy_bio_stat(&stats->bios_page_cache_completed,
+		      &vdo->stats.bios_page_cache_completed);
 	copy_bio_stat(&stats->bios_acknowledged, &vdo->stats.bios_acknowledged);
 	copy_bio_stat(&stats->bios_acknowledged_partial, &vdo->stats.bios_acknowledged_partial);
 	stats->bios_in_progress =
@@ -1709,10 +1647,8 @@ static void vdo_fetch_statistics_callback(struct vdo_completion *completion)
  */
 void vdo_fetch_statistics(struct vdo *vdo, struct vdo_statistics *stats)
 {
-	perform_synchronous_action(vdo,
-				   vdo_fetch_statistics_callback,
-				   vdo->thread_config.admin_thread,
-				   stats);
+	perform_synchronous_action(vdo, vdo_fetch_statistics_callback,
+				   vdo->thread_config.admin_thread, stats);
 }
 
 /**
@@ -1771,8 +1707,7 @@ void vdo_dump_status(const struct vdo *vdo)
 void vdo_assert_on_admin_thread(const struct vdo *vdo, const char *name)
 {
 	ASSERT_LOG_ONLY((vdo_get_callback_thread_id() == vdo->thread_config.admin_thread),
-			"%s called on admin thread",
-			name);
+			"%s called on admin thread", name);
 }
 
 /**
@@ -1782,14 +1717,12 @@ void vdo_assert_on_admin_thread(const struct vdo *vdo, const char *name)
  * @logical_zone: The number of the logical zone.
  * @name: The name of the calling function.
  */
-void vdo_assert_on_logical_zone_thread(const struct vdo *vdo,
-				       zone_count_t logical_zone,
+void vdo_assert_on_logical_zone_thread(const struct vdo *vdo, zone_count_t logical_zone,
 				       const char *name)
 {
 	ASSERT_LOG_ONLY((vdo_get_callback_thread_id() ==
 			 vdo->thread_config.logical_threads[logical_zone]),
-			"%s called on logical thread",
-			name);
+			"%s called on logical thread", name);
 }
 
 /**
@@ -1800,13 +1733,11 @@ void vdo_assert_on_logical_zone_thread(const struct vdo *vdo,
  * @name: The name of the calling function.
  */
 void vdo_assert_on_physical_zone_thread(const struct vdo *vdo,
-					zone_count_t physical_zone,
-					const char *name)
+					zone_count_t physical_zone, const char *name)
 {
 	ASSERT_LOG_ONLY((vdo_get_callback_thread_id() ==
 			 vdo->thread_config.physical_threads[physical_zone]),
-			"%s called on physical thread",
-			name);
+			"%s called on physical thread", name);
 }
 
 /**
@@ -1824,8 +1755,7 @@ void vdo_assert_on_physical_zone_thread(const struct vdo *vdo,
  * Return: VDO_SUCCESS or VDO_OUT_OF_RANGE if the block number is invalid or an error code for any
  *         other failure.
  */
-int vdo_get_physical_zone(const struct vdo *vdo,
-			  physical_block_number_t pbn,
+int vdo_get_physical_zone(const struct vdo *vdo, physical_block_number_t pbn,
 			  struct physical_zone **zone_ptr)
 {
 	struct vdo_slab *slab;

--- a/drivers/md/dm-vdo/vdo.c
+++ b/drivers/md/dm-vdo/vdo.c
@@ -89,7 +89,7 @@ void vdo_initialize_device_registry_once(void)
 	rwlock_init(&registry.lock);
 }
 
-/** vdo_is_equal() - Implements vdo_filter_t. */
+/** vdo_is_equal() - Implements vdo_filter_fn. */
 static bool vdo_is_equal(struct vdo *vdo, const void *context)
 {
 	return (vdo == context);
@@ -104,7 +104,7 @@ static bool vdo_is_equal(struct vdo *vdo, const void *context)
  *
  * Return: the vdo object found, if any.
  */
-static struct vdo * __must_check filter_vdos_locked(vdo_filter_t *filter,
+static struct vdo * __must_check filter_vdos_locked(vdo_filter_fn filter,
 						    const void *context)
 {
 	struct vdo *vdo;
@@ -122,7 +122,7 @@ static struct vdo * __must_check filter_vdos_locked(vdo_filter_t *filter,
  * @filter: The filter function to apply to vdos.
  * @context: A bit of context to provide the filter.
  */
-struct vdo *vdo_find_matching(vdo_filter_t *filter, const void *context)
+struct vdo *vdo_find_matching(vdo_filter_fn filter, const void *context)
 {
 	struct vdo *vdo;
 
@@ -1045,7 +1045,7 @@ void vdo_save_components(struct vdo *vdo, struct vdo_completion *parent)
  * Return: VDO_SUCCESS or an error.
  */
 int vdo_register_read_only_listener(struct vdo *vdo, void *listener,
-				    vdo_read_only_notification *notification,
+				    vdo_read_only_notification_fn notification,
 				    thread_id_t thread_id)
 {
 	struct vdo_thread *thread = &vdo->threads[thread_id];
@@ -1079,7 +1079,7 @@ int vdo_register_read_only_listener(struct vdo *vdo, void *listener,
  *
  * This will save the read-only state to the super block.
  *
- * Implements vdo_read_only_notification.
+ * Implements vdo_read_only_notification_fn.
  */
 static void notify_vdo_of_read_only_mode(void *listener, struct vdo_completion *parent)
 {
@@ -1405,7 +1405,7 @@ static void complete_synchronous_action(struct vdo_completion *completion)
  * @thread_id: The thread on which to run the action.
  * @parent: The parent of the sync completion (may be NULL).
  */
-static int perform_synchronous_action(struct vdo *vdo, vdo_action *action,
+static int perform_synchronous_action(struct vdo *vdo, vdo_action_fn action,
 				      thread_id_t thread_id, void *parent)
 {
 	struct sync_completion sync;

--- a/drivers/md/dm-vdo/vdo.h
+++ b/drivers/md/dm-vdo/vdo.h
@@ -299,19 +299,18 @@ typedef bool vdo_filter_t(struct vdo *vdo, const void *context);
 void vdo_initialize_device_registry_once(void);
 struct vdo * __must_check vdo_find_matching(vdo_filter_t *filter, const void *context);
 
-int __must_check vdo_make_thread(struct vdo *vdo,
-				 thread_id_t thread_id,
+int __must_check vdo_make_thread(struct vdo *vdo, thread_id_t thread_id,
 				 const struct vdo_work_queue_type *type,
-				 unsigned int queue_count,
-				 void *contexts[]);
+				 unsigned int queue_count, void *contexts[]);
 
-static inline int __must_check vdo_make_default_thread(struct vdo *vdo, thread_id_t thread_id)
+static inline int __must_check vdo_make_default_thread(struct vdo *vdo,
+						       thread_id_t thread_id)
 {
 	return vdo_make_thread(vdo, thread_id, NULL, 1, NULL);
 }
 
-int __must_check
-vdo_make(unsigned int instance, struct device_config *config, char **reason, struct vdo **vdo_ptr);
+int __must_check vdo_make(unsigned int instance, struct device_config *config,
+			  char **reason, struct vdo **vdo_ptr);
 
 void vdo_destroy(struct vdo *vdo);
 
@@ -341,8 +340,7 @@ void vdo_set_state(struct vdo *vdo, enum vdo_state state);
 
 void vdo_save_components(struct vdo *vdo, struct vdo_completion *parent);
 
-int vdo_register_read_only_listener(struct vdo *vdo,
-				    void *listener,
+int vdo_register_read_only_listener(struct vdo *vdo, void *listener,
 				    vdo_read_only_notification *notification,
 				    thread_id_t thread_id);
 
@@ -364,16 +362,13 @@ void vdo_enter_recovery_mode(struct vdo *vdo);
 
 void vdo_assert_on_admin_thread(const struct vdo *vdo, const char *name);
 
-void vdo_assert_on_logical_zone_thread(const struct vdo *vdo,
-				       zone_count_t logical_zone,
+void vdo_assert_on_logical_zone_thread(const struct vdo *vdo, zone_count_t logical_zone,
 				       const char *name);
 
-void vdo_assert_on_physical_zone_thread(const struct vdo *vdo,
-					zone_count_t physical_zone,
+void vdo_assert_on_physical_zone_thread(const struct vdo *vdo, zone_count_t physical_zone,
 					const char *name);
 
-int __must_check vdo_get_physical_zone(const struct vdo *vdo,
-				       physical_block_number_t pbn,
+int __must_check vdo_get_physical_zone(const struct vdo *vdo, physical_block_number_t pbn,
 				       struct physical_zone **zone_ptr);
 
 void vdo_dump_status(const struct vdo *vdo);

--- a/drivers/md/dm-vdo/vdo.h
+++ b/drivers/md/dm-vdo/vdo.h
@@ -36,12 +36,12 @@ enum notifier_state {
 };
 
 /**
- * typedef vdo_read_only_notification - A function to notify a listener that the VDO has gone
- *                                      read-only.
+ * typedef vdo_read_only_notification_fn - A function to notify a listener that the VDO has gone
+ *                                         read-only.
  * @listener: The object to notify.
  * @parent: The completion to notify in order to acknowledge the notification.
  */
-typedef void vdo_read_only_notification(void *listener, struct vdo_completion *parent);
+typedef void (*vdo_read_only_notification_fn)(void *listener, struct vdo_completion *parent);
 
 /*
  * An object to be notified when the VDO enters read-only mode
@@ -50,7 +50,7 @@ struct read_only_listener {
 	/* The listener */
 	void *listener;
 	/* The method to call to notify the listener */
-	vdo_read_only_notification *notify;
+	vdo_read_only_notification_fn notify;
 	/* A pointer to the next listener */
 	struct read_only_listener *next;
 };
@@ -168,7 +168,7 @@ struct vdo_administrator {
 struct vdo {
 	char thread_name_prefix[MAX_VDO_WORK_QUEUE_NAME_LEN];
 	struct vdo_thread *threads;
-	vdo_action *action;
+	vdo_action_fn action;
 	struct vdo_completion *completion;
 	struct vio_tracer *vio_tracer;
 
@@ -290,14 +290,14 @@ static inline bool vdo_uses_bio_ack_queue(struct vdo *vdo)
 }
 
 /**
- * typedef vdo_filter_t - Method type for vdo matching methods.
+ * typedef vdo_filter_fn - Method type for vdo matching methods.
  *
  * A filter function returns false if the vdo doesn't match.
  */
-typedef bool vdo_filter_t(struct vdo *vdo, const void *context);
+typedef bool (*vdo_filter_fn)(struct vdo *vdo, const void *context);
 
 void vdo_initialize_device_registry_once(void);
-struct vdo * __must_check vdo_find_matching(vdo_filter_t *filter, const void *context);
+struct vdo * __must_check vdo_find_matching(vdo_filter_fn filter, const void *context);
 
 int __must_check vdo_make_thread(struct vdo *vdo, thread_id_t thread_id,
 				 const struct vdo_work_queue_type *type,
@@ -341,7 +341,7 @@ void vdo_set_state(struct vdo *vdo, enum vdo_state state);
 void vdo_save_components(struct vdo *vdo, struct vdo_completion *parent);
 
 int vdo_register_read_only_listener(struct vdo *vdo, void *listener,
-				    vdo_read_only_notification *notification,
+				    vdo_read_only_notification_fn notification,
 				    thread_id_t thread_id);
 
 int vdo_enable_read_only_entry(struct vdo *vdo);

--- a/drivers/md/dm-vdo/vio.c
+++ b/drivers/md/dm-vdo/vio.c
@@ -238,10 +238,11 @@ int vio_reset_bio(struct vio *vio,
 		page = is_vmalloc_addr(data) ? vmalloc_to_page(data) : virt_to_page(data);
 		bytes_added = bio_add_page(bio, page, bytes, offset);
 
-		if (bytes_added != bytes)
+		if (bytes_added != bytes) {
 			return uds_log_error_strerror(VDO_BIO_CREATION_FAILED,
 						      "Could only add %i bytes to bio",
 						       bytes_added);
+		}
 
 		data += bytes;
 		len -= bytes;
@@ -292,16 +293,17 @@ void vio_record_metadata_io_error(struct vio *vio)
 	const char *description;
 	physical_block_number_t pbn = pbn_from_vio_bio(vio->bio);
 
-	if (bio_op(vio->bio) == REQ_OP_READ)
+	if (bio_op(vio->bio) == REQ_OP_READ) {
 		description = "read";
-	else if ((vio->bio->bi_opf & REQ_PREFLUSH) == REQ_PREFLUSH)
+	} else if ((vio->bio->bi_opf & REQ_PREFLUSH) == REQ_PREFLUSH) {
 		description = (((vio->bio->bi_opf & REQ_FUA) == REQ_FUA) ?
 			       "write+preflush+fua" :
 			       "write+preflush");
-	else if ((vio->bio->bi_opf & REQ_FUA) == REQ_FUA)
+	} else if ((vio->bio->bi_opf & REQ_FUA) == REQ_FUA) {
 		description = "write+fua";
-	else
+	} else {
 		description = "write";
+	}
 
 	update_vio_error_stats(vio,
 			       "Completing %s vio of type %u for physical block %llu with error",

--- a/drivers/md/dm-vdo/vio.c
+++ b/drivers/md/dm-vdo/vio.c
@@ -52,7 +52,8 @@ static int create_multi_block_bio(block_count_t size, struct bio **bio_ptr)
 	struct bio *bio = NULL;
 	int result;
 
-	result = uds_allocate_extended(struct bio, size + 1, struct bio_vec, "bio", &bio);
+	result = uds_allocate_extended(struct bio, size + 1, struct bio_vec,
+				       "bio", &bio);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -74,27 +75,21 @@ void vdo_free_bio(struct bio *bio)
 	uds_free(uds_forget(bio));
 }
 
-int allocate_vio_components(struct vdo *vdo,
-			    enum vio_type vio_type,
-			    enum vio_priority priority,
-			    void *parent,
-			    unsigned int block_count,
-			    char *data,
-			    struct vio *vio)
+int allocate_vio_components(struct vdo *vdo, enum vio_type vio_type,
+			    enum vio_priority priority, void *parent,
+			    unsigned int block_count, char *data, struct vio *vio)
 {
 	struct bio *bio;
 	int result;
 
 	result = ASSERT(block_count <= MAX_BLOCKS_PER_VIO,
-			"block count %u does not exceed maximum %u",
-			block_count,
+			"block count %u does not exceed maximum %u", block_count,
 			MAX_BLOCKS_PER_VIO);
 	if (result != VDO_SUCCESS)
 		return result;
 
 	result = ASSERT(((vio_type != VIO_TYPE_UNINITIALIZED) && (vio_type != VIO_TYPE_DATA)),
-			"%d is a metadata type",
-			vio_type);
+			"%d is a metadata type", vio_type);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -120,12 +115,9 @@ int allocate_vio_components(struct vdo *vdo,
  *
  * Return: VDO_SUCCESS or an error.
  */
-int create_multi_block_metadata_vio(struct vdo *vdo,
-				    enum vio_type vio_type,
-				    enum vio_priority priority,
-				    void *parent,
-				    unsigned int block_count,
-				    char *data,
+int create_multi_block_metadata_vio(struct vdo *vdo, enum vio_type vio_type,
+				    enum vio_priority priority, void *parent,
+				    unsigned int block_count, char *data,
 				    struct vio **vio_ptr)
 {
 	struct vio *vio;
@@ -144,7 +136,8 @@ int create_multi_block_metadata_vio(struct vdo *vdo,
 		return result;
 	}
 
-	result = allocate_vio_components(vdo, vio_type, priority, parent, block_count, data, vio);
+	result = allocate_vio_components(vdo, vio_type, priority, parent, block_count,
+					 data, vio);
 	if (result != VDO_SUCCESS) {
 		uds_free(vio);
 		return result;
@@ -178,11 +171,8 @@ void free_vio(struct vio *vio)
 }
 
 /* Set bio properties for a VDO read or write. */
-void vdo_set_bio_properties(struct bio *bio,
-			    struct vio *vio,
-			    bio_end_io_t callback,
-			    unsigned int bi_opf,
-			    physical_block_number_t pbn)
+void vdo_set_bio_properties(struct bio *bio, struct vio *vio, bio_end_io_t callback,
+			    unsigned int bi_opf, physical_block_number_t pbn)
 {
 	struct vdo *vdo = vio->completion.vdo;
 	struct device_config *config = vdo->device_config;
@@ -202,11 +192,8 @@ void vdo_set_bio_properties(struct bio *bio,
  * bio, as it assumes the bio wraps a 4k buffer that is 4k aligned, but there does not have to be a
  * vio associated with the bio.
  */
-int vio_reset_bio(struct vio *vio,
-		  char *data,
-		  bio_end_io_t callback,
-		  unsigned int bi_opf,
-		  physical_block_number_t pbn)
+int vio_reset_bio(struct vio *vio, char *data, bio_end_io_t callback,
+		  unsigned int bi_opf, physical_block_number_t pbn)
 {
 	int bvec_count, offset, len, i;
 	struct bio *bio = vio->bio;
@@ -241,7 +228,7 @@ int vio_reset_bio(struct vio *vio,
 		if (bytes_added != bytes) {
 			return uds_log_error_strerror(VDO_BIO_CREATION_FAILED,
 						      "Could only add %i bytes to bio",
-						       bytes_added);
+						      bytes_added);
 		}
 
 		data += bytes;
@@ -259,8 +246,7 @@ int vio_reset_bio(struct vio *vio,
  */
 void update_vio_error_stats(struct vio *vio, const char *format, ...)
 {
-	static DEFINE_RATELIMIT_STATE(error_limiter,
-				      DEFAULT_RATELIMIT_INTERVAL,
+	static DEFINE_RATELIMIT_STATE(error_limiter, DEFAULT_RATELIMIT_INTERVAL,
 				      DEFAULT_RATELIMIT_BURST);
 	va_list args;
 	int priority;
@@ -284,7 +270,8 @@ void update_vio_error_stats(struct vio *vio, const char *format, ...)
 		return;
 
 	va_start(args, format);
-	uds_vlog_strerror(priority, vio->completion.result, UDS_LOGGING_MODULE_NAME, format, args);
+	uds_vlog_strerror(priority, vio->completion.result, UDS_LOGGING_MODULE_NAME,
+			  format, args);
 	va_end(args);
 }
 
@@ -307,9 +294,7 @@ void vio_record_metadata_io_error(struct vio *vio)
 
 	update_vio_error_stats(vio,
 			       "Completing %s vio of type %u for physical block %llu with error",
-			       description,
-			       vio->type,
-			       (unsigned long long) pbn);
+			       description, vio->type, (unsigned long long) pbn);
 }
 
 /**
@@ -324,23 +309,16 @@ void vio_record_metadata_io_error(struct vio *vio)
  *
  * Return: A success or error code.
  */
-int make_vio_pool(struct vdo *vdo,
-		  size_t pool_size,
-		  thread_id_t thread_id,
-		  enum vio_type vio_type,
-		  enum vio_priority priority,
-		  void *context,
+int make_vio_pool(struct vdo *vdo, size_t pool_size, thread_id_t thread_id,
+		  enum vio_type vio_type, enum vio_priority priority, void *context,
 		  struct vio_pool **pool_ptr)
 {
 	struct vio_pool *pool;
 	char *ptr;
 	int result;
 
-	result = uds_allocate_extended(struct vio_pool,
-				       pool_size,
-				       struct pooled_vio,
-				       __func__,
-				       &pool);
+	result = uds_allocate_extended(struct vio_pool, pool_size, struct pooled_vio,
+				       __func__, &pool);
 	if (result != VDO_SUCCESS)
 		return result;
 
@@ -348,7 +326,8 @@ int make_vio_pool(struct vdo *vdo,
 	INIT_LIST_HEAD(&pool->available);
 	INIT_LIST_HEAD(&pool->busy);
 
-	result = uds_allocate(pool_size * VDO_BLOCK_SIZE, char, "VIO pool buffer", &pool->buffer);
+	result = uds_allocate(pool_size * VDO_BLOCK_SIZE, char,
+			      "VIO pool buffer", &pool->buffer);
 	if (result != VDO_SUCCESS) {
 		free_vio_pool(pool);
 		return result;
@@ -358,12 +337,7 @@ int make_vio_pool(struct vdo *vdo,
 	for (pool->size = 0; pool->size < pool_size; pool->size++, ptr += VDO_BLOCK_SIZE) {
 		struct pooled_vio *pooled = &pool->vios[pool->size];
 
-		result = allocate_vio_components(vdo,
-						 vio_type,
-						 priority,
-						 NULL,
-						 1,
-						 ptr,
+		result = allocate_vio_components(vdo, vio_type, priority, NULL, 1, ptr,
 						 &pooled->vio);
 		if (result != VDO_SUCCESS) {
 			free_vio_pool(pool);

--- a/drivers/md/dm-vdo/vio.h
+++ b/drivers/md/dm-vdo/vio.h
@@ -169,7 +169,7 @@ void vdo_count_completed_bios(struct bio *bio);
 /**
  * continue_vio_after_io() - Continue a vio now that its I/O has returned.
  */
-static inline void continue_vio_after_io(struct vio *vio, vdo_action *callback,
+static inline void continue_vio_after_io(struct vio *vio, vdo_action_fn callback,
 					 thread_id_t thread)
 {
 	vdo_count_completed_bios(vio->bio);

--- a/drivers/md/dm-vdo/vio.h
+++ b/drivers/md/dm-vdo/vio.h
@@ -69,37 +69,27 @@ static inline void assert_vio_in_bio_zone(struct vio *vio)
 
 	ASSERT_LOG_ONLY((expected == thread_id),
 			"vio I/O for physical block %llu on thread %u, should be on bio zone thread %u",
-			(unsigned long long) pbn_from_vio_bio(vio->bio),
-			thread_id,
+			(unsigned long long) pbn_from_vio_bio(vio->bio), thread_id,
 			expected);
 }
 
 int vdo_create_bio(struct bio **bio_ptr);
 void vdo_free_bio(struct bio *bio);
-int allocate_vio_components(struct vdo *vdo,
-			    enum vio_type vio_type,
-			    enum vio_priority priority,
-			    void *parent,
-			    unsigned int block_count,
-			    char *data,
-			    struct vio *vio);
-int __must_check create_multi_block_metadata_vio(struct vdo *vdo,
-						 enum vio_type vio_type,
+int allocate_vio_components(struct vdo *vdo, enum vio_type vio_type,
+			    enum vio_priority priority, void *parent,
+			    unsigned int block_count, char *data, struct vio *vio);
+int __must_check create_multi_block_metadata_vio(struct vdo *vdo, enum vio_type vio_type,
 						 enum vio_priority priority,
-						 void *parent,
-						 unsigned int block_count,
-						 char *data,
-						 struct vio **vio_ptr);
+						 void *parent, unsigned int block_count,
+						 char *data, struct vio **vio_ptr);
 
-static inline int __must_check
-create_metadata_vio(struct vdo *vdo,
-		    enum vio_type vio_type,
-		    enum vio_priority priority,
-		    void *parent,
-		    char *data,
-		    struct vio **vio_ptr)
+static inline int __must_check create_metadata_vio(struct vdo *vdo, enum vio_type vio_type,
+						   enum vio_priority priority,
+						   void *parent, char *data,
+						   struct vio **vio_ptr)
 {
-	return create_multi_block_metadata_vio(vdo, vio_type, priority, parent, 1, data, vio_ptr);
+	return create_multi_block_metadata_vio(vdo, vio_type, priority, parent, 1, data,
+					       vio_ptr);
 }
 
 void free_vio_components(struct vio *vio);
@@ -114,12 +104,9 @@ void free_vio(struct vio *vio);
  * @priority: The relative priority of the vio.
  * @vdo: The vdo for this vio.
  */
-static inline void initialize_vio(struct vio *vio,
-				  struct bio *bio,
-				  unsigned int block_count,
-				  enum vio_type vio_type,
-				  enum vio_priority priority,
-				  struct vdo *vdo)
+static inline void initialize_vio(struct vio *vio, struct bio *bio,
+				  unsigned int block_count, enum vio_type vio_type,
+				  enum vio_priority priority, struct vdo *vdo)
 {
 	/* data_vio's may not span multiple blocks */
 	BUG_ON((vio_type == VIO_TYPE_DATA) && (block_count != 1));
@@ -131,17 +118,11 @@ static inline void initialize_vio(struct vio *vio,
 	vdo_initialize_completion(&vio->completion, vdo, VIO_COMPLETION);
 }
 
-void vdo_set_bio_properties(struct bio *bio,
-			    struct vio *vio,
-			    bio_end_io_t callback,
-			    unsigned int bi_opf,
-			    physical_block_number_t pbn);
+void vdo_set_bio_properties(struct bio *bio, struct vio *vio, bio_end_io_t callback,
+			    unsigned int bi_opf, physical_block_number_t pbn);
 
-int vio_reset_bio(struct vio *vio,
-		  char *data,
-		  bio_end_io_t callback,
-		  unsigned int bi_opf,
-		  physical_block_number_t pbn);
+int vio_reset_bio(struct vio *vio, char *data, bio_end_io_t callback,
+		  unsigned int bi_opf, physical_block_number_t pbn);
 
 void update_vio_error_stats(struct vio *vio, const char *format, ...)
 	__printf(2, 3);
@@ -188,7 +169,8 @@ void vdo_count_completed_bios(struct bio *bio);
 /**
  * continue_vio_after_io() - Continue a vio now that its I/O has returned.
  */
-static inline void continue_vio_after_io(struct vio *vio, vdo_action *callback, thread_id_t thread)
+static inline void continue_vio_after_io(struct vio *vio, vdo_action *callback,
+					 thread_id_t thread)
 {
 	vdo_count_completed_bios(vio->bio);
 	vdo_set_completion_callback(&vio->completion, callback, thread);
@@ -206,13 +188,9 @@ static inline struct pooled_vio *vio_as_pooled_vio(struct vio *vio)
 
 struct vio_pool;
 
-int __must_check make_vio_pool(struct vdo *vdo,
-			       size_t pool_size,
-			       thread_id_t thread_id,
-			       enum vio_type vio_type,
-			       enum vio_priority priority,
-			       void *context,
-			       struct vio_pool **pool_ptr);
+int __must_check make_vio_pool(struct vdo *vdo, size_t pool_size, thread_id_t thread_id,
+			       enum vio_type vio_type, enum vio_priority priority,
+			       void *context, struct vio_pool **pool_ptr);
 void free_vio_pool(struct vio_pool *pool);
 bool __must_check is_vio_pool_busy(struct vio_pool *pool);
 void acquire_vio_from_pool(struct vio_pool *pool, struct waiter *waiter);

--- a/drivers/md/dm-vdo/volume-index.c
+++ b/drivers/md/dm-vdo/volume-index.c
@@ -1084,7 +1084,7 @@ int uds_save_volume_index(struct volume_index *volume_index,
 	int result = UDS_SUCCESS;
 	unsigned int zone;
 
-	for (zone = 0; zone < writer_count; ++zone) {
+	for (zone = 0; zone < writer_count; zone++) {
 		result = start_saving_volume_index(volume_index, zone, writers[zone]);
 		if (result != UDS_SUCCESS)
 			break;

--- a/drivers/md/dm-vdo/volume-index.c
+++ b/drivers/md/dm-vdo/volume-index.c
@@ -112,14 +112,14 @@ struct volume_index_data {
 	u32 sparse_sample_rate;
 };
 
-static inline u32
-extract_address(const struct volume_sub_index *sub_index, const struct uds_record_name *name)
+static inline u32 extract_address(const struct volume_sub_index *sub_index,
+				  const struct uds_record_name *name)
 {
 	return uds_extract_volume_index_bytes(name) & sub_index->address_mask;
 }
 
-static inline u32
-extract_dlist_num(const struct volume_sub_index *sub_index, const struct uds_record_name *name)
+static inline u32 extract_dlist_num(const struct volume_sub_index *sub_index,
+				    const struct uds_record_name *name)
 {
 	u64 bits = uds_extract_volume_index_bytes(name);
 
@@ -132,8 +132,8 @@ get_zone_for_record(const struct volume_index_record *record)
 	return &record->sub_index->zones[record->zone_number];
 }
 
-static inline u64
-convert_index_to_virtual(const struct volume_index_record *record, u32 index_chapter)
+static inline u64 convert_index_to_virtual(const struct volume_index_record *record,
+					   u32 index_chapter)
 {
 	const struct volume_sub_index_zone *volume_index_zone = get_zone_for_record(record);
 	u32 rolling_chapter = ((index_chapter - volume_index_zone->virtual_chapter_low) &
@@ -142,14 +142,14 @@ convert_index_to_virtual(const struct volume_index_record *record, u32 index_cha
 	return volume_index_zone->virtual_chapter_low + rolling_chapter;
 }
 
-static inline u32
-convert_virtual_to_index(const struct volume_sub_index *sub_index, u64 virtual_chapter)
+static inline u32 convert_virtual_to_index(const struct volume_sub_index *sub_index,
+					   u64 virtual_chapter)
 {
 	return virtual_chapter & sub_index->chapter_mask;
 }
 
-static inline bool
-is_virtual_chapter_indexed(const struct volume_index_record *record, u64 virtual_chapter)
+static inline bool is_virtual_chapter_indexed(const struct volume_index_record *record,
+					      u64 virtual_chapter)
 {
 	const struct volume_sub_index_zone *volume_index_zone = get_zone_for_record(record);
 
@@ -172,7 +172,8 @@ bool uds_is_volume_index_sample(const struct volume_index *volume_index,
 }
 
 static inline const struct volume_sub_index *
-get_volume_sub_index(const struct volume_index *volume_index, const struct uds_record_name *name)
+get_volume_sub_index(const struct volume_index *volume_index,
+		     const struct uds_record_name *name)
 {
 	return (uds_is_volume_index_sample(volume_index, name) ?
 		&volume_index->vi_hook :
@@ -299,8 +300,8 @@ void uds_free_volume_index(struct volume_index *volume_index)
 }
 
 
-static int
-compute_volume_sub_index_save_bytes(const struct configuration *config, size_t *bytes)
+static int compute_volume_sub_index_save_bytes(const struct configuration *config,
+					       size_t *bytes)
 {
 	struct sub_index_parameters params = { .address_bits = 0 };
 	int result;
@@ -310,12 +311,14 @@ compute_volume_sub_index_save_bytes(const struct configuration *config, size_t *
 		return result;
 
 	*bytes = (sizeof(struct sub_index_data) + params.list_count * sizeof(u64) +
-		  uds_compute_delta_index_save_bytes(params.list_count, params.memory_size));
+		  uds_compute_delta_index_save_bytes(params.list_count,
+						     params.memory_size));
 	return UDS_SUCCESS;
 }
 
 /* This function is only useful if the configuration includes sparse chapters. */
-static void split_configuration(const struct configuration *config, struct split_config *split)
+static void split_configuration(const struct configuration *config,
+				struct split_config *split)
 {
 	u64 sample_rate, sample_records;
 	u64 dense_chapters, sparse_chapters;
@@ -343,7 +346,8 @@ static void split_configuration(const struct configuration *config, struct split
 	split->non_hook_geometry.chapters_per_volume = dense_chapters;
 }
 
-static int compute_volume_index_save_bytes(const struct configuration *config, size_t *bytes)
+static int compute_volume_index_save_bytes(const struct configuration *config,
+					   size_t *bytes)
 {
 	size_t hook_bytes, non_hook_bytes;
 	struct split_config split;
@@ -357,7 +361,8 @@ static int compute_volume_index_save_bytes(const struct configuration *config, s
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = compute_volume_sub_index_save_bytes(&split.non_hook_config, &non_hook_bytes);
+	result = compute_volume_sub_index_save_bytes(&split.non_hook_config,
+						     &non_hook_bytes);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -366,8 +371,7 @@ static int compute_volume_index_save_bytes(const struct configuration *config, s
 }
 
 int uds_compute_volume_index_save_blocks(const struct configuration *config,
-					 size_t block_size,
-					 u64 *block_count)
+					 size_t block_size, u64 *block_count)
 {
 	size_t bytes;
 	int result;
@@ -412,25 +416,22 @@ static inline int flush_invalid_entries(struct volume_index_record *record,
 }
 
 /* Find the matching record, or the list offset where the record would go. */
-static int get_volume_index_entry(struct volume_index_record *record,
-				  u32 list_number,
-				  u32 key,
-				  struct chapter_range *flush_range)
+static int get_volume_index_entry(struct volume_index_record *record, u32 list_number,
+				  u32 key, struct chapter_range *flush_range)
 {
 	struct volume_index_record other_record;
 	const struct volume_sub_index *sub_index = record->sub_index;
 	u32 next_chapter_to_invalidate = sub_index->chapter_mask;
 	int result;
 
-	result = uds_start_delta_index_search(&sub_index->delta_index,
-					      list_number,
-					      0,
+	result = uds_start_delta_index_search(&sub_index->delta_index, list_number, 0,
 					      &record->delta_entry);
 	if (result != UDS_SUCCESS)
 		return result;
 
 	do {
-		result = flush_invalid_entries(record, flush_range, &next_chapter_to_invalidate);
+		result = flush_invalid_entries(record, flush_range,
+					       &next_chapter_to_invalidate);
 		if (result != UDS_SUCCESS)
 			return result;
 	} while (!record->delta_entry.at_end && (key > record->delta_entry.key));
@@ -445,8 +446,7 @@ static int get_volume_index_entry(struct volume_index_record *record,
 		for (;;) {
 			u8 collision_name[UDS_RECORD_NAME_SIZE];
 
-			result = flush_invalid_entries(&other_record,
-						       flush_range,
+			result = flush_invalid_entries(&other_record, flush_range,
 						       &next_chapter_to_invalidate);
 			if (result != UDS_SUCCESS)
 				return result;
@@ -467,8 +467,7 @@ static int get_volume_index_entry(struct volume_index_record *record,
 		}
 	}
 	while (!other_record.delta_entry.at_end) {
-		result = flush_invalid_entries(&other_record,
-					       flush_range,
+		result = flush_invalid_entries(&other_record, flush_range,
 					       &next_chapter_to_invalidate);
 		if (result != UDS_SUCCESS)
 			return result;
@@ -504,17 +503,16 @@ static int get_volume_sub_index_record(struct volume_sub_index *sub_index,
 		range.chapter_count = (flush_count > sub_index->chapter_mask ?
 				       sub_index->chapter_mask + 1 :
 				       flush_count);
-		result = get_volume_index_entry(record, delta_list_number, address, &range);
+		result = get_volume_index_entry(record, delta_list_number, address,
+						&range);
 		flush_chapter = convert_index_to_virtual(record, range.chapter_start);
 		if (flush_chapter > volume_index_zone->virtual_chapter_high)
 			flush_chapter = volume_index_zone->virtual_chapter_high;
 		sub_index->flush_chapters[delta_list_number] = flush_chapter;
 	} else {
 		result = uds_get_delta_index_entry(&sub_index->delta_index,
-						   delta_list_number,
-						   address,
-						   name->name,
-						   &record->delta_entry);
+						   delta_list_number, address,
+						   name->name, &record->delta_entry);
 	}
 
 	if (result != UDS_SUCCESS)
@@ -549,12 +547,14 @@ int uds_get_volume_index_record(struct volume_index *volume_index,
 		struct mutex *mutex = &volume_index->zones[zone].hook_mutex;
 
 		uds_lock_mutex(mutex);
-		result = get_volume_sub_index_record(&volume_index->vi_hook, name, record);
+		result = get_volume_sub_index_record(&volume_index->vi_hook, name,
+						     record);
 		uds_unlock_mutex(mutex);
 		/* Remember the mutex so that other operations on the index record can use it. */
 		record->mutex = mutex;
 	} else {
-		result = get_volume_sub_index_record(&volume_index->vi_non_hook, name, record);
+		result = get_volume_sub_index_record(&volume_index->vi_non_hook, name,
+						     record);
 	}
 
 	return result;
@@ -579,9 +579,9 @@ int uds_put_volume_index_record(struct volume_index_record *record, u64 virtual_
 	address = extract_address(sub_index, record->name);
 	if (unlikely(record->mutex != NULL))
 		uds_lock_mutex(record->mutex);
-	result = uds_put_delta_index_entry(&record->delta_entry,
-					   address,
-					   convert_virtual_to_index(sub_index, virtual_chapter),
+	result = uds_put_delta_index_entry(&record->delta_entry, address,
+					   convert_virtual_to_index(sub_index,
+								    virtual_chapter),
 					   record->is_found ? record->name->name : NULL);
 	if (unlikely(record->mutex != NULL))
 		uds_unlock_mutex(record->mutex);
@@ -592,8 +592,7 @@ int uds_put_volume_index_record(struct volume_index_record *record, u64 virtual_
 		record->is_found = true;
 		break;
 	case UDS_OVERFLOW:
-		uds_log_ratelimit(uds_log_warning_strerror,
-				  UDS_OVERFLOW,
+		uds_log_ratelimit(uds_log_warning_strerror, UDS_OVERFLOW,
 				  "Volume index entry dropped due to overflow condition");
 		uds_log_delta_index_entry(&record->delta_entry);
 		break;
@@ -609,7 +608,8 @@ int uds_remove_volume_index_record(struct volume_index_record *record)
 	int result;
 
 	if (!record->is_found)
-		return uds_log_warning_strerror(UDS_BAD_STATE, "illegal operation on new record");
+		return uds_log_warning_strerror(UDS_BAD_STATE,
+						"illegal operation on new record");
 
 	/* Mark the record so that it cannot be used again */
 	record->is_found = false;
@@ -680,8 +680,7 @@ void uds_set_volume_index_zone_open_chapter(struct volume_index *volume_index,
 {
 	struct mutex *mutex = &volume_index->zones[zone_number].hook_mutex;
 
-	set_volume_sub_index_zone_open_chapter(&volume_index->vi_non_hook,
-					       zone_number,
+	set_volume_sub_index_zone_open_chapter(&volume_index->vi_non_hook, zone_number,
 					       virtual_chapter);
 
 	/*
@@ -691,8 +690,7 @@ void uds_set_volume_index_zone_open_chapter(struct volume_index *volume_index,
 	if (has_sparse(volume_index)) {
 		uds_lock_mutex(mutex);
 		set_volume_sub_index_zone_open_chapter(&volume_index->vi_hook,
-						       zone_number,
-						       virtual_chapter);
+						       zone_number, virtual_chapter);
 		uds_unlock_mutex(mutex);
 	}
 }
@@ -701,7 +699,8 @@ void uds_set_volume_index_zone_open_chapter(struct volume_index *volume_index,
  * Set the newest open chapter number for the index, while also advancing the oldest valid chapter
  * number.
  */
-void uds_set_volume_index_open_chapter(struct volume_index *volume_index, u64 virtual_chapter)
+void uds_set_volume_index_open_chapter(struct volume_index *volume_index,
+				       u64 virtual_chapter)
 {
 	unsigned int zone;
 
@@ -709,13 +708,15 @@ void uds_set_volume_index_open_chapter(struct volume_index *volume_index, u64 vi
 		uds_set_volume_index_zone_open_chapter(volume_index, zone, virtual_chapter);
 }
 
-int uds_set_volume_index_record_chapter(struct volume_index_record *record, u64 virtual_chapter)
+int uds_set_volume_index_record_chapter(struct volume_index_record *record,
+					u64 virtual_chapter)
 {
 	const struct volume_sub_index *sub_index = record->sub_index;
 	int result;
 
 	if (!record->is_found)
-		return uds_log_warning_strerror(UDS_BAD_STATE, "illegal operation on new record");
+		return uds_log_warning_strerror(UDS_BAD_STATE,
+						"illegal operation on new record");
 
 	if (!is_virtual_chapter_indexed(record, virtual_chapter)) {
 		u64 low = get_zone_for_record(record)->virtual_chapter_low;
@@ -731,7 +732,8 @@ int uds_set_volume_index_record_chapter(struct volume_index_record *record, u64 
 	if (unlikely(record->mutex != NULL))
 		uds_lock_mutex(record->mutex);
 	result = uds_set_delta_entry_value(&record->delta_entry,
-					   convert_virtual_to_index(sub_index, virtual_chapter));
+					   convert_virtual_to_index(sub_index,
+								    virtual_chapter));
 	if (unlikely(record->mutex != NULL))
 		uds_unlock_mutex(record->mutex);
 	if (result != UDS_SUCCESS)
@@ -754,11 +756,8 @@ static u64 lookup_volume_sub_index_name(const struct volume_sub_index *sub_index
 	u32 rolling_chapter;
 	struct delta_index_entry delta_entry;
 
-	result = uds_get_delta_index_entry(&sub_index->delta_index,
-					   delta_list_number,
-					   address,
-					   name->name,
-					   &delta_entry);
+	result = uds_get_delta_index_entry(&sub_index->delta_index, delta_list_number,
+					   address, name->name, &delta_entry);
 	if (result != UDS_SUCCESS)
 		return NO_CHAPTER;
 
@@ -820,7 +819,8 @@ static int start_restoring_volume_sub_index(struct volume_sub_index *sub_index,
 		size_t offset = 0;
 		u32 j;
 
-		result = uds_read_from_buffered_reader(readers[i], buffer, sizeof(buffer));
+		result = uds_read_from_buffered_reader(readers[i], buffer,
+						       sizeof(buffer));
 		if (result != UDS_SUCCESS) {
 			return uds_log_warning_strerror(result,
 							"failed to read volume index header");
@@ -835,8 +835,7 @@ static int start_restoring_volume_sub_index(struct volume_sub_index *sub_index,
 		decode_u32_le(buffer, &offset, &header.list_count);
 
 		result = ASSERT(offset = sizeof(buffer),
-				"%zu bytes decoded of %zu expected",
-				offset,
+				"%zu bytes decoded of %zu expected", offset,
 				sizeof(buffer));
 		if (result != UDS_SUCCESS)
 			result = UDS_CORRUPT_DATA;
@@ -864,8 +863,7 @@ static int start_restoring_volume_sub_index(struct volume_sub_index *sub_index,
 							"Inconsistent volume index zone files: Chapter range is [%llu,%llu], chapter range %d is [%llu,%llu]",
 							(unsigned long long) virtual_chapter_low,
 							(unsigned long long) virtual_chapter_high,
-							i,
-							(unsigned long long) low,
+							i, (unsigned long long) low,
 							(unsigned long long) high);
 		} else if (virtual_chapter_low < header.virtual_chapter_low) {
 			virtual_chapter_low = header.virtual_chapter_low;
@@ -874,7 +872,8 @@ static int start_restoring_volume_sub_index(struct volume_sub_index *sub_index,
 		for (j = 0; j < header.list_count; j++) {
 			u8 decoded[sizeof(u64)];
 
-			result = uds_read_from_buffered_reader(readers[i], decoded, sizeof(u64));
+			result = uds_read_from_buffered_reader(readers[i], decoded,
+							       sizeof(u64));
 			if (result != UDS_SUCCESS) {
 				return uds_log_warning_strerror(result,
 								"failed to read volume index flush ranges");
@@ -891,7 +890,8 @@ static int start_restoring_volume_sub_index(struct volume_sub_index *sub_index,
 		sub_index->zones[z].virtual_chapter_high = virtual_chapter_high;
 	}
 
-	result = uds_start_restoring_delta_index(&sub_index->delta_index, readers, reader_count);
+	result = uds_start_restoring_delta_index(&sub_index->delta_index, readers,
+						 reader_count);
 	if (result != UDS_SUCCESS)
 		return uds_log_warning_strerror(result, "restoring delta index failed");
 
@@ -907,8 +907,7 @@ static int start_restoring_volume_index(struct volume_index *volume_index,
 
 	if (!has_sparse(volume_index)) {
 		return start_restoring_volume_sub_index(&volume_index->vi_non_hook,
-							buffered_readers,
-							reader_count);
+							buffered_readers, reader_count);
 	}
 
 	for (i = 0; i < reader_count; i++) {
@@ -916,7 +915,8 @@ static int start_restoring_volume_index(struct volume_index *volume_index,
 		u8 buffer[sizeof(struct volume_index_data)];
 		size_t offset = 0;
 
-		result = uds_read_from_buffered_reader(buffered_readers[i], buffer, sizeof(buffer));
+		result = uds_read_from_buffered_reader(buffered_readers[i], buffer,
+						       sizeof(buffer));
 		if (result != UDS_SUCCESS) {
 			return uds_log_warning_strerror(result,
 							"failed to read volume index header");
@@ -927,8 +927,7 @@ static int start_restoring_volume_index(struct volume_index *volume_index,
 		decode_u32_le(buffer, &offset, &header.sparse_sample_rate);
 
 		result = ASSERT(offset == sizeof(buffer),
-				"%zu bytes decoded of %zu expected",
-				offset,
+				"%zu bytes decoded of %zu expected", offset,
 				sizeof(buffer));
 		if (result != UDS_SUCCESS)
 			result = UDS_CORRUPT_DATA;
@@ -949,13 +948,11 @@ static int start_restoring_volume_index(struct volume_index *volume_index,
 	}
 
 	result = start_restoring_volume_sub_index(&volume_index->vi_non_hook,
-						  buffered_readers,
-						  reader_count);
+						  buffered_readers, reader_count);
 	if (result != UDS_SUCCESS)
 		return result;
 
-	return start_restoring_volume_sub_index(&volume_index->vi_hook,
-						buffered_readers,
+	return start_restoring_volume_sub_index(&volume_index->vi_hook, buffered_readers,
 						reader_count);
 }
 
@@ -964,8 +961,7 @@ static int finish_restoring_volume_sub_index(struct volume_sub_index *sub_index,
 					     unsigned int reader_count)
 {
 	return uds_finish_restoring_delta_index(&sub_index->delta_index,
-						buffered_readers,
-						reader_count);
+						buffered_readers, reader_count);
 }
 
 static int finish_restoring_volume_index(struct volume_index *volume_index,
@@ -975,8 +971,7 @@ static int finish_restoring_volume_index(struct volume_index *volume_index,
 	int result;
 
 	result = finish_restoring_volume_sub_index(&volume_index->vi_non_hook,
-						   buffered_readers,
-						   reader_count);
+						   buffered_readers, reader_count);
 	if ((result == UDS_SUCCESS) && has_sparse(volume_index)) {
 		result = finish_restoring_volume_sub_index(&volume_index->vi_hook,
 							   buffered_readers,
@@ -987,8 +982,7 @@ static int finish_restoring_volume_index(struct volume_index *volume_index,
 }
 
 int uds_load_volume_index(struct volume_index *volume_index,
-			  struct buffered_reader **readers,
-			  unsigned int reader_count)
+			  struct buffered_reader **readers, unsigned int reader_count)
 {
 	int result;
 
@@ -1032,28 +1026,30 @@ static int start_saving_volume_sub_index(const struct volume_sub_index *sub_inde
 	encode_u32_le(buffer, &offset, list_count);
 
 	result =  ASSERT(offset == sizeof(struct sub_index_data),
-			 "%zu bytes of config written, of %zu expected",
-			 offset,
+			 "%zu bytes of config written, of %zu expected", offset,
 			 sizeof(struct sub_index_data));
 	if (result != UDS_SUCCESS)
 		return result;
 
 	result = uds_write_to_buffered_writer(buffered_writer, buffer, offset);
 	if (result != UDS_SUCCESS)
-		return uds_log_warning_strerror(result, "failed to write volume index header");
+		return uds_log_warning_strerror(result,
+						"failed to write volume index header");
 
 	for (i = 0; i < list_count; i++) {
 		u8 encoded[sizeof(u64)];
 
 		put_unaligned_le64(sub_index->flush_chapters[first_list + i], &encoded);
-		result = uds_write_to_buffered_writer(buffered_writer, encoded, sizeof(u64));
+		result = uds_write_to_buffered_writer(buffered_writer, encoded,
+						      sizeof(u64));
 		if (result != UDS_SUCCESS) {
 			return uds_log_warning_strerror(result,
 							"failed to write volume index flush ranges");
 		}
 	}
 
-	return uds_start_saving_delta_index(&sub_index->delta_index, zone_number, buffered_writer);
+	return uds_start_saving_delta_index(&sub_index->delta_index, zone_number,
+					    buffered_writer);
 }
 
 static int start_saving_volume_index(const struct volume_index *volume_index,
@@ -1066,16 +1062,14 @@ static int start_saving_volume_index(const struct volume_index *volume_index,
 
 	if (!has_sparse(volume_index)) {
 		return start_saving_volume_sub_index(&volume_index->vi_non_hook,
-						     zone_number,
-						     writer);
+						     zone_number, writer);
 	}
 
 	memcpy(buffer, MAGIC_START_6, MAGIC_SIZE);
 	offset += MAGIC_SIZE;
 	encode_u32_le(buffer, &offset, volume_index->sparse_sample_rate);
 	result = ASSERT(offset == sizeof(struct volume_index_data),
-			"%zu bytes of header written, of %zu expected",
-			offset,
+			"%zu bytes of header written, of %zu expected", offset,
 			sizeof(struct volume_index_data));
 	if (result != UDS_SUCCESS)
 		return result;
@@ -1086,21 +1080,23 @@ static int start_saving_volume_index(const struct volume_index *volume_index,
 		return result;
 	}
 
-	result = start_saving_volume_sub_index(&volume_index->vi_non_hook, zone_number, writer);
+	result = start_saving_volume_sub_index(&volume_index->vi_non_hook, zone_number,
+					       writer);
 	if (result != UDS_SUCCESS)
 		return result;
 
-	return start_saving_volume_sub_index(&volume_index->vi_hook, zone_number, writer);
+	return start_saving_volume_sub_index(&volume_index->vi_hook, zone_number,
+					     writer);
 }
 
-static int
-finish_saving_volume_sub_index(const struct volume_sub_index *sub_index, unsigned int zone_number)
+static int finish_saving_volume_sub_index(const struct volume_sub_index *sub_index,
+					  unsigned int zone_number)
 {
 	return uds_finish_saving_delta_index(&sub_index->delta_index, zone_number);
 }
 
-static int
-finish_saving_volume_index(const struct volume_index *volume_index, unsigned int zone_number)
+static int finish_saving_volume_index(const struct volume_index *volume_index,
+				      unsigned int zone_number)
 {
 	int result;
 
@@ -1111,8 +1107,7 @@ finish_saving_volume_index(const struct volume_index *volume_index, unsigned int
 }
 
 int uds_save_volume_index(struct volume_index *volume_index,
-			  struct buffered_writer **writers,
-			  unsigned int writer_count)
+			  struct buffered_writer **writers, unsigned int writer_count)
 {
 	int result = UDS_SUCCESS;
 	unsigned int zone;
@@ -1178,8 +1173,7 @@ void uds_get_volume_index_stats(const struct volume_index *volume_index,
 }
 
 static int initialize_volume_sub_index(const struct configuration *config,
-				       u64 volume_nonce,
-				       u8 tag,
+				       u64 volume_nonce, u8 tag,
 				       struct volume_sub_index *sub_index)
 {
 	struct sub_index_parameters params = { .address_bits = 0 };
@@ -1202,12 +1196,9 @@ static int initialize_volume_sub_index(const struct configuration *config,
 	sub_index->chapter_zone_bits = params.chapter_size_in_bits / zone_count;
 	sub_index->volume_nonce = volume_nonce;
 
-	result = uds_initialize_delta_index(&sub_index->delta_index,
-					    zone_count,
-					    params.list_count,
-					    params.mean_delta,
-					    params.chapter_bits,
-					    params.memory_size,
+	result = uds_initialize_delta_index(&sub_index->delta_index, zone_count,
+					    params.list_count, params.mean_delta,
+					    params.chapter_bits, params.memory_size,
 					    tag);
 	if (result != UDS_SUCCESS)
 		return result;
@@ -1222,21 +1213,16 @@ static int initialize_volume_sub_index(const struct configuration *config,
 				  (zone_count * sizeof(struct volume_sub_index_zone)));
 
 	/* The following arrays are initialized to all zeros. */
-	result = uds_allocate(params.list_count,
-			      u64,
-			      "first chapter to flush",
+	result = uds_allocate(params.list_count, u64, "first chapter to flush",
 			      &sub_index->flush_chapters);
 	if (result != UDS_SUCCESS)
 		return result;
 
-	return uds_allocate(zone_count,
-			    struct volume_sub_index_zone,
-			    "volume index zones",
-			    &sub_index->zones);
+	return uds_allocate(zone_count, struct volume_sub_index_zone,
+			    "volume index zones", &sub_index->zones);
 }
 
-int uds_make_volume_index(const struct configuration *config,
-			  u64 volume_nonce,
+int uds_make_volume_index(const struct configuration *config, u64 volume_nonce,
 			  struct volume_index **volume_index_ptr)
 {
 	struct split_config split;
@@ -1251,9 +1237,7 @@ int uds_make_volume_index(const struct configuration *config,
 	volume_index->zone_count = config->zone_count;
 
 	if (!uds_is_sparse_geometry(config->geometry)) {
-		result = initialize_volume_sub_index(config,
-						     volume_nonce,
-						     'm',
+		result = initialize_volume_sub_index(config, volume_nonce, 'm',
 						     &volume_index->vi_non_hook);
 		if (result != UDS_SUCCESS) {
 			uds_free_volume_index(volume_index);
@@ -1267,10 +1251,8 @@ int uds_make_volume_index(const struct configuration *config,
 
 	volume_index->sparse_sample_rate = config->sparse_sample_rate;
 
-	result = uds_allocate(config->zone_count,
-			      struct volume_index_zone,
-			      "volume index zones",
-			      &volume_index->zones);
+	result = uds_allocate(config->zone_count, struct volume_index_zone,
+			      "volume index zones", &volume_index->zones);
 	if (result != UDS_SUCCESS) {
 		uds_free_volume_index(volume_index);
 		return result;
@@ -1285,22 +1267,20 @@ int uds_make_volume_index(const struct configuration *config,
 	}
 
 	split_configuration(config, &split);
-	result = initialize_volume_sub_index(&split.non_hook_config,
-					     volume_nonce,
-					     'd',
+	result = initialize_volume_sub_index(&split.non_hook_config, volume_nonce, 'd',
 					     &volume_index->vi_non_hook);
 	if (result != UDS_SUCCESS) {
 		uds_free_volume_index(volume_index);
-		return uds_log_error_strerror(result, "Error creating non hook volume index");
+		return uds_log_error_strerror(result,
+					      "Error creating non hook volume index");
 	}
 
-	result = initialize_volume_sub_index(&split.hook_config,
-					     volume_nonce,
-					     's',
+	result = initialize_volume_sub_index(&split.hook_config, volume_nonce, 's',
 					     &volume_index->vi_hook);
 	if (result != UDS_SUCCESS) {
 		uds_free_volume_index(volume_index);
-		return uds_log_error_strerror(result, "Error creating hook volume index");
+		return uds_log_error_strerror(result,
+					      "Error creating hook volume index");
 	}
 
 	volume_index->memory_size =

--- a/drivers/md/dm-vdo/volume-index.c
+++ b/drivers/md/dm-vdo/volume-index.c
@@ -220,14 +220,17 @@ static int compute_volume_sub_index_parameters(const struct configuration *confi
 	params->list_count = max(delta_list_records / DELTA_LIST_SIZE, min_delta_lists);
 	params->address_bits = bits_per(address_count - 1);
 	params->chapter_bits = bits_per(rounded_chapters - 1);
-	if ((u32) params->list_count != params->list_count)
+	if ((u32) params->list_count != params->list_count) {
 		return uds_log_warning_strerror(UDS_INVALID_ARGUMENT,
 						"cannot initialize volume index with %llu delta lists",
 						(unsigned long long) params->list_count);
-	if (params->address_bits > 31)
+	}
+
+	if (params->address_bits > 31) {
 		return uds_log_warning_strerror(UDS_INVALID_ARGUMENT,
 						"cannot initialize volume index with %u address bits",
 						params->address_bits);
+	}
 
 	/*
 	 * The probability that a given delta list is not touched during the writing of an entire
@@ -353,6 +356,7 @@ static int compute_volume_index_save_bytes(const struct configuration *config, s
 	result = compute_volume_sub_index_save_bytes(&split.hook_config, &hook_bytes);
 	if (result != UDS_SUCCESS)
 		return result;
+
 	result = compute_volume_sub_index_save_bytes(&split.non_hook_config, &non_hook_bytes);
 	if (result != UDS_SUCCESS)
 		return result;
@@ -387,6 +391,7 @@ static inline int flush_invalid_entries(struct volume_index_record *record,
 	result = uds_next_delta_index_entry(&record->delta_entry);
 	if (result != UDS_SUCCESS)
 		return result;
+
 	while (!record->delta_entry.at_end) {
 		u32 index_chapter = uds_get_delta_entry_value(&record->delta_entry);
 		u32 relative_chapter = ((index_chapter - flush_range->chapter_start) &
@@ -397,10 +402,12 @@ static inline int flush_invalid_entries(struct volume_index_record *record,
 				*next_chapter_to_invalidate = relative_chapter;
 			break;
 		}
+
 		result = uds_remove_delta_index_entry(&record->delta_entry);
 		if (result != UDS_SUCCESS)
 			return result;
 	}
+
 	return UDS_SUCCESS;
 }
 
@@ -421,6 +428,7 @@ static int get_volume_index_entry(struct volume_index_record *record,
 					      &record->delta_entry);
 	if (result != UDS_SUCCESS)
 		return result;
+
 	do {
 		result = flush_invalid_entries(record, flush_range, &next_chapter_to_invalidate);
 		if (result != UDS_SUCCESS)
@@ -442,13 +450,16 @@ static int get_volume_index_entry(struct volume_index_record *record,
 						       &next_chapter_to_invalidate);
 			if (result != UDS_SUCCESS)
 				return result;
+
 			if (other_record.delta_entry.at_end ||
 			    !other_record.delta_entry.is_collision)
 				break;
+
 			result = uds_get_delta_entry_collision(&other_record.delta_entry,
 							       collision_name);
 			if (result != UDS_SUCCESS)
 				return result;
+
 			if (memcmp(collision_name, record->name, UDS_RECORD_NAME_SIZE) == 0) {
 				*record = other_record;
 				break;
@@ -505,14 +516,18 @@ static int get_volume_sub_index_record(struct volume_sub_index *sub_index,
 						   name->name,
 						   &record->delta_entry);
 	}
+
 	if (result != UDS_SUCCESS)
 		return result;
-	record->is_found = (!record->delta_entry.at_end && (record->delta_entry.key == address));
+
+	record->is_found =
+		(!record->delta_entry.at_end && (record->delta_entry.key == address));
 	if (record->is_found) {
 		u32 index_chapter = uds_get_delta_entry_value(&record->delta_entry);
 
 		record->virtual_chapter = convert_index_to_virtual(record, index_chapter);
 	}
+
 	record->is_collision = record->delta_entry.is_collision;
 	return UDS_SUCCESS;
 }
@@ -529,7 +544,8 @@ int uds_get_volume_index_record(struct volume_index *volume_index,
 		 * this thread is finding the volume index record. Due to the lazy LRU flushing of
 		 * the volume index, uds_get_volume_index_record() is not a read-only operation.
 		 */
-		unsigned int zone = get_volume_sub_index_zone(&volume_index->vi_hook, name);
+		unsigned int zone =
+			get_volume_sub_index_zone(&volume_index->vi_hook, name);
 		struct mutex *mutex = &volume_index->zones[zone].hook_mutex;
 
 		uds_lock_mutex(mutex);
@@ -540,6 +556,7 @@ int uds_get_volume_index_record(struct volume_index *volume_index,
 	} else {
 		result = get_volume_sub_index_record(&volume_index->vi_non_hook, name, record);
 	}
+
 	return result;
 }
 
@@ -583,6 +600,7 @@ int uds_put_volume_index_record(struct volume_index_record *record, u64 virtual_
 	default:
 		break;
 	}
+
 	return result;
 }
 
@@ -592,6 +610,7 @@ int uds_remove_volume_index_record(struct volume_index_record *record)
 
 	if (!record->is_found)
 		return uds_log_warning_strerror(UDS_BAD_STATE, "illegal operation on new record");
+
 	/* Mark the record so that it cannot be used again */
 	record->is_found = false;
 	if (unlikely(record->mutex != NULL))
@@ -697,6 +716,7 @@ int uds_set_volume_index_record_chapter(struct volume_index_record *record, u64 
 
 	if (!record->is_found)
 		return uds_log_warning_strerror(UDS_BAD_STATE, "illegal operation on new record");
+
 	if (!is_virtual_chapter_indexed(record, virtual_chapter)) {
 		u64 low = get_zone_for_record(record)->virtual_chapter_low;
 		u64 high = get_zone_for_record(record)->virtual_chapter_high;
@@ -707,6 +727,7 @@ int uds_set_volume_index_record_chapter(struct volume_index_record *record, u64 
 						(unsigned long long) low,
 						(unsigned long long) high);
 	}
+
 	if (unlikely(record->mutex != NULL))
 		uds_lock_mutex(record->mutex);
 	result = uds_set_delta_entry_value(&record->delta_entry,
@@ -715,6 +736,7 @@ int uds_set_volume_index_record_chapter(struct volume_index_record *record, u64 
 		uds_unlock_mutex(record->mutex);
 	if (result != UDS_SUCCESS)
 		return result;
+
 	record->virtual_chapter = virtual_chapter;
 	return UDS_SUCCESS;
 }
@@ -799,9 +821,10 @@ static int start_restoring_volume_sub_index(struct volume_sub_index *sub_index,
 		u32 j;
 
 		result = uds_read_from_buffered_reader(readers[i], buffer, sizeof(buffer));
-		if (result != UDS_SUCCESS)
+		if (result != UDS_SUCCESS) {
 			return uds_log_warning_strerror(result,
 							"failed to read volume index header");
+		}
 
 		memcpy(&header.magic, buffer, MAGIC_SIZE);
 		offset += MAGIC_SIZE;
@@ -818,15 +841,17 @@ static int start_restoring_volume_sub_index(struct volume_sub_index *sub_index,
 		if (result != UDS_SUCCESS)
 			result = UDS_CORRUPT_DATA;
 
-		if (memcmp(header.magic, MAGIC_START_5, MAGIC_SIZE) != 0)
+		if (memcmp(header.magic, MAGIC_START_5, MAGIC_SIZE) != 0) {
 			return uds_log_warning_strerror(UDS_CORRUPT_DATA,
 							"volume index file had bad magic number");
+		}
 
-		if (sub_index->volume_nonce == 0)
+		if (sub_index->volume_nonce == 0) {
 			sub_index->volume_nonce = header.volume_nonce;
-		else if (header.volume_nonce != sub_index->volume_nonce)
+		} else if (header.volume_nonce != sub_index->volume_nonce) {
 			return uds_log_warning_strerror(UDS_CORRUPT_DATA,
 							"volume index volume nonce incorrect");
+		}
 
 		if (i == 0) {
 			virtual_chapter_low = header.virtual_chapter_low;
@@ -850,9 +875,10 @@ static int start_restoring_volume_sub_index(struct volume_sub_index *sub_index,
 			u8 decoded[sizeof(u64)];
 
 			result = uds_read_from_buffered_reader(readers[i], decoded, sizeof(u64));
-			if (result != UDS_SUCCESS)
+			if (result != UDS_SUCCESS) {
 				return uds_log_warning_strerror(result,
 								"failed to read volume index flush ranges");
+			}
 
 			sub_index->flush_chapters[header.first_list + j] =
 				get_unaligned_le64(decoded);
@@ -879,10 +905,11 @@ static int start_restoring_volume_index(struct volume_index *volume_index,
 	unsigned int i;
 	int result;
 
-	if (!has_sparse(volume_index))
+	if (!has_sparse(volume_index)) {
 		return start_restoring_volume_sub_index(&volume_index->vi_non_hook,
 							buffered_readers,
 							reader_count);
+	}
 
 	for (i = 0; i < reader_count; i++) {
 		struct volume_index_data header;
@@ -890,9 +917,10 @@ static int start_restoring_volume_index(struct volume_index *volume_index,
 		size_t offset = 0;
 
 		result = uds_read_from_buffered_reader(buffered_readers[i], buffer, sizeof(buffer));
-		if (result != UDS_SUCCESS)
+		if (result != UDS_SUCCESS) {
 			return uds_log_warning_strerror(result,
 							"failed to read volume index header");
+		}
 
 		memcpy(&header.magic, buffer, MAGIC_SIZE);
 		offset += MAGIC_SIZE;
@@ -925,6 +953,7 @@ static int start_restoring_volume_index(struct volume_index *volume_index,
 						  reader_count);
 	if (result != UDS_SUCCESS)
 		return result;
+
 	return start_restoring_volume_sub_index(&volume_index->vi_hook,
 						buffered_readers,
 						reader_count);
@@ -948,10 +977,12 @@ static int finish_restoring_volume_index(struct volume_index *volume_index,
 	result = finish_restoring_volume_sub_index(&volume_index->vi_non_hook,
 						   buffered_readers,
 						   reader_count);
-	if ((result == UDS_SUCCESS) && has_sparse(volume_index))
+	if ((result == UDS_SUCCESS) && has_sparse(volume_index)) {
 		result = finish_restoring_volume_sub_index(&volume_index->vi_hook,
 							   buffered_readers,
 							   reader_count);
+	}
+
 	return result;
 }
 
@@ -1016,9 +1047,10 @@ static int start_saving_volume_sub_index(const struct volume_sub_index *sub_inde
 
 		put_unaligned_le64(sub_index->flush_chapters[first_list + i], &encoded);
 		result = uds_write_to_buffered_writer(buffered_writer, encoded, sizeof(u64));
-		if (result != UDS_SUCCESS)
+		if (result != UDS_SUCCESS) {
 			return uds_log_warning_strerror(result,
 							"failed to write volume index flush ranges");
+		}
 	}
 
 	return uds_start_saving_delta_index(&sub_index->delta_index, zone_number, buffered_writer);
@@ -1032,10 +1064,11 @@ static int start_saving_volume_index(const struct volume_index *volume_index,
 	size_t offset = 0;
 	int result;
 
-	if (!has_sparse(volume_index))
+	if (!has_sparse(volume_index)) {
 		return start_saving_volume_sub_index(&volume_index->vi_non_hook,
 						     zone_number,
 						     writer);
+	}
 
 	memcpy(buffer, MAGIC_START_6, MAGIC_SIZE);
 	offset += MAGIC_SIZE;

--- a/drivers/md/dm-vdo/volume-index.h
+++ b/drivers/md/dm-vdo/volume-index.h
@@ -146,9 +146,8 @@ int __must_check uds_compute_volume_index_save_blocks(const struct configuration
 						      size_t block_size,
 						      u64 *block_count);
 
-unsigned int __must_check
-uds_get_volume_index_zone(const struct volume_index *volume_index,
-			  const struct uds_record_name *name);
+unsigned int __must_check uds_get_volume_index_zone(const struct volume_index *volume_index,
+						    const struct uds_record_name *name);
 
 bool __must_check uds_is_volume_index_sample(const struct volume_index *volume_index,
 					     const struct uds_record_name *name);
@@ -164,15 +163,16 @@ int __must_check uds_get_volume_index_record(struct volume_index *volume_index,
 					     const struct uds_record_name *name,
 					     struct volume_index_record *record);
 
-int __must_check
-uds_put_volume_index_record(struct volume_index_record *record, u64 virtual_chapter);
+int __must_check uds_put_volume_index_record(struct volume_index_record *record,
+					     u64 virtual_chapter);
 
 int __must_check uds_remove_volume_index_record(struct volume_index_record *record);
 
-int __must_check
-uds_set_volume_index_record_chapter(struct volume_index_record *record, u64 virtual_chapter);
+int __must_check uds_set_volume_index_record_chapter(struct volume_index_record *record,
+						     u64 virtual_chapter);
 
-void uds_set_volume_index_open_chapter(struct volume_index *volume_index, u64 virtual_chapter);
+void uds_set_volume_index_open_chapter(struct volume_index *volume_index,
+				       u64 virtual_chapter);
 
 void uds_set_volume_index_zone_open_chapter(struct volume_index *volume_index,
 					    unsigned int zone_number,

--- a/drivers/md/dm-vdo/volume.c
+++ b/drivers/md/dm-vdo/volume.c
@@ -105,8 +105,8 @@ static u32 map_to_physical_page(const struct geometry *geometry, u32 chapter, u3
 	return HEADER_PAGES_PER_VOLUME + (geometry->pages_per_chapter * chapter) + page;
 }
 
-static inline union invalidate_counter
-get_invalidate_counter(struct page_cache *cache, unsigned int zone_number)
+static inline union invalidate_counter get_invalidate_counter(struct page_cache *cache,
+							      unsigned int zone_number)
 {
 	return (union invalidate_counter) {
 		.value = READ_ONCE(cache->search_pending_counters[zone_number].atomic_value),
@@ -127,8 +127,8 @@ static inline bool search_pending(union invalidate_counter invalidate_counter)
 }
 
 /* Lock the cache for a zone in order to search for a page. */
-static void
-begin_pending_search(struct page_cache *cache, u32 physical_page, unsigned int zone_number)
+static void begin_pending_search(struct page_cache *cache, u32 physical_page,
+				 unsigned int zone_number)
 {
 	union invalidate_counter invalidate_counter =
 		get_invalidate_counter(cache, zone_number);
@@ -137,8 +137,7 @@ begin_pending_search(struct page_cache *cache, u32 physical_page, unsigned int z
 	invalidate_counter.counter++;
 	set_invalidate_counter(cache, zone_number, invalidate_counter);
 	ASSERT_LOG_ONLY(search_pending(invalidate_counter),
-			"Search is pending for zone %u",
-			zone_number);
+			"Search is pending for zone %u", zone_number);
 	/*
 	 * This memory barrier ensures that the write to the invalidate counter is seen by other
 	 * threads before this thread accesses the cached page. The corresponding read memory
@@ -161,8 +160,7 @@ static void end_pending_search(struct page_cache *cache, unsigned int zone_numbe
 
 	invalidate_counter = get_invalidate_counter(cache, zone_number);
 	ASSERT_LOG_ONLY(search_pending(invalidate_counter),
-			"Search is pending for zone %u",
-			zone_number);
+			"Search is pending for zone %u", zone_number);
 	invalidate_counter.counter++;
 	set_invalidate_counter(cache, zone_number, invalidate_counter);
 }
@@ -191,7 +189,8 @@ static void wait_for_pending_searches(struct page_cache *cache, u32 physical_pag
 			 *
 			 * FIXME: Investigate using wait_event() to wait for the search to finish.
 			 */
-			while (initial_counters[i].value == get_invalidate_counter(cache, i).value)
+			while (initial_counters[i].value ==
+			       get_invalidate_counter(cache, i).value)
 				cond_resched();
 		}
 	}
@@ -255,8 +254,8 @@ static struct cached_page *select_victim_in_cache(struct page_cache *cache)
 }
 
 /* Make a newly filled cache entry available to other threads. */
-static int
-put_page_in_cache(struct page_cache *cache, u32 physical_page, struct cached_page *page)
+static int put_page_in_cache(struct page_cache *cache, u32 physical_page,
+			     struct cached_page *page)
 {
 	int result;
 
@@ -281,8 +280,7 @@ put_page_in_cache(struct page_cache *cache, u32 physical_page, struct cached_pag
 	return UDS_SUCCESS;
 }
 
-static void cancel_page_in_cache(struct page_cache *cache,
-				 u32 physical_page,
+static void cancel_page_in_cache(struct page_cache *cache, u32 physical_page,
 				 struct cached_page *page)
 {
 	int result;
@@ -314,8 +312,8 @@ static inline bool read_queue_is_full(struct page_cache *cache)
 	return cache->read_queue_first == next_queue_position(cache->read_queue_last);
 }
 
-static bool
-enqueue_read(struct page_cache *cache, struct uds_request *request, u32 physical_page)
+static bool enqueue_read(struct page_cache *cache, struct uds_request *request,
+			 u32 physical_page)
 {
 	struct queued_read *queue_entry;
 	u16 last = cache->read_queue_last;
@@ -355,13 +353,14 @@ enqueue_read(struct page_cache *cache, struct uds_request *request, u32 physical
 	return true;
 }
 
-static void
-enqueue_page_read(struct volume *volume, struct uds_request *request, u32 physical_page)
+static void enqueue_page_read(struct volume *volume, struct uds_request *request,
+			      u32 physical_page)
 {
 	/* Mark the page as queued, so that chapter invalidation knows to cancel a read. */
 	while (!enqueue_read(&volume->page_cache, request, physical_page)) {
 		uds_log_debug("Read queue full, waiting for reads to finish");
-		uds_wait_cond(&volume->read_threads_read_done_cond, &volume->read_threads_mutex);
+		uds_wait_cond(&volume->read_threads_read_done_cond,
+			      &volume->read_threads_mutex);
 	}
 
 	uds_signal_cond(&volume->read_threads_cond);
@@ -416,10 +415,8 @@ static inline struct queued_read *wait_to_reserve_read_queue_entry(struct volume
 	return queue_entry;
 }
 
-static int init_chapter_index_page(const struct volume *volume,
-				   u8 *index_page,
-				   u32 chapter,
-				   u32 index_page_number,
+static int init_chapter_index_page(const struct volume *volume, u8 *index_page,
+				   u32 chapter, u32 index_page_number,
 				   struct delta_index_page *chapter_index_page)
 {
 	u64 ci_virtual;
@@ -429,25 +426,19 @@ static int init_chapter_index_page(const struct volume *volume,
 	struct geometry *geometry = volume->geometry;
 	int result;
 
-	result = uds_initialize_chapter_index_page(chapter_index_page,
-						   geometry,
-						   index_page,
-						   volume->nonce);
+	result = uds_initialize_chapter_index_page(chapter_index_page, geometry,
+						   index_page, volume->nonce);
 	if (volume->lookup_mode == LOOKUP_FOR_REBUILD)
 		return result;
 
 	if (result != UDS_SUCCESS) {
 		return uds_log_error_strerror(result,
 					      "Reading chapter index page for chapter %u page %u",
-					      chapter,
-					      index_page_number);
+					      chapter, index_page_number);
 	}
 
-	uds_get_list_number_bounds(volume->index_page_map,
-				   chapter,
-				   index_page_number,
-				   &lowest_list,
-				   &highest_list);
+	uds_get_list_number_bounds(volume->index_page_map, chapter, index_page_number,
+				   &lowest_list, &highest_list);
 	ci_virtual = chapter_index_page->virtual_chapter_number;
 	ci_chapter = uds_map_to_physical_chapter(geometry, ci_virtual);
 	if ((chapter == ci_chapter) &&
@@ -458,10 +449,7 @@ static int init_chapter_index_page(const struct volume *volume,
 	uds_log_warning("Index page map updated to %llu",
 			(unsigned long long) volume->index_page_map->last_update);
 	uds_log_warning("Page map expects that chapter %u page %u has range %u to %u, but chapter index page has chapter %llu with range %u to %u",
-			chapter,
-			index_page_number,
-			lowest_list,
-			highest_list,
+			chapter, index_page_number, lowest_list, highest_list,
 			(unsigned long long) ci_virtual,
 			chapter_index_page->lowest_list_number,
 			chapter_index_page->highest_list_number);
@@ -469,25 +457,20 @@ static int init_chapter_index_page(const struct volume *volume,
 				      "index page map mismatch with chapter index");
 }
 
-static int initialize_index_page(const struct volume *volume,
-				 u32 physical_page,
+static int initialize_index_page(const struct volume *volume, u32 physical_page,
 				 struct cached_page *page)
 {
 	u32 chapter = map_to_chapter_number(volume->geometry, physical_page);
 	u32 index_page_number = map_to_page_number(volume->geometry, physical_page);
 
-	return init_chapter_index_page(volume,
-				       dm_bufio_get_block_data(page->buffer),
-				       chapter,
-				       index_page_number,
-				       &page->index_page);
+	return init_chapter_index_page(volume, dm_bufio_get_block_data(page->buffer),
+				       chapter, index_page_number, &page->index_page);
 }
 
-static bool
-search_record_page(const u8 record_page[],
-		   const struct uds_record_name *name,
-		   const struct geometry *geometry,
-		   struct uds_record_data *metadata)
+static bool search_record_page(const u8 record_page[],
+			       const struct uds_record_name *name,
+			       const struct geometry *geometry,
+			       struct uds_record_data *metadata)
 {
 	/*
 	 * The array of records is sorted by name and stored as a binary tree in heap order, so the
@@ -521,10 +504,8 @@ search_record_page(const u8 record_page[],
  * index page again. We use the location, virtual_chapter, and old_metadata fields in the request
  * to allow the index code to know where to begin processing the request again.
  */
-static int search_page(struct cached_page *page,
-		       const struct volume *volume,
-		       struct uds_request *request,
-		       u32 physical_page)
+static int search_page(struct cached_page *page, const struct volume *volume,
+		       struct uds_request *request, u32 physical_page)
 {
 	int result;
 	enum uds_index_region location;
@@ -532,8 +513,7 @@ static int search_page(struct cached_page *page,
 
 	if (is_record_page(volume->geometry, physical_page)) {
 		if (search_record_page(dm_bufio_get_block_data(page->buffer),
-				       &request->record_name,
-				       volume->geometry,
+				       &request->record_name, volume->geometry,
 				       &request->old_metadata))
 			location = UDS_LOCATION_RECORD_PAGE_LOOKUP;
 		else
@@ -617,7 +597,8 @@ static int process_entry(struct volume *volume, struct queued_read *entry)
 	return result;
 }
 
-static void release_queued_requests(struct volume *volume, struct queued_read *entry, int result)
+static void release_queued_requests(struct volume *volume, struct queued_read *entry,
+				    int result)
 {
 	struct page_cache *cache = &volume->page_cache;
 	u16 next_read = cache->read_queue_next_read;
@@ -661,10 +642,8 @@ static void read_thread_function(void *arg)
 	uds_log_debug("reader done");
 }
 
-static void get_page_and_index(struct page_cache *cache,
-			       u32 physical_page,
-			       int *queue_index,
-			       struct cached_page **page_ptr)
+static void get_page_and_index(struct page_cache *cache, u32 physical_page,
+			       int *queue_index, struct cached_page **page_ptr)
 {
 	u16 index_value;
 	u16 index;
@@ -700,8 +679,8 @@ static void get_page_and_index(struct page_cache *cache,
 	*queue_index = queued ? index : -1;
 }
 
-static void
-get_page_from_cache(struct page_cache *cache, u32 physical_page, struct cached_page **page)
+static void get_page_from_cache(struct page_cache *cache, u32 physical_page,
+				struct cached_page **page)
 {
 	/*
 	 * ASSERTION: We are in a zone thread.
@@ -712,8 +691,7 @@ get_page_from_cache(struct page_cache *cache, u32 physical_page, struct cached_p
 	get_page_and_index(cache, physical_page, &queue_index, page);
 }
 
-static int read_page_locked(struct volume *volume,
-			    u32 physical_page,
+static int read_page_locked(struct volume *volume, u32 physical_page,
 			    struct cached_page **page_ptr)
 {
 	int result = UDS_SUCCESS;
@@ -753,8 +731,8 @@ static int read_page_locked(struct volume *volume,
 }
 
 /* Retrieve a page from the cache while holding the read threads mutex. */
-static int
-get_volume_page_locked(struct volume *volume, u32 physical_page, struct cached_page **page_ptr)
+static int get_volume_page_locked(struct volume *volume, u32 physical_page,
+				  struct cached_page **page_ptr)
 {
 	int result;
 	struct cached_page *page = NULL;
@@ -773,11 +751,8 @@ get_volume_page_locked(struct volume *volume, u32 physical_page, struct cached_p
 }
 
 /* Retrieve a page from the cache while holding a search_pending lock. */
-static int
-get_volume_page_protected(struct volume *volume,
-			  struct uds_request *request,
-			  u32 physical_page,
-			  struct cached_page **page_ptr)
+static int get_volume_page_protected(struct volume *volume, struct uds_request *request,
+				     u32 physical_page, struct cached_page **page_ptr)
 {
 	struct cached_page *page;
 
@@ -813,7 +788,8 @@ get_volume_page_protected(struct volume *volume,
 		 * the order does not matter for correctness as it does below.
 		 */
 		uds_unlock_mutex(&volume->read_threads_mutex);
-		begin_pending_search(&volume->page_cache, physical_page, request->zone_number);
+		begin_pending_search(&volume->page_cache, physical_page,
+				     request->zone_number);
 		return UDS_QUEUED;
 	}
 
@@ -828,9 +804,7 @@ get_volume_page_protected(struct volume *volume,
 	return UDS_SUCCESS;
 }
 
-static int get_volume_page(struct volume *volume,
-			   u32 chapter,
-			   u32 page_number,
+static int get_volume_page(struct volume *volume, u32 chapter, u32 page_number,
 			   struct cached_page **page_ptr)
 {
 	int result;
@@ -842,7 +816,8 @@ static int get_volume_page(struct volume *volume,
 	return result;
 }
 
-int uds_get_volume_record_page(struct volume *volume, u32 chapter, u32 page_number, u8 **data_ptr)
+int uds_get_volume_record_page(struct volume *volume, u32 chapter, u32 page_number,
+			       u8 **data_ptr)
 {
 	int result;
 	struct cached_page *page = NULL;
@@ -853,9 +828,7 @@ int uds_get_volume_record_page(struct volume *volume, u32 chapter, u32 page_numb
 	return result;
 }
 
-int uds_get_volume_index_page(struct volume *volume,
-			      u32 chapter,
-			      u32 page_number,
+int uds_get_volume_index_page(struct volume *volume, u32 chapter, u32 page_number,
 			      struct delta_index_page **index_page_ptr)
 {
 	int result;
@@ -871,15 +844,14 @@ int uds_get_volume_index_page(struct volume *volume,
  * Find the record page associated with a name in a given index page. This will return UDS_QUEUED
  * if the page in question must be read from storage.
  */
-static int search_cached_index_page(struct volume *volume,
-				    struct uds_request *request,
-				    u32 chapter,
-				    u32 index_page_number,
+static int search_cached_index_page(struct volume *volume, struct uds_request *request,
+				    u32 chapter, u32 index_page_number,
 				    u16 *record_page_number)
 {
 	int result;
 	struct cached_page *page = NULL;
-	u32 physical_page = map_to_physical_page(volume->geometry, chapter, index_page_number);
+	u32 physical_page = map_to_physical_page(volume->geometry, chapter,
+						 index_page_number);
 
 	/*
 	 * Make sure the invalidate counter is updated before we try and read the mapping. This
@@ -895,8 +867,7 @@ static int search_cached_index_page(struct volume *volume,
 		return result;
 	}
 
-	result = uds_search_chapter_index_page(&page->index_page,
-					       volume->geometry,
+	result = uds_search_chapter_index_page(&page->index_page, volume->geometry,
 					       &request->record_name,
 					       record_page_number);
 	end_pending_search(&volume->page_cache, request->zone_number);
@@ -907,11 +878,8 @@ static int search_cached_index_page(struct volume *volume,
  * Find the metadata associated with a name in a given record page. This will return UDS_QUEUED if
  * the page in question must be read from storage.
  */
-int uds_search_cached_record_page(struct volume *volume,
-				  struct uds_request *request,
-				  u32 chapter,
-				  u16 record_page_number,
-				  bool *found)
+int uds_search_cached_record_page(struct volume *volume, struct uds_request *request,
+				  u32 chapter, u16 record_page_number, bool *found)
 {
 	struct cached_page *record_page;
 	struct geometry *geometry = volume->geometry;
@@ -923,8 +891,7 @@ int uds_search_cached_record_page(struct volume *volume,
 		return UDS_SUCCESS;
 
 	result = ASSERT(record_page_number < geometry->record_pages_per_chapter,
-			"0 <= %d < %u",
-			record_page_number,
+			"0 <= %d < %u", record_page_number,
 			geometry->record_pages_per_chapter);
 	if (result != UDS_SUCCESS)
 		return result;
@@ -948,9 +915,7 @@ int uds_search_cached_record_page(struct volume *volume,
 	}
 
 	if (search_record_page(dm_bufio_get_block_data(record_page->buffer),
-			       &request->record_name,
-			       geometry,
-			       &request->old_metadata))
+			       &request->record_name, geometry, &request->old_metadata))
 		*found = true;
 
 	end_pending_search(&volume->page_cache, request->zone_number);
@@ -965,8 +930,7 @@ void uds_prefetch_volume_chapter(const struct volume *volume, u32 chapter)
 	dm_bufio_prefetch(volume->client, physical_page, geometry->pages_per_chapter);
 }
 
-int uds_read_chapter_index_from_volume(const struct volume *volume,
-				       u64 virtual_chapter,
+int uds_read_chapter_index_from_volume(const struct volume *volume, u64 virtual_chapter,
 				       struct dm_buffer *volume_buffers[],
 				       struct delta_index_page index_pages[])
 {
@@ -980,7 +944,8 @@ int uds_read_chapter_index_from_volume(const struct volume *volume,
 	for (i = 0; i < geometry->index_pages_per_chapter; i++) {
 		u8 *index_page;
 
-		index_page = dm_bufio_read(volume->client, physical_page + i, &volume_buffers[i]);
+		index_page = dm_bufio_read(volume->client, physical_page + i,
+					   &volume_buffers[i]);
 		if (IS_ERR(index_page)) {
 			result = -PTR_ERR(index_page);
 			uds_log_warning_strerror(result,
@@ -989,10 +954,7 @@ int uds_read_chapter_index_from_volume(const struct volume *volume,
 			return result;
 		}
 
-		result = init_chapter_index_page(volume,
-						 index_page,
-						 physical_chapter,
-						 i,
+		result = init_chapter_index_page(volume, index_page, physical_chapter, i,
 						 &index_pages[i]);
 		if (result != UDS_SUCCESS)
 			return result;
@@ -1001,7 +963,8 @@ int uds_read_chapter_index_from_volume(const struct volume *volume,
 	return UDS_SUCCESS;
 }
 
-int uds_search_volume_page_cache(struct volume *volume, struct uds_request *request, bool *found)
+int uds_search_volume_page_cache(struct volume *volume, struct uds_request *request,
+				 bool *found)
 {
 	int result;
 	u32 physical_chapter =
@@ -1016,26 +979,20 @@ int uds_search_volume_page_cache(struct volume *volume, struct uds_request *requ
 	if (request->location == UDS_LOCATION_INDEX_PAGE_LOOKUP) {
 		record_page_number = *((u16 *) &request->old_metadata);
 	} else {
-		result = search_cached_index_page(volume,
-						  request,
-						  physical_chapter,
+		result = search_cached_index_page(volume, request, physical_chapter,
 						  index_page_number,
 						  &record_page_number);
 		if (result != UDS_SUCCESS)
 			return result;
 	}
 
-	return uds_search_cached_record_page(volume,
-					     request,
-					     physical_chapter,
-					     record_page_number,
-					     found);
+	return uds_search_cached_record_page(volume, request, physical_chapter,
+					     record_page_number, found);
 }
 
 int uds_search_volume_page_cache_for_rebuild(struct volume *volume,
 					     const struct uds_record_name *name,
-					     u64 virtual_chapter,
-					     bool *found)
+					     u64 virtual_chapter, bool *found)
 {
 	int result;
 	struct geometry *geometry = volume->geometry;
@@ -1047,14 +1004,13 @@ int uds_search_volume_page_cache_for_rebuild(struct volume *volume,
 
 	*found = false;
 	index_page_number =
-		uds_find_index_page_number(volume->index_page_map, name, physical_chapter);
+		uds_find_index_page_number(volume->index_page_map, name,
+					   physical_chapter);
 	result = get_volume_page(volume, physical_chapter, index_page_number, &page);
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = uds_search_chapter_index_page(&page->index_page,
-					       geometry,
-					       name,
+	result = uds_search_chapter_index_page(&page->index_page, geometry, name,
 					       &record_page_number);
 	if (result != UDS_SUCCESS)
 		return result;
@@ -1067,7 +1023,8 @@ int uds_search_volume_page_cache_for_rebuild(struct volume *volume,
 	if (result != UDS_SUCCESS)
 		return result;
 
-	*found = search_record_page(dm_bufio_get_block_data(page->buffer), name, geometry, NULL);
+	*found = search_record_page(dm_bufio_get_block_data(page->buffer), name,
+				    geometry, NULL);
 	return UDS_SUCCESS;
 }
 
@@ -1106,22 +1063,19 @@ void uds_forget_chapter(struct volume *volume, u64 virtual_chapter)
  * Donate an index pages from a newly written chapter to the page cache since it is likely to be
  * used again soon. The caller must already hold the reader thread mutex.
  */
-static int donate_index_page_locked(struct volume *volume,
-				    u32 physical_chapter,
-				    u32 index_page_number,
-				    struct dm_buffer *page_buffer)
+static int donate_index_page_locked(struct volume *volume, u32 physical_chapter,
+				    u32 index_page_number, struct dm_buffer *page_buffer)
 {
 	int result;
 	struct cached_page *page = NULL;
 	u32 physical_page =
-		map_to_physical_page(volume->geometry, physical_chapter, index_page_number);
+		map_to_physical_page(volume->geometry, physical_chapter,
+				     index_page_number);
 
 	page = select_victim_in_cache(&volume->page_cache);
 	page->buffer = page_buffer;
-	result = init_chapter_index_page(volume,
-					 dm_bufio_get_block_data(page_buffer),
-					 physical_chapter,
-					 index_page_number,
+	result = init_chapter_index_page(volume, dm_bufio_get_block_data(page_buffer),
+					 physical_chapter, index_page_number,
 					 &page->index_page);
 	if (result != UDS_SUCCESS) {
 		uds_log_warning("Error initialize chapter index page");
@@ -1139,8 +1093,7 @@ static int donate_index_page_locked(struct volume *volume,
 	return UDS_SUCCESS;
 }
 
-static int write_index_pages(struct volume *volume,
-			     u32 physical_chapter_number,
+static int write_index_pages(struct volume *volume, u32 physical_chapter_number,
 			     struct open_chapter_index *chapter_index)
 {
 	struct geometry *geometry = volume->geometry;
@@ -1165,37 +1118,32 @@ static int write_index_pages(struct volume *volume,
 		}
 
 		last_page = ((index_page_number + 1) == geometry->index_pages_per_chapter);
-		result = uds_pack_open_chapter_index_page(chapter_index,
-							  page_data,
-							  delta_list_number,
-							  last_page,
+		result = uds_pack_open_chapter_index_page(chapter_index, page_data,
+							  delta_list_number, last_page,
 							  &lists_packed);
 		if (result != UDS_SUCCESS) {
 			dm_bufio_release(page_buffer);
-			return uds_log_warning_strerror(result, "failed to pack index page");
+			return uds_log_warning_strerror(result,
+							"failed to pack index page");
 		}
 
 		dm_bufio_mark_buffer_dirty(page_buffer);
 
 		if (lists_packed == 0) {
 			uds_log_debug("no delta lists packed on chapter %u page %u",
-				      physical_chapter_number,
-				      index_page_number);
+				      physical_chapter_number, index_page_number);
 		} else {
 			delta_list_number += lists_packed;
 		}
 
 		uds_update_index_page_map(volume->index_page_map,
 					  chapter_index->virtual_chapter_number,
-					  physical_chapter_number,
-					  index_page_number,
+					  physical_chapter_number, index_page_number,
 					  delta_list_number - 1);
 
 		uds_lock_mutex(&volume->read_threads_mutex);
-		result = donate_index_page_locked(volume,
-						  physical_chapter_number,
-						  index_page_number,
-						  page_buffer);
+		result = donate_index_page_locked(volume, physical_chapter_number,
+						  index_page_number, page_buffer);
 		uds_unlock_mutex(&volume->read_threads_mutex);
 		if (result != UDS_SUCCESS) {
 			dm_bufio_release(page_buffer);
@@ -1208,41 +1156,30 @@ static int write_index_pages(struct volume *volume,
 
 static u32 encode_tree(u8 record_page[],
 		       const struct uds_volume_record *sorted_pointers[],
-		       u32 next_record,
-		       u32 node,
-		       u32 node_count)
+		       u32 next_record, u32 node, u32 node_count)
 {
 	if (node < node_count) {
 		u32 child = (2 * node) + 1;
 
-		next_record = encode_tree(record_page,
-					  sorted_pointers,
-					  next_record,
-					  child,
-					  node_count);
+		next_record = encode_tree(record_page, sorted_pointers, next_record,
+					  child, node_count);
 
 		/*
 		 * In-order traversal: copy the contents of the next record into the page at the
 		 * node offset.
 		 */
 		memcpy(&record_page[node * BYTES_PER_RECORD],
-		       sorted_pointers[next_record++],
-		       BYTES_PER_RECORD);
+		       sorted_pointers[next_record++], BYTES_PER_RECORD);
 
-		next_record = encode_tree(record_page,
-					  sorted_pointers,
-					  next_record,
-					  child + 1,
-					  node_count);
+		next_record = encode_tree(record_page, sorted_pointers, next_record,
+					  child + 1, node_count);
 	}
 
 	return next_record;
 }
 
-static int
-encode_record_page(const struct volume *volume,
-		   const struct uds_volume_record records[],
-		   u8 record_page[])
+static int encode_record_page(const struct volume *volume,
+			      const struct uds_volume_record records[], u8 record_page[])
 {
 	int result;
 	u32 i;
@@ -1257,10 +1194,8 @@ encode_record_page(const struct volume *volume,
 	 * sorting the entire record values.
 	 */
 	BUILD_BUG_ON(offsetof(struct uds_volume_record, name) != 0);
-	result = uds_radix_sort(volume->radix_sorter,
-				(const u8 **) record_pointers,
-				records_per_page,
-				UDS_RECORD_NAME_SIZE);
+	result = uds_radix_sort(volume->radix_sorter, (const u8 **) record_pointers,
+				records_per_page, UDS_RECORD_NAME_SIZE);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -1268,16 +1203,14 @@ encode_record_page(const struct volume *volume,
 	return UDS_SUCCESS;
 }
 
-static int write_record_pages(struct volume *volume,
-			      u32 physical_chapter_number,
+static int write_record_pages(struct volume *volume, u32 physical_chapter_number,
 			      const struct uds_volume_record *records)
 {
 	u32 record_page_number;
 	struct geometry *geometry = volume->geometry;
 	struct dm_buffer *page_buffer;
 	const struct uds_volume_record *next_record = records;
-	u32 first_record_page = map_to_physical_page(geometry,
-						     physical_chapter_number,
+	u32 first_record_page = map_to_physical_page(geometry, physical_chapter_number,
 						     geometry->index_pages_per_chapter);
 
 	for (record_page_number = 0;
@@ -1309,8 +1242,7 @@ static int write_record_pages(struct volume *volume,
 	return UDS_SUCCESS;
 }
 
-int uds_write_chapter(struct volume *volume,
-		      struct open_chapter_index *chapter_index,
+int uds_write_chapter(struct volume *volume, struct open_chapter_index *chapter_index,
 		      const struct uds_volume_record *records)
 {
 	int result;
@@ -1333,7 +1265,8 @@ int uds_write_chapter(struct volume *volume,
 	return result;
 }
 
-static void probe_chapter(struct volume *volume, u32 chapter_number, u64 *virtual_chapter_number)
+static void probe_chapter(struct volume *volume, u32 chapter_number,
+			  u64 *virtual_chapter_number)
 {
 	const struct geometry *geometry = volume->geometry;
 	u32 expected_list_number = 0;
@@ -1354,7 +1287,8 @@ static void probe_chapter(struct volume *volume, u32 chapter_number, u64 *virtua
 			return;
 
 		if (page->virtual_chapter_number == BAD_CHAPTER) {
-			uds_log_error("corrupt index page in chapter %u", chapter_number);
+			uds_log_error("corrupt index page in chapter %u",
+				      chapter_number);
 			return;
 		}
 
@@ -1362,18 +1296,14 @@ static void probe_chapter(struct volume *volume, u32 chapter_number, u64 *virtua
 			vcn = page->virtual_chapter_number;
 		} else if (page->virtual_chapter_number != vcn) {
 			uds_log_error("inconsistent chapter %u index page %u: expected vcn %llu, got vcn %llu",
-				      chapter_number,
-				      i,
-				      (unsigned long long) vcn,
+				      chapter_number, i, (unsigned long long) vcn,
 				      (unsigned long long) page->virtual_chapter_number);
 			return;
 		}
 
 		if (expected_list_number != page->lowest_list_number) {
 			uds_log_error("inconsistent chapter %u index page %u: expected list number %u, got list number %u",
-				      chapter_number,
-				      i,
-				      expected_list_number,
+				      chapter_number, i, expected_list_number,
 				      page->lowest_list_number);
 			return;
 		}
@@ -1385,10 +1315,8 @@ static void probe_chapter(struct volume *volume, u32 chapter_number, u64 *virtua
 	}
 
 	if (chapter_number != uds_map_to_physical_chapter(geometry, vcn)) {
-		uds_log_error("chapter %u vcn %llu is out of phase (%u)",
-			      chapter_number,
-			      (unsigned long long) vcn,
-			      geometry->chapters_per_volume);
+		uds_log_error("chapter %u vcn %llu is out of phase (%u)", chapter_number,
+			      (unsigned long long) vcn, geometry->chapters_per_volume);
 		return;
 	}
 
@@ -1421,8 +1349,8 @@ static void find_real_end_of_volume(struct volume *volume, u32 limit, u32 *limit
 	*limit_ptr = limit;
 }
 
-static int
-find_chapter_limits(struct volume *volume, u32 chapter_limit, u64 *lowest_vcn, u64 *highest_vcn)
+static int find_chapter_limits(struct volume *volume, u32 chapter_limit, u64 *lowest_vcn,
+			       u64 *highest_vcn)
 {
 	struct geometry *geometry = volume->geometry;
 	u64 zero_vcn;
@@ -1504,7 +1432,8 @@ find_chapter_limits(struct volume *volume, u32 chapter_limit, u64 *lowest_vcn, u
 
 		probe_chapter(volume, right_chapter, &highest);
 		if (bad_chapters++ >= MAX_BAD_CHAPTERS) {
-			uds_log_error("too many bad chapters in volume: %u", bad_chapters);
+			uds_log_error("too many bad chapters in volume: %u",
+				      bad_chapters);
 			return UDS_CORRUPT_DATA;
 		}
 	}
@@ -1518,10 +1447,8 @@ find_chapter_limits(struct volume *volume, u32 chapter_limit, u64 *lowest_vcn, u
  * Find the highest and lowest contiguous chapters present in the volume and determine their
  * virtual chapter numbers. This is used by rebuild.
  */
-int uds_find_volume_chapter_boundaries(struct volume *volume,
-				       u64 *lowest_vcn,
-				       u64 *highest_vcn,
-				       bool *is_empty)
+int uds_find_volume_chapter_boundaries(struct volume *volume, u64 *lowest_vcn,
+				       u64 *highest_vcn, bool *is_empty)
 {
 	u32 chapter_limit = volume->geometry->chapters_per_volume;
 
@@ -1558,17 +1485,14 @@ int __must_check uds_replace_volume_storage(struct volume *volume,
 	if (volume->client != NULL)
 		dm_bufio_client_destroy(uds_forget(volume->client));
 
-	return uds_open_volume_bufio(layout,
-				     volume->geometry->bytes_per_page,
-				     volume->reserved_buffers,
-				     &volume->client);
+	return uds_open_volume_bufio(layout, volume->geometry->bytes_per_page,
+				     volume->reserved_buffers, &volume->client);
 }
 
-static int __must_check
-initialize_page_cache(struct page_cache *cache,
-		      const struct geometry *geometry,
-		      u32 chapters_in_cache,
-		      unsigned int zone_count)
+static int __must_check initialize_page_cache(struct page_cache *cache,
+					      const struct geometry *geometry,
+					      u32 chapters_in_cache,
+					      unsigned int zone_count)
 {
 	int result;
 	u32 i;
@@ -1580,32 +1504,26 @@ initialize_page_cache(struct page_cache *cache,
 
 	result = ASSERT((cache->cache_slots <= VOLUME_CACHE_MAX_ENTRIES),
 			"requested cache size, %u, within limit %u",
-			cache->cache_slots,
-			VOLUME_CACHE_MAX_ENTRIES);
+			cache->cache_slots, VOLUME_CACHE_MAX_ENTRIES);
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = uds_allocate(VOLUME_CACHE_MAX_QUEUED_READS,
-			      struct queued_read,
-			      "volume read queue",
-			      &cache->read_queue);
+	result = uds_allocate(VOLUME_CACHE_MAX_QUEUED_READS, struct queued_read,
+			      "volume read queue", &cache->read_queue);
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = uds_allocate(cache->zone_count,
-			      struct search_pending_counter,
-			      "Volume Cache Zones",
-			      &cache->search_pending_counters);
+	result = uds_allocate(cache->zone_count, struct search_pending_counter,
+			      "Volume Cache Zones", &cache->search_pending_counters);
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = uds_allocate(cache->indexable_pages, u16, "page cache index", &cache->index);
+	result = uds_allocate(cache->indexable_pages, u16, "page cache index",
+			      &cache->index);
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = uds_allocate(cache->cache_slots,
-			      struct cached_page,
-			      "page cache cache",
+	result = uds_allocate(cache->cache_slots, struct cached_page, "page cache cache",
 			      &cache->cache);
 	if (result != UDS_SUCCESS)
 		return result;
@@ -1620,8 +1538,7 @@ initialize_page_cache(struct page_cache *cache,
 	return UDS_SUCCESS;
 }
 
-int uds_make_volume(const struct configuration *config,
-		    struct index_layout *layout,
+int uds_make_volume(const struct configuration *config, struct index_layout *layout,
 		    struct volume **new_volume)
 {
 	unsigned int i;
@@ -1639,7 +1556,8 @@ int uds_make_volume(const struct configuration *config,
 	result = uds_copy_geometry(config->geometry, &volume->geometry);
 	if (result != UDS_SUCCESS) {
 		uds_free_volume(volume);
-		return uds_log_warning_strerror(result, "failed to allocate geometry: error");
+		return uds_log_warning_strerror(result,
+						"failed to allocate geometry: error");
 	}
 	geometry = volume->geometry;
 
@@ -1652,24 +1570,22 @@ int uds_make_volume(const struct configuration *config,
 	if (uds_is_sparse_geometry(geometry))
 		reserved_buffers += (config->cache_chapters * geometry->index_pages_per_chapter);
 	volume->reserved_buffers = reserved_buffers;
-	result = uds_open_volume_bufio(layout,
-				       geometry->bytes_per_page,
-				       volume->reserved_buffers,
-				       &volume->client);
+	result = uds_open_volume_bufio(layout, geometry->bytes_per_page,
+				       volume->reserved_buffers, &volume->client);
 	if (result != UDS_SUCCESS) {
 		uds_free_volume(volume);
 		return result;
 	}
 
-	result = uds_make_radix_sorter(geometry->records_per_page, &volume->radix_sorter);
+	result = uds_make_radix_sorter(geometry->records_per_page,
+				       &volume->radix_sorter);
 	if (result != UDS_SUCCESS) {
 		uds_free_volume(volume);
 		return result;
 	}
 
 	result = uds_allocate(geometry->records_per_page,
-			      const struct uds_volume_record *,
-			      "record pointers",
+			      const struct uds_volume_record *, "record pointers",
 			      &volume->record_pointers);
 	if (result != UDS_SUCCESS) {
 		uds_free_volume(volume);
@@ -1679,8 +1595,7 @@ int uds_make_volume(const struct configuration *config,
 	if (uds_is_sparse_geometry(geometry)) {
 		size_t page_size = sizeof(struct delta_index_page) + geometry->bytes_per_page;
 
-		result = uds_make_sparse_cache(geometry,
-					       config->cache_chapters,
+		result = uds_make_sparse_cache(geometry, config->cache_chapters,
 					       config->zone_count,
 					       &volume->sparse_cache);
 		if (result != UDS_SUCCESS) {
@@ -1692,10 +1607,8 @@ int uds_make_volume(const struct configuration *config,
 			page_size * geometry->index_pages_per_chapter * config->cache_chapters;
 	}
 
-	result = initialize_page_cache(&volume->page_cache,
-				       geometry,
-				       config->cache_chapters,
-				       config->zone_count);
+	result = initialize_page_cache(&volume->page_cache, geometry,
+				       config->cache_chapters, config->zone_count);
 	if (result != UDS_SUCCESS) {
 		uds_free_volume(volume);
 		return result;
@@ -1726,9 +1639,7 @@ int uds_make_volume(const struct configuration *config,
 		return result;
 	}
 
-	result = uds_allocate(config->read_threads,
-			      struct thread *,
-			      "reader threads",
+	result = uds_allocate(config->read_threads, struct thread *, "reader threads",
 			      &volume->reader_threads);
 	if (result != UDS_SUCCESS) {
 		uds_free_volume(volume);
@@ -1736,10 +1647,8 @@ int uds_make_volume(const struct configuration *config,
 	}
 
 	for (i = 0; i < config->read_threads; i++) {
-		result = uds_create_thread(read_thread_function,
-					   (void *) volume,
-					   "reader",
-					   &volume->reader_threads[i]);
+		result = uds_create_thread(read_thread_function, (void *) volume,
+					   "reader", &volume->reader_threads[i]);
 		if (result != UDS_SUCCESS) {
 			uds_free_volume(volume);
 			return result;

--- a/drivers/md/dm-vdo/volume.c
+++ b/drivers/md/dm-vdo/volume.c
@@ -130,7 +130,8 @@ static inline bool search_pending(union invalidate_counter invalidate_counter)
 static void
 begin_pending_search(struct page_cache *cache, u32 physical_page, unsigned int zone_number)
 {
-	union invalidate_counter invalidate_counter = get_invalidate_counter(cache, zone_number);
+	union invalidate_counter invalidate_counter =
+		get_invalidate_counter(cache, zone_number);
 
 	invalidate_counter.page = physical_page;
 	invalidate_counter.counter++;
@@ -181,9 +182,9 @@ static void wait_for_pending_searches(struct page_cache *cache, u32 physical_pag
 
 	for (i = 0; i < cache->zone_count; i++)
 		initial_counters[i] = get_invalidate_counter(cache, i);
-	for (i = 0; i < cache->zone_count; i++)
+	for (i = 0; i < cache->zone_count; i++) {
 		if (search_pending(initial_counters[i]) &&
-		    (initial_counters[i].page == physical_page))
+		    (initial_counters[i].page == physical_page)) {
 			/*
 			 * There is an active search using the physical page. We need to wait for
 			 * the search to finish.
@@ -192,6 +193,8 @@ static void wait_for_pending_searches(struct page_cache *cache, u32 physical_pag
 			 */
 			while (initial_counters[i].value == get_invalidate_counter(cache, i).value)
 				cond_resched();
+		}
+	}
 }
 
 static void release_page_buffer(struct cached_page *page)
@@ -433,11 +436,12 @@ static int init_chapter_index_page(const struct volume *volume,
 	if (volume->lookup_mode == LOOKUP_FOR_REBUILD)
 		return result;
 
-	if (result != UDS_SUCCESS)
+	if (result != UDS_SUCCESS) {
 		return uds_log_error_strerror(result,
 					      "Reading chapter index page for chapter %u page %u",
 					      chapter,
 					      index_page_number);
+	}
 
 	uds_get_list_number_bounds(volume->index_page_map,
 				   chapter,
@@ -779,9 +783,10 @@ get_volume_page_protected(struct volume *volume,
 
 	get_page_from_cache(&volume->page_cache, physical_page, &page);
 	if (page != NULL) {
-		if (request->zone_number == 0)
+		if (request->zone_number == 0) {
 			/* Only one zone is allowed to update the LRU. */
 			make_page_most_recent(&volume->page_cache, page);
+		}
 
 		*page_ptr = page;
 		return UDS_SUCCESS;
@@ -1085,7 +1090,8 @@ static void invalidate_page(struct page_cache *cache, u32 physical_page)
 
 void uds_forget_chapter(struct volume *volume, u64 virtual_chapter)
 {
-	u32 physical_chapter = uds_map_to_physical_chapter(volume->geometry, virtual_chapter);
+	u32 physical_chapter =
+		uds_map_to_physical_chapter(volume->geometry, virtual_chapter);
 	u32 first_page = map_to_physical_page(volume->geometry, physical_chapter, 0);
 	u32 i;
 
@@ -1153,9 +1159,10 @@ static int write_index_pages(struct volume *volume,
 		int result;
 
 		page_data = dm_bufio_new(volume->client, physical_page, &page_buffer);
-		if (IS_ERR(page_data))
+		if (IS_ERR(page_data)) {
 			return uds_log_warning_strerror(-PTR_ERR(page_data),
 							"failed to prepare index page");
+		}
 
 		last_page = ((index_page_number + 1) == geometry->index_pages_per_chapter);
 		result = uds_pack_open_chapter_index_page(chapter_index,
@@ -1170,12 +1177,13 @@ static int write_index_pages(struct volume *volume,
 
 		dm_bufio_mark_buffer_dirty(page_buffer);
 
-		if (lists_packed == 0)
+		if (lists_packed == 0) {
 			uds_log_debug("no delta lists packed on chapter %u page %u",
 				      physical_chapter_number,
 				      index_page_number);
-		else
+		} else {
 			delta_list_number += lists_packed;
+		}
 
 		uds_update_index_page_map(volume->index_page_map,
 					  chapter_index->virtual_chapter_number,
@@ -1280,9 +1288,10 @@ static int write_record_pages(struct volume *volume,
 		int result;
 
 		page_data = dm_bufio_new(volume->client, physical_page, &page_buffer);
-		if (IS_ERR(page_data))
+		if (IS_ERR(page_data)) {
 			return uds_log_warning_strerror(-PTR_ERR(page_data),
 							"failed to prepare record page");
+		}
 
 		result = encode_record_page(volume, next_record, page_data);
 		if (result != UDS_SUCCESS) {

--- a/drivers/md/dm-vdo/volume.c
+++ b/drivers/md/dm-vdo/volume.c
@@ -1336,7 +1336,7 @@ static void probe_chapter(struct volume *volume, u32 chapter_number, u64 *virtua
 			  map_to_physical_page(geometry, chapter_number, 0),
 			  geometry->index_pages_per_chapter);
 
-	for (i = 0; i < geometry->index_pages_per_chapter; ++i) {
+	for (i = 0; i < geometry->index_pages_per_chapter; i++) {
 		struct delta_index_page *page;
 		int result;
 

--- a/drivers/md/dm-vdo/volume.h
+++ b/drivers/md/dm-vdo/volume.h
@@ -132,12 +132,12 @@ int __must_check uds_replace_volume_storage(struct volume *volume,
 					    struct block_device *bdev);
 
 int __must_check uds_find_volume_chapter_boundaries(struct volume *volume,
-						    u64 *lowest_vcn,
-						    u64 *highest_vcn,
+						    u64 *lowest_vcn, u64 *highest_vcn,
 						    bool *is_empty);
 
-int __must_check
-uds_search_volume_page_cache(struct volume *volume, struct uds_request *request, bool *found);
+int __must_check uds_search_volume_page_cache(struct volume *volume,
+					      struct uds_request *request,
+					      bool *found);
 
 int __must_check uds_search_volume_page_cache_for_rebuild(struct volume *volume,
 							  const struct uds_record_name *name,
@@ -145,10 +145,8 @@ int __must_check uds_search_volume_page_cache_for_rebuild(struct volume *volume,
 							  bool *found);
 
 int __must_check uds_search_cached_record_page(struct volume *volume,
-					       struct uds_request *request,
-					       u32 chapter,
-					       u16 record_page_number,
-					       bool *found);
+					       struct uds_request *request, u32 chapter,
+					       u16 record_page_number, bool *found);
 
 void uds_forget_chapter(struct volume *volume, u64 chapter);
 
@@ -158,17 +156,15 @@ int __must_check uds_write_chapter(struct volume *volume,
 
 void uds_prefetch_volume_chapter(const struct volume *volume, u32 chapter);
 
-int __must_check
-uds_read_chapter_index_from_volume(const struct volume *volume,
-				   u64 virtual_chapter,
-				   struct dm_buffer *volume_buffers[],
-				   struct delta_index_page index_pages[]);
+int __must_check uds_read_chapter_index_from_volume(const struct volume *volume,
+						    u64 virtual_chapter,
+						    struct dm_buffer *volume_buffers[],
+						    struct delta_index_page index_pages[]);
 
-int __must_check
-uds_get_volume_record_page(struct volume *volume, u32 chapter, u32 page_number, u8 **data_ptr);
+int __must_check uds_get_volume_record_page(struct volume *volume, u32 chapter,
+					    u32 page_number, u8 **data_ptr);
 
-int __must_check uds_get_volume_index_page(struct volume *volume,
-					   u32 chapter,
+int __must_check uds_get_volume_index_page(struct volume *volume, u32 chapter,
 					   u32 page_number,
 					   struct delta_index_page **page_ptr);
 

--- a/drivers/md/dm-vdo/wait-queue.c
+++ b/drivers/md/dm-vdo/wait-queue.c
@@ -81,7 +81,7 @@ void vdo_transfer_all_waiters(struct wait_queue *from_queue, struct wait_queue *
  * function on each of them in turn. The queue is copied and emptied before invoking any callbacks,
  * and only the waiters that were in the queue at the start of the call will be notified.
  */
-void vdo_notify_all_waiters(struct wait_queue *queue, waiter_callback *callback,
+void vdo_notify_all_waiters(struct wait_queue *queue, waiter_callback_fn callback,
 			    void *context)
 {
 	/*
@@ -125,7 +125,7 @@ struct waiter *vdo_get_first_waiter(const struct wait_queue *queue)
  * @match_context: Contextual info for the match method.
  * @matched_queue: A wait_queue to store matches.
  */
-void vdo_dequeue_matching_waiters(struct wait_queue *queue, waiter_match *match_method,
+void vdo_dequeue_matching_waiters(struct wait_queue *queue, waiter_match_fn match_method,
 				  void *match_context, struct wait_queue *matched_queue)
 {
 	struct wait_queue matched_waiters, iteration_queue;
@@ -191,7 +191,7 @@ struct waiter *vdo_dequeue_next_waiter(struct wait_queue *queue)
  *
  * Return: true if there was a waiter in the queue.
  */
-bool vdo_notify_next_waiter(struct wait_queue *queue, waiter_callback *callback,
+bool vdo_notify_next_waiter(struct wait_queue *queue, waiter_callback_fn callback,
 			    void *context)
 {
 	struct waiter *waiter = vdo_dequeue_next_waiter(queue);

--- a/drivers/md/dm-vdo/wait-queue.c
+++ b/drivers/md/dm-vdo/wait-queue.c
@@ -93,9 +93,8 @@ void vdo_notify_all_waiters(struct wait_queue *queue, waiter_callback *callback,
 	vdo_transfer_all_waiters(queue, &waiters);
 
 	/* Drain the copied queue, invoking the callback on every entry. */
-	while (vdo_notify_next_waiter(&waiters, callback, context))
-		/* All the work is done by the loop condition. */
-		;
+	while (vdo_has_waiters(&waiters))
+		vdo_notify_next_waiter(&waiters, callback, context);
 }
 
 /**
@@ -108,9 +107,10 @@ struct waiter *vdo_get_first_waiter(const struct wait_queue *queue)
 {
 	struct waiter *last_waiter = queue->last_waiter;
 
-	if (last_waiter == NULL)
+	if (last_waiter == NULL) {
 		/* There are no waiters, so we're done. */
 		return NULL;
+	}
 
 	/* The queue is circular, so the last entry links to the head of the queue. */
 	return last_waiter->next_waiter;
@@ -164,19 +164,21 @@ struct waiter *vdo_dequeue_next_waiter(struct wait_queue *queue)
 	if (first_waiter == NULL)
 		return NULL;
 
-	if (first_waiter == last_waiter)
+	if (first_waiter == last_waiter) {
 		/* The queue has a single entry, so just empty it out by nulling the tail. */
 		queue->last_waiter = NULL;
-	else
+	} else {
 		/*
 		 * The queue has more than one entry, so splice the first waiter out of the
 		 * circular queue.
 		 */
 		last_waiter->next_waiter = first_waiter->next_waiter;
+	}
 
 	/* The waiter is no longer in a wait queue. */
 	first_waiter->next_waiter = NULL;
 	queue->queue_length -= 1;
+
 	return first_waiter;
 }
 
@@ -202,6 +204,7 @@ bool vdo_notify_next_waiter(struct wait_queue *queue, waiter_callback *callback,
 	if (callback == NULL)
 		callback = waiter->callback;
 	(*callback)(waiter, context);
+
 	return true;
 }
 
@@ -219,5 +222,6 @@ vdo_get_next_waiter(const struct wait_queue *queue, const struct waiter *waiter)
 
 	if (waiter == NULL)
 		return first_waiter;
+
 	return ((waiter->next_waiter != first_waiter) ? waiter->next_waiter : NULL);
 }

--- a/drivers/md/dm-vdo/wait-queue.c
+++ b/drivers/md/dm-vdo/wait-queue.c
@@ -81,7 +81,8 @@ void vdo_transfer_all_waiters(struct wait_queue *from_queue, struct wait_queue *
  * function on each of them in turn. The queue is copied and emptied before invoking any callbacks,
  * and only the waiters that were in the queue at the start of the call will be notified.
  */
-void vdo_notify_all_waiters(struct wait_queue *queue, waiter_callback *callback, void *context)
+void vdo_notify_all_waiters(struct wait_queue *queue, waiter_callback *callback,
+			    void *context)
 {
 	/*
 	 * Copy and empty the queue first, avoiding the possibility of an infinite loop if entries
@@ -124,10 +125,8 @@ struct waiter *vdo_get_first_waiter(const struct wait_queue *queue)
  * @match_context: Contextual info for the match method.
  * @matched_queue: A wait_queue to store matches.
  */
-void vdo_dequeue_matching_waiters(struct wait_queue *queue,
-				  waiter_match *match_method,
-				  void *match_context,
-				  struct wait_queue *matched_queue)
+void vdo_dequeue_matching_waiters(struct wait_queue *queue, waiter_match *match_method,
+				  void *match_context, struct wait_queue *matched_queue)
 {
 	struct wait_queue matched_waiters, iteration_queue;
 
@@ -139,9 +138,7 @@ void vdo_dequeue_matching_waiters(struct wait_queue *queue,
 		struct waiter *waiter = vdo_dequeue_next_waiter(&iteration_queue);
 
 		vdo_enqueue_waiter((match_method(waiter, match_context) ?
-				    &matched_waiters :
-				    queue),
-				   waiter);
+				    &matched_waiters : queue), waiter);
 	}
 
 	vdo_transfer_all_waiters(&matched_waiters, matched_queue);
@@ -194,7 +191,8 @@ struct waiter *vdo_dequeue_next_waiter(struct wait_queue *queue)
  *
  * Return: true if there was a waiter in the queue.
  */
-bool vdo_notify_next_waiter(struct wait_queue *queue, waiter_callback *callback, void *context)
+bool vdo_notify_next_waiter(struct wait_queue *queue, waiter_callback *callback,
+			    void *context)
 {
 	struct waiter *waiter = vdo_dequeue_next_waiter(queue);
 
@@ -215,8 +213,8 @@ bool vdo_notify_next_waiter(struct wait_queue *queue, waiter_callback *callback,
  *
  * Return: The next waiter, or NULL.
  */
-const struct waiter *
-vdo_get_next_waiter(const struct wait_queue *queue, const struct waiter *waiter)
+const struct waiter *vdo_get_next_waiter(const struct wait_queue *queue,
+					 const struct waiter *waiter)
 {
 	struct waiter *first_waiter = vdo_get_first_waiter(queue);
 

--- a/drivers/md/dm-vdo/wait-queue.h
+++ b/drivers/md/dm-vdo/wait-queue.h
@@ -97,18 +97,19 @@ static inline bool __must_check vdo_has_waiters(const struct wait_queue *queue)
 
 void vdo_enqueue_waiter(struct wait_queue *queue, struct waiter *waiter);
 
-void vdo_notify_all_waiters(struct wait_queue *queue, waiter_callback *callback, void *context);
+void vdo_notify_all_waiters(struct wait_queue *queue, waiter_callback *callback,
+			    void *context);
 
-bool vdo_notify_next_waiter(struct wait_queue *queue, waiter_callback *callback, void *context);
+bool vdo_notify_next_waiter(struct wait_queue *queue, waiter_callback *callback,
+			    void *context);
 
-void vdo_transfer_all_waiters(struct wait_queue *from_queue, struct wait_queue *to_queue);
+void vdo_transfer_all_waiters(struct wait_queue *from_queue,
+			      struct wait_queue *to_queue);
 
 struct waiter *vdo_get_first_waiter(const struct wait_queue *queue);
 
-void vdo_dequeue_matching_waiters(struct wait_queue *queue,
-				  waiter_match *match_method,
-				  void *match_context,
-				  struct wait_queue *matched_queue);
+void vdo_dequeue_matching_waiters(struct wait_queue *queue, waiter_match *match_method,
+				  void *match_context, struct wait_queue *matched_queue);
 
 struct waiter *vdo_dequeue_next_waiter(struct wait_queue *queue);
 
@@ -123,7 +124,7 @@ static inline size_t __must_check vdo_count_waiters(const struct wait_queue *que
 	return queue->queue_length;
 }
 
-const struct waiter * __must_check
-vdo_get_next_waiter(const struct wait_queue *queue, const struct waiter *waiter);
+const struct waiter * __must_check vdo_get_next_waiter(const struct wait_queue *queue,
+						       const struct waiter *waiter);
 
 #endif /* VDO_WAIT_QUEUE_H */

--- a/drivers/md/dm-vdo/wait-queue.h
+++ b/drivers/md/dm-vdo/wait-queue.h
@@ -37,17 +37,18 @@ struct wait_queue {
 };
 
 /**
- * typedef waiter_callback - Callback type for functions which will be called to resume processing
- *                           of a waiter after it has been removed from its wait queue.
+ * typedef waiter_callback_fn - Callback type for functions which will be called to resume
+ *                              processing of a waiter after it has been removed from its wait
+ *                              queue.
  */
-typedef void waiter_callback(struct waiter *waiter, void *context);
+typedef void (*waiter_callback_fn)(struct waiter *waiter, void *context);
 
 /**
- * typedef waiter_match - Method type for waiter matching methods.
+ * typedef waiter_match_fn - Method type for waiter matching methods.
  *
- * A waiter_match method returns false if the waiter does not match.
+ * A waiter_match_fn method returns false if the waiter does not match.
  */
-typedef bool waiter_match(struct waiter *waiter, void *context);
+typedef bool (*waiter_match_fn)(struct waiter *waiter, void *context);
 
 /* The queue entry structure for entries in a wait_queue. */
 struct waiter {
@@ -58,7 +59,7 @@ struct waiter {
 	struct waiter *next_waiter;
 
 	/* Optional waiter-specific callback to invoke when waking this waiter. */
-	waiter_callback *callback;
+	waiter_callback_fn callback;
 };
 
 /**
@@ -97,10 +98,10 @@ static inline bool __must_check vdo_has_waiters(const struct wait_queue *queue)
 
 void vdo_enqueue_waiter(struct wait_queue *queue, struct waiter *waiter);
 
-void vdo_notify_all_waiters(struct wait_queue *queue, waiter_callback *callback,
+void vdo_notify_all_waiters(struct wait_queue *queue, waiter_callback_fn callback,
 			    void *context);
 
-bool vdo_notify_next_waiter(struct wait_queue *queue, waiter_callback *callback,
+bool vdo_notify_next_waiter(struct wait_queue *queue, waiter_callback_fn callback,
 			    void *context);
 
 void vdo_transfer_all_waiters(struct wait_queue *from_queue,
@@ -108,7 +109,7 @@ void vdo_transfer_all_waiters(struct wait_queue *from_queue,
 
 struct waiter *vdo_get_first_waiter(const struct wait_queue *queue);
 
-void vdo_dequeue_matching_waiters(struct wait_queue *queue, waiter_match *match_method,
+void vdo_dequeue_matching_waiters(struct wait_queue *queue, waiter_match_fn match_method,
 				  void *match_context, struct wait_queue *matched_queue);
 
 struct waiter *vdo_dequeue_next_waiter(struct wait_queue *queue);


### PR DESCRIPTION
This series incorporates most of Mike's reformatting suggestions, but also generalizes them to cover the rest of the VDO codebase. This does not necessairly cover all instance that need reformatting. However, the remaining cases can be fixed individually as we notice them.
This series contains commits from PRs vdo-devel/27, vdo-devel/31, vdo-devel/14, vdo-devel/38, and vdo-devel/39 (in that order).