### PR TITLE
[VDO-5659] [VDO-5660] Rename geometry and configuration structs

### DIFF
--- a/drivers/md/dm-vdo/chapter-index.c
+++ b/drivers/md/dm-vdo/chapter-index.c
@@ -13,7 +13,7 @@
 #include "uds.h"
 
 int uds_make_open_chapter_index(struct open_chapter_index **chapter_index,
-				const struct geometry *geometry, u64 volume_nonce)
+				const struct index_geometry *geometry, u64 volume_nonce)
 {
 	int result;
 	size_t memory_size;
@@ -79,7 +79,7 @@ int uds_put_open_chapter_index_record(struct open_chapter_index *chapter_index,
 	u32 list_number;
 	const u8 *found_name;
 	bool found;
-	const struct geometry *geometry = chapter_index->geometry;
+	const struct index_geometry *geometry = chapter_index->geometry;
 	u64 chapter_number = chapter_index->virtual_chapter_number;
 	u32 record_pages = geometry->record_pages_per_chapter;
 
@@ -128,7 +128,7 @@ int uds_pack_open_chapter_index_page(struct open_chapter_index *chapter_index,
 	struct delta_index_stats stats;
 	u64 nonce = chapter_index->volume_nonce;
 	u64 chapter_number = chapter_index->virtual_chapter_number;
-	const struct geometry *geometry = chapter_index->geometry;
+	const struct index_geometry *geometry = chapter_index->geometry;
 	u32 list_count = geometry->delta_lists_per_chapter;
 	unsigned int removals = 0;
 	struct delta_index_entry entry;
@@ -206,8 +206,8 @@ int uds_pack_open_chapter_index_page(struct open_chapter_index *chapter_index,
 
 /* Make a new chapter index page, initializing it with the data from a given index_page buffer. */
 int uds_initialize_chapter_index_page(struct delta_index_page *index_page,
-				      const struct geometry *geometry, u8 *page_buffer,
-				      u64 volume_nonce)
+				      const struct index_geometry *geometry,
+				      u8 *page_buffer, u64 volume_nonce)
 {
 	return uds_initialize_delta_index_page(index_page, volume_nonce,
 					       geometry->chapter_mean_delta,
@@ -217,7 +217,7 @@ int uds_initialize_chapter_index_page(struct delta_index_page *index_page,
 
 /* Validate a chapter index page read during rebuild. */
 int uds_validate_chapter_index_page(const struct delta_index_page *index_page,
-				    const struct geometry *geometry)
+				    const struct index_geometry *geometry)
 {
 	int result;
 	const struct delta_index *delta_index = &index_page->delta_index;
@@ -266,7 +266,7 @@ int uds_validate_chapter_index_page(const struct delta_index_page *index_page,
  * the name.
  */
 int uds_search_chapter_index_page(struct delta_index_page *index_page,
-				  const struct geometry *geometry,
+				  const struct index_geometry *geometry,
 				  const struct uds_record_name *name,
 				  u16 *record_page_ptr)
 {

--- a/drivers/md/dm-vdo/chapter-index.h
+++ b/drivers/md/dm-vdo/chapter-index.h
@@ -24,7 +24,7 @@ enum {
 };
 
 struct open_chapter_index {
-	const struct geometry *geometry;
+	const struct index_geometry *geometry;
 	struct delta_index delta_index;
 	u64 virtual_chapter_number;
 	u64 volume_nonce;
@@ -32,7 +32,7 @@ struct open_chapter_index {
 };
 
 int __must_check uds_make_open_chapter_index(struct open_chapter_index **chapter_index,
-					     const struct geometry *geometry,
+					     const struct index_geometry *geometry,
 					     u64 volume_nonce);
 
 void uds_free_open_chapter_index(struct open_chapter_index *chapter_index);
@@ -49,14 +49,14 @@ int __must_check uds_pack_open_chapter_index_page(struct open_chapter_index *cha
 						  bool last_page, u32 *lists_packed);
 
 int __must_check uds_initialize_chapter_index_page(struct delta_index_page *index_page,
-						   const struct geometry *geometry,
+						   const struct index_geometry *geometry,
 						   u8 *page_buffer, u64 volume_nonce);
 
 int __must_check uds_validate_chapter_index_page(const struct delta_index_page *index_page,
-						 const struct geometry *geometry);
+						 const struct index_geometry *geometry);
 
 int __must_check uds_search_chapter_index_page(struct delta_index_page *index_page,
-					       const struct geometry *geometry,
+					       const struct index_geometry *geometry,
 					       const struct uds_record_name *name,
 					       u16 *record_page_ptr);
 

--- a/drivers/md/dm-vdo/config.c
+++ b/drivers/md/dm-vdo/config.c
@@ -27,9 +27,9 @@ static bool is_version(const u8 *version, u8 *buffer)
 	return memcmp(version, buffer, INDEX_CONFIG_VERSION_LENGTH) == 0;
 }
 
-static bool are_matching_configurations(struct configuration *saved_config,
+static bool are_matching_configurations(struct uds_configuration *saved_config,
 					struct index_geometry *saved_geometry,
-					struct configuration *user)
+					struct uds_configuration *user)
 {
 	struct index_geometry *geometry = user->geometry;
 	bool result = true;
@@ -93,10 +93,10 @@ static bool are_matching_configurations(struct configuration *saved_config,
 
 /* Read the configuration and validate it against the provided one. */
 int uds_validate_config_contents(struct buffered_reader *reader,
-				 struct configuration *user_config)
+				 struct uds_configuration *user_config)
 {
 	int result;
-	struct configuration config;
+	struct uds_configuration config;
 	struct index_geometry geometry;
 	u8 version_buffer[INDEX_CONFIG_VERSION_LENGTH];
 	u32 bytes_per_page;
@@ -174,7 +174,7 @@ int uds_validate_config_contents(struct buffered_reader *reader,
  * been reduced by one chapter.
  */
 int uds_write_config_contents(struct buffered_writer *writer,
-			      struct configuration *config, u32 version)
+			      struct uds_configuration *config, u32 version)
 {
 	int result;
 	struct index_geometry *geometry = config->geometry;
@@ -313,9 +313,9 @@ static unsigned int __must_check normalize_read_threads(unsigned int requested)
 }
 
 int uds_make_configuration(const struct uds_parameters *params,
-			   struct configuration **config_ptr)
+			   struct uds_configuration **config_ptr)
 {
-	struct configuration *config;
+	struct uds_configuration *config;
 	u32 chapters_per_volume = 0;
 	u32 record_pages_per_chapter = 0;
 	u32 sparse_chapters_per_volume = 0;
@@ -327,7 +327,7 @@ int uds_make_configuration(const struct uds_parameters *params,
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = uds_allocate(1, struct configuration, __func__, &config);
+	result = uds_allocate(1, struct uds_configuration, __func__, &config);
 	if (result != UDS_SUCCESS)
 		return result;
 
@@ -354,7 +354,7 @@ int uds_make_configuration(const struct uds_parameters *params,
 	return UDS_SUCCESS;
 }
 
-void uds_free_configuration(struct configuration *config)
+void uds_free_configuration(struct uds_configuration *config)
 {
 	if (config != NULL) {
 		uds_free_index_geometry(config->geometry);
@@ -362,7 +362,7 @@ void uds_free_configuration(struct configuration *config)
 	}
 }
 
-void uds_log_configuration(struct configuration *config)
+void uds_log_configuration(struct uds_configuration *config)
 {
 	struct index_geometry *geometry = config->geometry;
 

--- a/drivers/md/dm-vdo/config.c
+++ b/drivers/md/dm-vdo/config.c
@@ -28,10 +28,10 @@ static bool is_version(const u8 *version, u8 *buffer)
 }
 
 static bool are_matching_configurations(struct configuration *saved_config,
-					struct geometry *saved_geometry,
+					struct index_geometry *saved_geometry,
 					struct configuration *user)
 {
-	struct geometry *geometry = user->geometry;
+	struct index_geometry *geometry = user->geometry;
 	bool result = true;
 
 	if (saved_geometry->record_pages_per_chapter != geometry->record_pages_per_chapter) {
@@ -97,7 +97,7 @@ int uds_validate_config_contents(struct buffered_reader *reader,
 {
 	int result;
 	struct configuration config;
-	struct geometry geometry;
+	struct index_geometry geometry;
 	u8 version_buffer[INDEX_CONFIG_VERSION_LENGTH];
 	u32 bytes_per_page;
 	u8 buffer[sizeof(struct uds_configuration_6_02)];
@@ -177,7 +177,7 @@ int uds_write_config_contents(struct buffered_writer *writer,
 			      struct configuration *config, u32 version)
 {
 	int result;
-	struct geometry *geometry = config->geometry;
+	struct index_geometry *geometry = config->geometry;
 	u8 buffer[sizeof(struct uds_configuration_8_02)];
 	size_t offset = 0;
 
@@ -331,9 +331,9 @@ int uds_make_configuration(const struct uds_parameters *params,
 	if (result != UDS_SUCCESS)
 		return result;
 
-	result = uds_make_geometry(DEFAULT_BYTES_PER_PAGE, record_pages_per_chapter,
-				   chapters_per_volume, sparse_chapters_per_volume, 0, 0,
-				   &config->geometry);
+	result = uds_make_index_geometry(DEFAULT_BYTES_PER_PAGE, record_pages_per_chapter,
+					 chapters_per_volume, sparse_chapters_per_volume,
+					 0, 0, &config->geometry);
 	if (result != UDS_SUCCESS) {
 		uds_free_configuration(config);
 		return result;
@@ -357,14 +357,14 @@ int uds_make_configuration(const struct uds_parameters *params,
 void uds_free_configuration(struct configuration *config)
 {
 	if (config != NULL) {
-		uds_free_geometry(config->geometry);
+		uds_free_index_geometry(config->geometry);
 		uds_free(config);
 	}
 }
 
 void uds_log_configuration(struct configuration *config)
 {
-	struct geometry *geometry = config->geometry;
+	struct index_geometry *geometry = config->geometry;
 
 	uds_log_debug("Configuration:");
 	uds_log_debug("  Record pages per chapter:   %10u", geometry->record_pages_per_chapter);

--- a/drivers/md/dm-vdo/config.h
+++ b/drivers/md/dm-vdo/config.h
@@ -11,7 +11,7 @@
 #include "uds.h"
 
 /*
- * The configuration records a variety of parameters used to configure a new UDS index. Some
+ * The uds_configuration records a variety of parameters used to configure a new UDS index. Some
  * parameters are provided by the client, while others are fixed or derived from user-supplied
  * values. It is created when an index is created, and it is recorded in the index metadata.
  */
@@ -24,7 +24,7 @@ enum {
 };
 
 /* A set of configuration parameters for the indexer. */
-struct configuration {
+struct uds_configuration {
 	/* Storage device for the index */
 	struct block_device *bdev;
 
@@ -109,16 +109,16 @@ struct uds_configuration_6_02 {
 } __packed;
 
 int __must_check uds_make_configuration(const struct uds_parameters *params,
-					struct configuration **config_ptr);
+					struct uds_configuration **config_ptr);
 
-void uds_free_configuration(struct configuration *config);
+void uds_free_configuration(struct uds_configuration *config);
 
 int __must_check uds_validate_config_contents(struct buffered_reader *reader,
-					      struct configuration *config);
+					      struct uds_configuration *config);
 
 int __must_check uds_write_config_contents(struct buffered_writer *writer,
-					   struct configuration *config, u32 version);
+					   struct uds_configuration *config, u32 version);
 
-void uds_log_configuration(struct configuration *config);
+void uds_log_configuration(struct uds_configuration *config);
 
 #endif /* UDS_CONFIG_H */

--- a/drivers/md/dm-vdo/config.h
+++ b/drivers/md/dm-vdo/config.h
@@ -37,7 +37,7 @@ struct configuration {
 	/* Parameters for the volume */
 
 	/* The volume layout */
-	struct geometry *geometry;
+	struct index_geometry *geometry;
 
 	/* Index owner's nonce */
 	u64 nonce;

--- a/drivers/md/dm-vdo/geometry.h
+++ b/drivers/md/dm-vdo/geometry.h
@@ -3,18 +3,18 @@
  * Copyright 2023 Red Hat
  */
 
-#ifndef UDS_GEOMETRY_H
-#define UDS_GEOMETRY_H
+#ifndef UDS_INDEX_GEOMETRY_H
+#define UDS_INDEX_GEOMETRY_H
 
 #include "uds.h"
 
 /*
- * The geometry records parameters that define the layout of a UDS index volume, and the size and
+ * The index_geometry records parameters that define the layout of a UDS index volume, and the size and
  * shape of various index structures. It is created when the index is created, and is referenced by
  * many index sub-components.
  */
 
-struct geometry {
+struct index_geometry {
 	/* Size of a chapter page, in bytes */
 	size_t bytes_per_page;
 	/* Number of record pages in a chapter */
@@ -95,44 +95,46 @@ enum {
 	HEADER_PAGES_PER_VOLUME = 1,
 };
 
-int __must_check uds_make_geometry(size_t bytes_per_page, u32 record_pages_per_chapter,
-				   u32 chapters_per_volume,
-				   u32 sparse_chapters_per_volume, u64 remapped_virtual,
-				   u64 remapped_physical,
-				   struct geometry **geometry_ptr);
+int __must_check uds_make_index_geometry(size_t bytes_per_page, u32 record_pages_per_chapter,
+					 u32 chapters_per_volume,
+					 u32 sparse_chapters_per_volume, u64 remapped_virtual,
+					 u64 remapped_physical,
+					 struct index_geometry **geometry_ptr);
 
-int __must_check uds_copy_geometry(struct geometry *source,
-				   struct geometry **geometry_ptr);
+int __must_check uds_copy_index_geometry(struct index_geometry *source,
+					 struct index_geometry **geometry_ptr);
 
-void uds_free_geometry(struct geometry *geometry);
+void uds_free_index_geometry(struct index_geometry *geometry);
 
-u32 __must_check uds_map_to_physical_chapter(const struct geometry *geometry,
+u32 __must_check uds_map_to_physical_chapter(const struct index_geometry *geometry,
 					     u64 virtual_chapter);
 
 /*
  * Check whether this geometry is reduced by a chapter. This will only be true if the volume was
  * converted from a non-lvm volume to an lvm volume.
  */
-static inline bool __must_check uds_is_reduced_geometry(const struct geometry *geometry)
+static inline bool __must_check
+uds_is_reduced_index_geometry(const struct index_geometry *geometry)
 {
 	return !!(geometry->chapters_per_volume & 1);
 }
 
-static inline bool __must_check uds_is_sparse_geometry(const struct geometry *geometry)
+static inline bool __must_check
+uds_is_sparse_index_geometry(const struct index_geometry *geometry)
 {
 	return geometry->sparse_chapters_per_volume > 0;
 }
 
-bool __must_check uds_has_sparse_chapters(const struct geometry *geometry,
+bool __must_check uds_has_sparse_chapters(const struct index_geometry *geometry,
 					  u64 oldest_virtual_chapter,
 					  u64 newest_virtual_chapter);
 
-bool __must_check uds_is_chapter_sparse(const struct geometry *geometry,
+bool __must_check uds_is_chapter_sparse(const struct index_geometry *geometry,
 					u64 oldest_virtual_chapter,
 					u64 newest_virtual_chapter,
 					u64 virtual_chapter_number);
 
-u32 __must_check uds_chapters_to_expire(const struct geometry *geometry,
+u32 __must_check uds_chapters_to_expire(const struct index_geometry *geometry,
 					u64 newest_chapter);
 
-#endif /* UDS_GEOMETRY_H */
+#endif /* UDS_INDEX_GEOMETRY_H */

--- a/drivers/md/dm-vdo/hash-utils.h
+++ b/drivers/md/dm-vdo/hash-utils.h
@@ -43,7 +43,7 @@ static inline u32 uds_extract_sampling_bytes(const struct uds_record_name *name)
 
 /* Compute the chapter delta list for a given name. */
 static inline u32 uds_hash_to_chapter_delta_list(const struct uds_record_name *name,
-						 const struct geometry *geometry)
+						 const struct index_geometry *geometry)
 {
 	return ((uds_extract_chapter_index_bytes(name) >> geometry->chapter_address_bits) &
 		((1 << geometry->chapter_delta_list_bits) - 1));
@@ -51,7 +51,7 @@ static inline u32 uds_hash_to_chapter_delta_list(const struct uds_record_name *n
 
 /* Compute the chapter delta address for a given name. */
 static inline u32 uds_hash_to_chapter_delta_address(const struct uds_record_name *name,
-						    const struct geometry *geometry)
+						    const struct index_geometry *geometry)
 {
 	return uds_extract_chapter_index_bytes(name) & ((1 << geometry->chapter_address_bits) - 1);
 }

--- a/drivers/md/dm-vdo/index-layout.c
+++ b/drivers/md/dm-vdo/index-layout.c
@@ -222,7 +222,7 @@ static inline bool is_converted_super_block(struct super_block_data *super)
 	return super->version == 7;
 }
 
-static int __must_check compute_sizes(const struct configuration *config,
+static int __must_check compute_sizes(const struct uds_configuration *config,
 				      struct save_layout_sizes *sls)
 {
 	int result;
@@ -256,7 +256,7 @@ static int __must_check compute_sizes(const struct configuration *config,
 int uds_compute_index_size(const struct uds_parameters *parameters, u64 *index_size)
 {
 	int result;
-	struct configuration *index_config;
+	struct uds_configuration *index_config;
 	struct save_layout_sizes sizes;
 
 	if (index_size == NULL) {
@@ -752,7 +752,7 @@ static int __must_check write_layout_header(struct index_layout *layout,
 }
 
 static int __must_check write_uds_index_config(struct index_layout *layout,
-					       struct configuration *config,
+					       struct uds_configuration *config,
 					       off_t offset)
 {
 	int result;
@@ -801,7 +801,7 @@ static int __must_check save_layout(struct index_layout *layout, off_t offset)
 	return result;
 }
 
-static int create_index_layout(struct index_layout *layout, struct configuration *config)
+static int create_index_layout(struct index_layout *layout, struct uds_configuration *config)
 {
 	int result;
 	struct save_layout_sizes sizes;
@@ -1620,7 +1620,7 @@ static int __must_check load_sub_index_regions(struct index_layout *layout)
 }
 
 static int __must_check verify_uds_index_config(struct index_layout *layout,
-						struct configuration *config)
+						struct uds_configuration *config)
 {
 	int result;
 	struct buffered_reader *reader = NULL;
@@ -1641,7 +1641,7 @@ static int __must_check verify_uds_index_config(struct index_layout *layout,
 	return UDS_SUCCESS;
 }
 
-static int load_index_layout(struct index_layout *layout, struct configuration *config)
+static int load_index_layout(struct index_layout *layout, struct uds_configuration *config)
 {
 	int result;
 	struct buffered_reader *reader;
@@ -1665,7 +1665,7 @@ static int load_index_layout(struct index_layout *layout, struct configuration *
 }
 
 static int create_layout_factory(struct index_layout *layout,
-				 const struct configuration *config)
+				 const struct uds_configuration *config)
 {
 	int result;
 	size_t writable_size;
@@ -1689,7 +1689,7 @@ static int create_layout_factory(struct index_layout *layout,
 	return UDS_SUCCESS;
 }
 
-int uds_make_index_layout(struct configuration *config, bool new_layout,
+int uds_make_index_layout(struct uds_configuration *config, bool new_layout,
 			  struct index_layout **layout_ptr)
 {
 	int result;

--- a/drivers/md/dm-vdo/index-layout.c
+++ b/drivers/md/dm-vdo/index-layout.c
@@ -226,7 +226,7 @@ static int __must_check compute_sizes(const struct configuration *config,
 				      struct save_layout_sizes *sls)
 {
 	int result;
-	struct geometry *geometry = config->geometry;
+	struct index_geometry *geometry = config->geometry;
 
 	memset(sls, 0, sizeof(*sls));
 	sls->save_count = MAX_SAVES;

--- a/drivers/md/dm-vdo/index-layout.h
+++ b/drivers/md/dm-vdo/index-layout.h
@@ -18,7 +18,7 @@
 
 struct index_layout;
 
-int __must_check uds_make_index_layout(struct configuration *config, bool new_layout,
+int __must_check uds_make_index_layout(struct uds_configuration *config, bool new_layout,
 				       struct index_layout **layout_ptr);
 
 void uds_free_index_layout(struct index_layout *layout);

--- a/drivers/md/dm-vdo/index-page-map.c
+++ b/drivers/md/dm-vdo/index-page-map.c
@@ -28,12 +28,12 @@ enum {
 	PAGE_MAP_MAGIC_LENGTH = sizeof(PAGE_MAP_MAGIC) - 1,
 };
 
-static inline u32 get_entry_count(const struct geometry *geometry)
+static inline u32 get_entry_count(const struct index_geometry *geometry)
 {
 	return geometry->chapters_per_volume * (geometry->index_pages_per_chapter - 1);
 }
 
-int uds_make_index_page_map(const struct geometry *geometry,
+int uds_make_index_page_map(const struct index_geometry *geometry,
 			    struct index_page_map **map_ptr)
 {
 	int result;
@@ -106,7 +106,7 @@ void uds_get_list_number_bounds(const struct index_page_map *map, u32 chapter_nu
 			 map->geometry->delta_lists_per_chapter - 1);
 }
 
-u64 uds_compute_index_page_map_save_size(const struct geometry *geometry)
+u64 uds_compute_index_page_map_save_size(const struct index_geometry *geometry)
 {
 	return PAGE_MAP_MAGIC_LENGTH + sizeof(u64) + sizeof(u16) * get_entry_count(geometry);
 }

--- a/drivers/md/dm-vdo/index-page-map.h
+++ b/drivers/md/dm-vdo/index-page-map.h
@@ -16,13 +16,13 @@
  */
 
 struct index_page_map {
-	const struct geometry *geometry;
+	const struct index_geometry *geometry;
 	u64 last_update;
 	u32 entries_per_chapter;
 	u16 *entries;
 };
 
-int __must_check uds_make_index_page_map(const struct geometry *geometry,
+int __must_check uds_make_index_page_map(const struct index_geometry *geometry,
 					 struct index_page_map **map_ptr);
 
 void uds_free_index_page_map(struct index_page_map *map);
@@ -45,6 +45,6 @@ void uds_get_list_number_bounds(const struct index_page_map *map, u32 chapter_nu
 				u32 index_page_number, u32 *lowest_list,
 				u32 *highest_list);
 
-u64 uds_compute_index_page_map_save_size(const struct geometry *geometry);
+u64 uds_compute_index_page_map_save_size(const struct index_geometry *geometry);
 
 #endif /* UDS_INDEX_PAGE_MAP_H */

--- a/drivers/md/dm-vdo/index-session.c
+++ b/drivers/md/dm-vdo/index-session.c
@@ -314,7 +314,7 @@ static int initialize_index_session(struct uds_index_session *index_session,
 				    enum uds_open_index_type open_type)
 {
 	int result;
-	struct configuration *config;
+	struct uds_configuration *config;
 
 	result = uds_make_configuration(&index_session->parameters, &config);
 	if (result != UDS_SUCCESS) {

--- a/drivers/md/dm-vdo/index.c
+++ b/drivers/md/dm-vdo/index.c
@@ -1162,7 +1162,7 @@ static int make_index_zone(struct uds_index *index, unsigned int zone_number)
 	return UDS_SUCCESS;
 }
 
-int uds_make_index(struct configuration *config, enum uds_open_index_type open_type,
+int uds_make_index(struct uds_configuration *config, enum uds_open_index_type open_type,
 		   struct index_load_context *load_context, index_callback_fn callback,
 		   struct uds_index **new_index)
 {

--- a/drivers/md/dm-vdo/index.c
+++ b/drivers/md/dm-vdo/index.c
@@ -153,7 +153,7 @@ static int simulate_index_zone_barrier_message(struct index_zone *zone,
 	u64 sparse_virtual_chapter;
 
 	if ((zone->index->zone_count > 1) ||
-	    !uds_is_sparse_geometry(zone->index->volume->geometry))
+	    !uds_is_sparse_index_geometry(zone->index->volume->geometry))
 		return UDS_SUCCESS;
 
 	sparse_virtual_chapter = triage_index_request(zone->index, request);
@@ -472,7 +472,7 @@ static int search_index_zone(struct index_zone *zone, struct uds_request *reques
 			found = true;
 		} else if (request->location == UDS_LOCATION_UNAVAILABLE) {
 			found = false;
-		} else if (uds_is_sparse_geometry(zone->index->volume->geometry) &&
+		} else if (uds_is_sparse_index_geometry(zone->index->volume->geometry) &&
 			   !uds_is_volume_index_sample(zone->index->volume_index,
 						       &request->record_name)) {
 			result = search_sparse_cache_in_zone(zone, request, NO_CHAPTER,
@@ -647,7 +647,7 @@ static void execute_zone_request(struct uds_request *request)
 }
 
 static int initialize_index_queues(struct uds_index *index,
-				   const struct geometry *geometry)
+				   const struct index_geometry *geometry)
 {
 	int result;
 	unsigned int i;
@@ -660,7 +660,7 @@ static int initialize_index_queues(struct uds_index *index,
 	}
 
 	/* The triage queue is only needed for sparse multi-zone indexes. */
-	if ((index->zone_count > 1) && uds_is_sparse_geometry(geometry)) {
+	if ((index->zone_count > 1) && uds_is_sparse_index_geometry(geometry)) {
 		result = uds_make_request_queue("triageW", &triage_request,
 						&index->triage_queue);
 		if (result != UDS_SUCCESS)
@@ -840,7 +840,7 @@ static int rebuild_index_page_map(struct uds_index *index, u64 vcn)
 {
 	int result;
 	struct delta_index_page *chapter_index_page;
-	struct geometry *geometry = index->volume->geometry;
+	struct index_geometry *geometry = index->volume->geometry;
 	u32 chapter = uds_map_to_physical_chapter(geometry, vcn);
 	u32 expected_list_number = 0;
 	u32 index_page_number;
@@ -987,7 +987,7 @@ static int replay_chapter(struct uds_index *index, u64 virtual, bool sparse)
 	int result;
 	u32 i;
 	u32 j;
-	const struct geometry *geometry;
+	const struct index_geometry *geometry;
 	u32 physical_chapter;
 
 	if (check_for_suspend(index)) {

--- a/drivers/md/dm-vdo/index.h
+++ b/drivers/md/dm-vdo/index.h
@@ -62,7 +62,7 @@ enum request_stage {
 	STAGE_MESSAGE,
 };
 
-int __must_check uds_make_index(struct configuration *config,
+int __must_check uds_make_index(struct uds_configuration *config,
 				enum uds_open_index_type open_type,
 				struct index_load_context *load_context,
 				index_callback_fn callback, struct uds_index **new_index);

--- a/drivers/md/dm-vdo/open-chapter.c
+++ b/drivers/md/dm-vdo/open-chapter.c
@@ -61,7 +61,7 @@ static inline size_t slots_size(size_t slot_count)
 	return sizeof(struct open_chapter_zone_slot) * slot_count;
 }
 
-int uds_make_open_chapter(const struct geometry *geometry, unsigned int zone_count,
+int uds_make_open_chapter(const struct index_geometry *geometry, unsigned int zone_count,
 			  struct open_chapter_zone **open_chapter_ptr)
 {
 	int result;
@@ -346,7 +346,7 @@ int uds_save_open_chapter(struct uds_index *index, struct buffered_writer *write
 	return uds_flush_buffered_writer(writer);
 }
 
-u64 uds_compute_saved_open_chapter_size(struct geometry *geometry)
+u64 uds_compute_saved_open_chapter_size(struct index_geometry *geometry)
 {
 	unsigned int records_per_chapter = geometry->records_per_chapter;
 

--- a/drivers/md/dm-vdo/open-chapter.h
+++ b/drivers/md/dm-vdo/open-chapter.h
@@ -43,7 +43,7 @@ struct open_chapter_zone {
 	struct open_chapter_zone_slot slots[];
 };
 
-int __must_check uds_make_open_chapter(const struct geometry *geometry,
+int __must_check uds_make_open_chapter(const struct index_geometry *geometry,
 				       unsigned int zone_count,
 				       struct open_chapter_zone **open_chapter_ptr);
 
@@ -74,6 +74,6 @@ int __must_check uds_save_open_chapter(struct uds_index *index,
 int __must_check uds_load_open_chapter(struct uds_index *index,
 				       struct buffered_reader *reader);
 
-u64 uds_compute_saved_open_chapter_size(struct geometry *geometry);
+u64 uds_compute_saved_open_chapter_size(struct index_geometry *geometry);
 
 #endif /* UDS_OPEN_CHAPTER_H */

--- a/drivers/md/dm-vdo/sparse-cache.c
+++ b/drivers/md/dm-vdo/sparse-cache.c
@@ -142,7 +142,7 @@ struct search_list {
 };
 
 struct sparse_cache {
-	const struct geometry *geometry;
+	const struct index_geometry *geometry;
 	unsigned int capacity;
 	unsigned int zone_count;
 
@@ -157,7 +157,7 @@ struct sparse_cache {
 };
 
 static int __must_check initialize_cached_chapter_index(struct cached_chapter_index *chapter,
-							const struct geometry *geometry)
+							const struct index_geometry *geometry)
 {
 	int result;
 
@@ -197,7 +197,7 @@ static int __must_check make_search_list(struct sparse_cache *cache,
 	return UDS_SUCCESS;
 }
 
-int uds_make_sparse_cache(const struct geometry *geometry, unsigned int capacity,
+int uds_make_sparse_cache(const struct index_geometry *geometry, unsigned int capacity,
 			  unsigned int zone_count, struct sparse_cache **cache_ptr)
 {
 	int result;
@@ -512,7 +512,7 @@ static inline bool should_skip_chapter(struct cached_chapter_index *chapter,
 }
 
 static int __must_check search_cached_chapter_index(struct cached_chapter_index *chapter,
-						    const struct geometry *geometry,
+						    const struct index_geometry *geometry,
 						    const struct index_page_map *index_page_map,
 						    const struct uds_record_name *name,
 						    u16 *record_page_ptr)

--- a/drivers/md/dm-vdo/sparse-cache.h
+++ b/drivers/md/dm-vdo/sparse-cache.h
@@ -26,7 +26,7 @@
 struct index_zone;
 struct sparse_cache;
 
-int __must_check uds_make_sparse_cache(const struct geometry *geometry,
+int __must_check uds_make_sparse_cache(const struct index_geometry *geometry,
 				       unsigned int capacity, unsigned int zone_count,
 				       struct sparse_cache **cache_ptr);
 

--- a/drivers/md/dm-vdo/volume-index.c
+++ b/drivers/md/dm-vdo/volume-index.c
@@ -80,11 +80,11 @@ struct sub_index_parameters {
 
 struct split_config {
 	/* The hook subindex configuration */
-	struct configuration hook_config;
+	struct uds_configuration hook_config;
 	struct index_geometry hook_geometry;
 
 	/* The non-hook subindex configuration */
-	struct configuration non_hook_config;
+	struct uds_configuration non_hook_config;
 	struct index_geometry non_hook_geometry;
 };
 
@@ -192,7 +192,7 @@ unsigned int uds_get_volume_index_zone(const struct volume_index *volume_index,
 	return get_volume_sub_index_zone(get_volume_sub_index(volume_index, name), name);
 }
 
-static int compute_volume_sub_index_parameters(const struct configuration *config,
+static int compute_volume_sub_index_parameters(const struct uds_configuration *config,
 					       struct sub_index_parameters *params)
 {
 	enum { DELTA_LIST_SIZE = 256 };
@@ -300,7 +300,7 @@ void uds_free_volume_index(struct volume_index *volume_index)
 }
 
 
-static int compute_volume_sub_index_save_bytes(const struct configuration *config,
+static int compute_volume_sub_index_save_bytes(const struct uds_configuration *config,
 					       size_t *bytes)
 {
 	struct sub_index_parameters params = { .address_bits = 0 };
@@ -317,7 +317,7 @@ static int compute_volume_sub_index_save_bytes(const struct configuration *confi
 }
 
 /* This function is only useful if the configuration includes sparse chapters. */
-static void split_configuration(const struct configuration *config,
+static void split_configuration(const struct uds_configuration *config,
 				struct split_config *split)
 {
 	u64 sample_rate, sample_records;
@@ -346,7 +346,7 @@ static void split_configuration(const struct configuration *config,
 	split->non_hook_geometry.chapters_per_volume = dense_chapters;
 }
 
-static int compute_volume_index_save_bytes(const struct configuration *config,
+static int compute_volume_index_save_bytes(const struct uds_configuration *config,
 					   size_t *bytes)
 {
 	size_t hook_bytes, non_hook_bytes;
@@ -370,7 +370,7 @@ static int compute_volume_index_save_bytes(const struct configuration *config,
 	return UDS_SUCCESS;
 }
 
-int uds_compute_volume_index_save_blocks(const struct configuration *config,
+int uds_compute_volume_index_save_blocks(const struct uds_configuration *config,
 					 size_t block_size, u64 *block_count)
 {
 	size_t bytes;
@@ -1172,7 +1172,7 @@ void uds_get_volume_index_stats(const struct volume_index *volume_index,
 	stats->early_flushes += sparse_stats.early_flushes;
 }
 
-static int initialize_volume_sub_index(const struct configuration *config,
+static int initialize_volume_sub_index(const struct uds_configuration *config,
 				       u64 volume_nonce, u8 tag,
 				       struct volume_sub_index *sub_index)
 {
@@ -1222,7 +1222,7 @@ static int initialize_volume_sub_index(const struct configuration *config,
 			    "volume index zones", &sub_index->zones);
 }
 
-int uds_make_volume_index(const struct configuration *config, u64 volume_nonce,
+int uds_make_volume_index(const struct uds_configuration *config, u64 volume_nonce,
 			  struct volume_index **volume_index_ptr)
 {
 	struct split_config split;

--- a/drivers/md/dm-vdo/volume-index.c
+++ b/drivers/md/dm-vdo/volume-index.c
@@ -81,11 +81,11 @@ struct sub_index_parameters {
 struct split_config {
 	/* The hook subindex configuration */
 	struct configuration hook_config;
-	struct geometry hook_geometry;
+	struct index_geometry hook_geometry;
 
 	/* The non-hook subindex configuration */
 	struct configuration non_hook_config;
-	struct geometry non_hook_geometry;
+	struct index_geometry non_hook_geometry;
 };
 
 struct chapter_range {
@@ -204,7 +204,7 @@ static int compute_volume_sub_index_parameters(const struct configuration *confi
 	u64 index_size_in_bits;
 	size_t expected_index_size;
 	u64 min_delta_lists = MAX_ZONES * MAX_ZONES;
-	struct geometry *geometry = config->geometry;
+	struct index_geometry *geometry = config->geometry;
 	u64 records_per_chapter = geometry->records_per_chapter;
 
 	params->chapter_count = geometry->chapters_per_volume;
@@ -214,7 +214,7 @@ static int compute_volume_sub_index_parameters(const struct configuration *confi
 	 * index delta list.
 	 */
 	rounded_chapters = params->chapter_count;
-	if (uds_is_reduced_geometry(geometry))
+	if (uds_is_reduced_index_geometry(geometry))
 		rounded_chapters += 1;
 	delta_list_records = records_per_chapter * rounded_chapters;
 	address_count = config->volume_index_mean_delta * DELTA_LIST_SIZE;
@@ -353,7 +353,7 @@ static int compute_volume_index_save_bytes(const struct configuration *config,
 	struct split_config split;
 	int result;
 
-	if (!uds_is_sparse_geometry(config->geometry))
+	if (!uds_is_sparse_index_geometry(config->geometry))
 		return compute_volume_sub_index_save_bytes(config, bytes);
 
 	split_configuration(config, &split);
@@ -1236,7 +1236,7 @@ int uds_make_volume_index(const struct configuration *config, u64 volume_nonce,
 
 	volume_index->zone_count = config->zone_count;
 
-	if (!uds_is_sparse_geometry(config->geometry)) {
+	if (!uds_is_sparse_index_geometry(config->geometry)) {
 		result = initialize_volume_sub_index(config, volume_nonce, 'm',
 						     &volume_index->vi_non_hook);
 		if (result != UDS_SUCCESS) {

--- a/drivers/md/dm-vdo/volume-index.h
+++ b/drivers/md/dm-vdo/volume-index.h
@@ -136,13 +136,13 @@ struct volume_index_record {
 	struct delta_index_entry delta_entry;
 };
 
-int __must_check uds_make_volume_index(const struct configuration *config,
+int __must_check uds_make_volume_index(const struct uds_configuration *config,
 				       u64 volume_nonce,
 				       struct volume_index **volume_index);
 
 void uds_free_volume_index(struct volume_index *volume_index);
 
-int __must_check uds_compute_volume_index_save_blocks(const struct configuration *config,
+int __must_check uds_compute_volume_index_save_blocks(const struct uds_configuration *config,
 						      size_t block_size,
 						      u64 *block_count);
 

--- a/drivers/md/dm-vdo/volume.c
+++ b/drivers/md/dm-vdo/volume.c
@@ -1538,7 +1538,7 @@ static int __must_check initialize_page_cache(struct page_cache *cache,
 	return UDS_SUCCESS;
 }
 
-int uds_make_volume(const struct configuration *config, struct index_layout *layout,
+int uds_make_volume(const struct uds_configuration *config, struct index_layout *layout,
 		    struct volume **new_volume)
 {
 	unsigned int i;

--- a/drivers/md/dm-vdo/volume.h
+++ b/drivers/md/dm-vdo/volume.h
@@ -96,7 +96,7 @@ struct page_cache {
 };
 
 struct volume {
-	struct geometry *geometry;
+	struct index_geometry *geometry;
 	struct dm_bufio_client *client;
 	u64 nonce;
 	size_t cache_size;

--- a/drivers/md/dm-vdo/volume.h
+++ b/drivers/md/dm-vdo/volume.h
@@ -121,7 +121,7 @@ struct volume {
 	unsigned int reserved_buffers;
 };
 
-int __must_check uds_make_volume(const struct configuration *config,
+int __must_check uds_make_volume(const struct uds_configuration *config,
 				 struct index_layout *layout,
 				 struct volume **new_volume);
 


### PR DESCRIPTION
Apply Mike's upstream suggestions renaming struct geometry to struct index_geometry and struct configuration to struct uds_configuration.
This series contains commits from PR vdo-devel/75.