### PR TITLE
Fix checkout action of vdo-devel in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
     - uses: actions/checkout@v2
       with:
-        repo: ${{ github.event.repository.owner.login }}/vdo-devel
+        repository: ${{ github.event.repository.owner.login }}/vdo-devel
         path: vdo-devel
 
     - name: Add private testing running label


### PR DESCRIPTION
The checkout action for vdo-devel was using an incorrect parameter name. It should have been using 'repository' instead of 'repo'.