### PR TITLE
[VDO-5655] Rename is_trim flag to is_discard

### DIFF
--- a/drivers/md/dm-vdo/block-map.c
+++ b/drivers/md/dm-vdo/block-map.c
@@ -2194,8 +2194,8 @@ static void allocate_block_map_page(struct block_map_zone *zone,
 {
 	int result;
 
-	if (!data_vio->write || data_vio->is_trim) {
-		/* This is a pure read or a trim, so there's nothing left to do here. */
+	if (!data_vio->write || data_vio->is_discard) {
+		/* This is a pure read or a discard, so there's nothing left to do here. */
 		finish_lookup(data_vio, VDO_SUCCESS);
 		return;
 	}

--- a/drivers/md/dm-vdo/data-vio.h
+++ b/drivers/md/dm-vdo/data-vio.h
@@ -199,7 +199,7 @@ struct data_vio {
 	u16 write : 1;
 	u16 fua : 1;
 	u16 is_zero : 1;
-	u16 is_trim : 1;
+	u16 is_discard : 1;
 	u16 is_partial : 1;
 	u16 is_duplicate : 1;
 	u16 first_reference_operation_complete : 1;

--- a/drivers/md/dm-vdo/types.h
+++ b/drivers/md/dm-vdo/types.h
@@ -144,7 +144,7 @@ struct block_map_slot {
 
 /*
  * Four bits of each five-byte block map entry contain a mapping state value used to distinguish
- * unmapped or trimmed logical blocks (which are treated as mapped to the zero block) from entries
+ * unmapped or discarded logical blocks (which are treated as mapped to the zero block) from entries
  * that have been mapped to a physical block, including the zero block.
  *
  * FIXME: these should maybe be defines.


### PR DESCRIPTION
Apply Mike's upstream suggestions renaming is_trim to is_discard for clarity.
This series contains commits from PR vdo-devel/70.