### PR TITLE
[VDO-5679] Format/reflow message stats

### DIFF
--- a/drivers/md/dm-vdo/message-stats.c
+++ b/drivers/md/dm-vdo/message-stats.c
@@ -11,16 +11,11 @@
 #include "thread-device.h"
 #include "vdo.h"
 
-static int write_u64(char *prefix,
-		     u64 value,
-		     char *suffix,
-		     char **buf,
+static int write_u64(char *prefix, u64 value, char *suffix, char **buf,
 		     unsigned int *maxlen)
 {
-	int count = scnprintf(*buf, *maxlen, "%s%llu%s",
-			      prefix == NULL ? "" : prefix,
-			      value,
-			      suffix == NULL ? "" : suffix);
+	int count = scnprintf(*buf, *maxlen, "%s%llu%s", prefix == NULL ? "" : prefix,
+			      value, suffix == NULL ? "" : suffix);
 	*buf += count;
 	*maxlen -= count;
 	if (count >= *maxlen)
@@ -28,16 +23,11 @@ static int write_u64(char *prefix,
 	return VDO_SUCCESS;
 }
 
-static int write_u32(char *prefix,
-		     u32 value,
-		     char *suffix,
-		     char **buf,
+static int write_u32(char *prefix, u32 value, char *suffix, char **buf,
 		     unsigned int *maxlen)
 {
-	int count = scnprintf(*buf, *maxlen, "%s%u%s",
-			      prefix == NULL ? "" : prefix,
-			      value,
-			      suffix == NULL ? "" : suffix);
+	int count = scnprintf(*buf, *maxlen, "%s%u%s", prefix == NULL ? "" : prefix,
+			      value, suffix == NULL ? "" : suffix);
 	*buf += count;
 	*maxlen -= count;
 	if (count >= *maxlen)
@@ -45,16 +35,11 @@ static int write_u32(char *prefix,
 	return VDO_SUCCESS;
 }
 
-static int write_block_count_t(char *prefix,
-			       block_count_t value,
-			       char *suffix,
-			       char **buf,
-			       unsigned int *maxlen)
+static int write_block_count_t(char *prefix, block_count_t value, char *suffix,
+			       char **buf, unsigned int *maxlen)
 {
-	int count = scnprintf(*buf, *maxlen, "%s%llu%s",
-			      prefix == NULL ? "" : prefix,
-			      value,
-			      suffix == NULL ? "" : suffix);
+	int count = scnprintf(*buf, *maxlen, "%s%llu%s", prefix == NULL ? "" : prefix,
+			      value, suffix == NULL ? "" : suffix);
 	*buf += count;
 	*maxlen -= count;
 	if (count >= *maxlen)
@@ -62,16 +47,11 @@ static int write_block_count_t(char *prefix,
 	return VDO_SUCCESS;
 }
 
-static int write_string(char *prefix,
-			char *value,
-			char *suffix,
-			char **buf,
+static int write_string(char *prefix, char *value, char *suffix, char **buf,
 			unsigned int *maxlen)
 {
-	int count = scnprintf(*buf, *maxlen, "%s%s%s",
-			      prefix == NULL ? "" : prefix,
-			      value,
-			      suffix == NULL ? "" : suffix);
+	int count = scnprintf(*buf, *maxlen, "%s%s%s", prefix == NULL ? "" : prefix,
+			      value, suffix == NULL ? "" : suffix);
 	*buf += count;
 	*maxlen -= count;
 	if (count >= *maxlen)
@@ -79,16 +59,11 @@ static int write_string(char *prefix,
 	return VDO_SUCCESS;
 }
 
-static int write_bool(char *prefix,
-		      bool value,
-		      char *suffix,
-		      char **buf,
+static int write_bool(char *prefix, bool value, char *suffix, char **buf,
 		      unsigned int *maxlen)
 {
-	int count = scnprintf(*buf, *maxlen, "%s%d%s",
-			      prefix == NULL ? "" : prefix,
-			      value,
-			      suffix == NULL ? "" : suffix);
+	int count = scnprintf(*buf, *maxlen, "%s%d%s", prefix == NULL ? "" : prefix,
+			      value, suffix == NULL ? "" : suffix);
 	*buf += count;
 	*maxlen -= count;
 	if (count >= *maxlen)
@@ -96,16 +71,11 @@ static int write_bool(char *prefix,
 	return VDO_SUCCESS;
 }
 
-static int write_u8(char *prefix,
-		    u8 value,
-		    char *suffix,
-		    char **buf,
+static int write_u8(char *prefix, u8 value, char *suffix, char **buf,
 		    unsigned int *maxlen)
 {
-	int count = scnprintf(*buf, *maxlen, "%s%u%s",
-			      prefix == NULL ? "" : prefix,
-			      value,
-			      suffix == NULL ? "" : suffix);
+	int count = scnprintf(*buf, *maxlen, "%s%u%s", prefix == NULL ? "" : prefix,
+			      value, suffix == NULL ? "" : suffix);
 	*buf += count;
 	*maxlen -= count;
 	if (count >= *maxlen)
@@ -115,8 +85,7 @@ static int write_u8(char *prefix,
 
 static int write_block_allocator_statistics(char *prefix,
 					    struct block_allocator_statistics *stats,
-					    char *suffix,
-					    char **buf,
+					    char *suffix, char **buf,
 					    unsigned int *maxlen)
 {
 	int result;
@@ -125,27 +94,15 @@ static int write_block_allocator_statistics(char *prefix,
 	if (result != VDO_SUCCESS)
 		return result;
 	/* The total number of slabs from which blocks may be allocated */
-	result = write_u64("slabCount : ",
-			   stats->slab_count,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("slabCount : ", stats->slab_count, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* The total number of slabs from which blocks have ever been allocated */
-	result = write_u64("slabsOpened : ",
-			   stats->slabs_opened,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("slabsOpened : ", stats->slabs_opened, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* The number of times since loading that a slab has been re-opened */
-	result = write_u64("slabsReopened : ",
-			   stats->slabs_reopened,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("slabsReopened : ", stats->slabs_reopened, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	result = write_string(NULL, "}", suffix, buf, maxlen);
@@ -154,11 +111,8 @@ static int write_block_allocator_statistics(char *prefix,
 	return VDO_SUCCESS;
 }
 
-static int write_commit_statistics(char *prefix,
-				   struct commit_statistics *stats,
-				   char *suffix,
-				   char **buf,
-				   unsigned int *maxlen)
+static int write_commit_statistics(char *prefix, struct commit_statistics *stats,
+				   char *suffix, char **buf, unsigned int *maxlen)
 {
 	int result;
 
@@ -166,27 +120,15 @@ static int write_commit_statistics(char *prefix,
 	if (result != VDO_SUCCESS)
 		return result;
 	/* The total number of items on which processing has started */
-	result = write_u64("started : ",
-			   stats->started,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("started : ", stats->started, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* The total number of items for which a write operation has been issued */
-	result = write_u64("written : ",
-			   stats->written,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("written : ", stats->written, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* The total number of items for which a write operation has completed */
-	result = write_u64("committed : ",
-			   stats->committed,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("committed : ", stats->committed, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	result = write_string(NULL, "}", suffix, buf, maxlen);
@@ -197,8 +139,7 @@ static int write_commit_statistics(char *prefix,
 
 static int write_recovery_journal_statistics(char *prefix,
 					     struct recovery_journal_statistics *stats,
-					     char *suffix,
-					     char **buf,
+					     char *suffix, char **buf,
 					     unsigned int *maxlen)
 {
 	int result;
@@ -207,35 +148,21 @@ static int write_recovery_journal_statistics(char *prefix,
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of times the on-disk journal was full */
-	result = write_u64("diskFull : ",
-			   stats->disk_full,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("diskFull : ", stats->disk_full, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of times the recovery journal requested slab journal commits. */
 	result = write_u64("slabJournalCommitsRequested : ",
-			   stats->slab_journal_commits_requested,
-			   ", ",
-			   buf,
-			   maxlen);
+			   stats->slab_journal_commits_requested, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Write/Commit totals for individual journal entries */
-	result = write_commit_statistics("entries : ",
-					 &stats->entries,
-					 ", ",
-					 buf,
+	result = write_commit_statistics("entries : ", &stats->entries, ", ", buf,
 					 maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Write/Commit totals for journal blocks */
-	result = write_commit_statistics("blocks : ",
-					 &stats->blocks,
-					 ", ",
-					 buf,
-					 maxlen);
+	result = write_commit_statistics("blocks : ", &stats->blocks, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	result = write_string(NULL, "}", suffix, buf, maxlen);
@@ -244,11 +171,8 @@ static int write_recovery_journal_statistics(char *prefix,
 	return VDO_SUCCESS;
 }
 
-static int write_packer_statistics(char *prefix,
-				   struct packer_statistics *stats,
-				   char *suffix,
-				   char **buf,
-				   unsigned int *maxlen)
+static int write_packer_statistics(char *prefix, struct packer_statistics *stats,
+				   char *suffix, char **buf, unsigned int *maxlen)
 {
 	int result;
 
@@ -257,26 +181,17 @@ static int write_packer_statistics(char *prefix,
 		return result;
 	/* Number of compressed data items written since startup */
 	result = write_u64("compressedFragmentsWritten : ",
-			   stats->compressed_fragments_written,
-			   ", ",
-			   buf,
-			   maxlen);
+			   stats->compressed_fragments_written, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of blocks containing compressed items written since startup */
 	result = write_u64("compressedBlocksWritten : ",
-			   stats->compressed_blocks_written,
-			   ", ",
-			   buf,
-			   maxlen);
+			   stats->compressed_blocks_written, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of VIOs that are pending in the packer */
 	result = write_u64("compressedFragmentsInPacker : ",
-			   stats->compressed_fragments_in_packer,
-			   ", ",
-			   buf,
-			   maxlen);
+			   stats->compressed_fragments_in_packer, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	result = write_string(NULL, "}", suffix, buf, maxlen);
@@ -287,9 +202,7 @@ static int write_packer_statistics(char *prefix,
 
 static int write_slab_journal_statistics(char *prefix,
 					 struct slab_journal_statistics *stats,
-					 char *suffix,
-					 char **buf,
-					 unsigned int *maxlen)
+					 char *suffix, char **buf, unsigned int *maxlen)
 {
 	int result;
 
@@ -297,42 +210,24 @@ static int write_slab_journal_statistics(char *prefix,
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of times the on-disk journal was full */
-	result = write_u64("diskFullCount : ",
-			   stats->disk_full_count,
-			   ", ",
-			   buf,
+	result = write_u64("diskFullCount : ", stats->disk_full_count, ", ", buf,
 			   maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of times an entry was added over the flush threshold */
-	result = write_u64("flushCount : ",
-			   stats->flush_count,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("flushCount : ", stats->flush_count, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of times an entry was added over the block threshold */
-	result = write_u64("blockedCount : ",
-			   stats->blocked_count,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("blockedCount : ", stats->blocked_count, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of times a tail block was written */
-	result = write_u64("blocksWritten : ",
-			   stats->blocks_written,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("blocksWritten : ", stats->blocks_written, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of times we had to wait for the tail to write */
-	result = write_u64("tailBusyCount : ",
-			   stats->tail_busy_count,
-			   ", ",
-			   buf,
+	result = write_u64("tailBusyCount : ", stats->tail_busy_count, ", ", buf,
 			   maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
@@ -344,9 +239,7 @@ static int write_slab_journal_statistics(char *prefix,
 
 static int write_slab_summary_statistics(char *prefix,
 					 struct slab_summary_statistics *stats,
-					 char *suffix,
-					 char **buf,
-					 unsigned int *maxlen)
+					 char *suffix, char **buf, unsigned int *maxlen)
 {
 	int result;
 
@@ -354,11 +247,7 @@ static int write_slab_summary_statistics(char *prefix,
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of blocks written */
-	result = write_u64("blocksWritten : ",
-			   stats->blocks_written,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("blocksWritten : ", stats->blocks_written, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	result = write_string(NULL, "}", suffix, buf, maxlen);
@@ -367,11 +256,8 @@ static int write_slab_summary_statistics(char *prefix,
 	return VDO_SUCCESS;
 }
 
-static int write_ref_counts_statistics(char *prefix,
-				       struct ref_counts_statistics *stats,
-				       char *suffix,
-				       char **buf,
-				       unsigned int *maxlen)
+static int write_ref_counts_statistics(char *prefix, struct ref_counts_statistics *stats,
+				       char *suffix, char **buf, unsigned int *maxlen)
 {
 	int result;
 
@@ -379,11 +265,7 @@ static int write_ref_counts_statistics(char *prefix,
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of reference blocks written */
-	result = write_u64("blocksWritten : ",
-			   stats->blocks_written,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("blocksWritten : ", stats->blocks_written, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	result = write_string(NULL, "}", suffix, buf, maxlen);
@@ -392,11 +274,8 @@ static int write_ref_counts_statistics(char *prefix,
 	return VDO_SUCCESS;
 }
 
-static int write_block_map_statistics(char *prefix,
-				      struct block_map_statistics *stats,
-				      char *suffix,
-				      char **buf,
-				      unsigned int *maxlen)
+static int write_block_map_statistics(char *prefix, struct block_map_statistics *stats,
+				      char *suffix, char **buf, unsigned int *maxlen)
 {
 	int result;
 
@@ -404,163 +283,84 @@ static int write_block_map_statistics(char *prefix,
 	if (result != VDO_SUCCESS)
 		return result;
 	/* number of dirty (resident) pages */
-	result = write_u32("dirtyPages : ",
-			   stats->dirty_pages,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u32("dirtyPages : ", stats->dirty_pages, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* number of clean (resident) pages */
-	result = write_u32("cleanPages : ",
-			   stats->clean_pages,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u32("cleanPages : ", stats->clean_pages, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* number of free pages */
-	result = write_u32("freePages : ",
-			   stats->free_pages,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u32("freePages : ", stats->free_pages, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* number of pages in failed state */
-	result = write_u32("failedPages : ",
-			   stats->failed_pages,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u32("failedPages : ", stats->failed_pages, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* number of pages incoming */
-	result = write_u32("incomingPages : ",
-			   stats->incoming_pages,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u32("incomingPages : ", stats->incoming_pages, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* number of pages outgoing */
-	result = write_u32("outgoingPages : ",
-			   stats->outgoing_pages,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u32("outgoingPages : ", stats->outgoing_pages, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* how many times free page not avail */
-	result = write_u32("cachePressure : ",
-			   stats->cache_pressure,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u32("cachePressure : ", stats->cache_pressure, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* number of get_vdo_page() calls for read */
-	result = write_u64("readCount : ",
-			   stats->read_count,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("readCount : ", stats->read_count, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* number of get_vdo_page() calls for write */
-	result = write_u64("writeCount : ",
-			   stats->write_count,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("writeCount : ", stats->write_count, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* number of times pages failed to read */
-	result = write_u64("failedReads : ",
-			   stats->failed_reads,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("failedReads : ", stats->failed_reads, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* number of times pages failed to write */
-	result = write_u64("failedWrites : ",
-			   stats->failed_writes,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("failedWrites : ", stats->failed_writes, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* number of gets that are reclaimed */
-	result = write_u64("reclaimed : ",
-			   stats->reclaimed,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("reclaimed : ", stats->reclaimed, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* number of gets for outgoing pages */
-	result = write_u64("readOutgoing : ",
-			   stats->read_outgoing,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("readOutgoing : ", stats->read_outgoing, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* number of gets that were already there */
-	result = write_u64("foundInCache : ",
-			   stats->found_in_cache,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("foundInCache : ", stats->found_in_cache, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* number of gets requiring discard */
-	result = write_u64("discardRequired : ",
-			   stats->discard_required,
-			   ", ",
-			   buf,
+	result = write_u64("discardRequired : ", stats->discard_required, ", ", buf,
 			   maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* number of gets enqueued for their page */
-	result = write_u64("waitForPage : ",
-			   stats->wait_for_page,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("waitForPage : ", stats->wait_for_page, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* number of gets that have to fetch */
-	result = write_u64("fetchRequired : ",
-			   stats->fetch_required,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("fetchRequired : ", stats->fetch_required, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* number of page fetches */
-	result = write_u64("pagesLoaded : ",
-			   stats->pages_loaded,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("pagesLoaded : ", stats->pages_loaded, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* number of page saves */
-	result = write_u64("pagesSaved : ",
-			   stats->pages_saved,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("pagesSaved : ", stats->pages_saved, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* the number of flushes issued */
-	result = write_u64("flushCount : ",
-			   stats->flush_count,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("flushCount : ", stats->flush_count, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	result = write_string(NULL, "}", suffix, buf, maxlen);
@@ -569,11 +369,8 @@ static int write_block_map_statistics(char *prefix,
 	return VDO_SUCCESS;
 }
 
-static int write_hash_lock_statistics(char *prefix,
-				      struct hash_lock_statistics *stats,
-				      char *suffix,
-				      char **buf,
-				      unsigned int *maxlen)
+static int write_hash_lock_statistics(char *prefix, struct hash_lock_statistics *stats,
+				      char *suffix, char **buf, unsigned int *maxlen)
 {
 	int result;
 
@@ -581,42 +378,27 @@ static int write_hash_lock_statistics(char *prefix,
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of times the UDS advice proved correct */
-	result = write_u64("dedupeAdviceValid : ",
-			   stats->dedupe_advice_valid,
-			   ", ",
-			   buf,
+	result = write_u64("dedupeAdviceValid : ", stats->dedupe_advice_valid, ", ", buf,
 			   maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of times the UDS advice proved incorrect */
-	result = write_u64("dedupeAdviceStale : ",
-			   stats->dedupe_advice_stale,
-			   ", ",
-			   buf,
+	result = write_u64("dedupeAdviceStale : ", stats->dedupe_advice_stale, ", ", buf,
 			   maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of writes with the same data as another in-flight write */
-	result = write_u64("concurrentDataMatches : ",
-			   stats->concurrent_data_matches,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("concurrentDataMatches : ", stats->concurrent_data_matches,
+			   ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of writes whose hash collided with an in-flight write */
 	result = write_u64("concurrentHashCollisions : ",
-			   stats->concurrent_hash_collisions,
-			   ", ",
-			   buf,
-			   maxlen);
+			   stats->concurrent_hash_collisions, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Current number of dedupe queries that are in flight */
-	result = write_u32("currDedupeQueries : ",
-			   stats->curr_dedupe_queries,
-			   ", ",
-			   buf,
+	result = write_u32("currDedupeQueries : ", stats->curr_dedupe_queries, ", ", buf,
 			   maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
@@ -626,11 +408,8 @@ static int write_hash_lock_statistics(char *prefix,
 	return VDO_SUCCESS;
 }
 
-static int write_error_statistics(char *prefix,
-				  struct error_statistics *stats,
-				  char *suffix,
-				  char **buf,
-				  unsigned int *maxlen)
+static int write_error_statistics(char *prefix, struct error_statistics *stats,
+				  char *suffix, char **buf, unsigned int *maxlen)
 {
 	int result;
 
@@ -638,27 +417,18 @@ static int write_error_statistics(char *prefix,
 	if (result != VDO_SUCCESS)
 		return result;
 	/* number of times VDO got an invalid dedupe advice PBN from UDS */
-	result = write_u64("invalidAdvicePBNCount : ",
-			   stats->invalid_advice_pbn_count,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("invalidAdvicePBNCount : ", stats->invalid_advice_pbn_count,
+			   ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* number of times a VIO completed with a VDO_NO_SPACE error */
-	result = write_u64("noSpaceErrorCount : ",
-			   stats->no_space_error_count,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("noSpaceErrorCount : ", stats->no_space_error_count, ", ",
+			   buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* number of times a VIO completed with a VDO_READ_ONLY error */
-	result = write_u64("readOnlyErrorCount : ",
-			   stats->read_only_error_count,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("readOnlyErrorCount : ", stats->read_only_error_count, ", ",
+			   buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	result = write_string(NULL, "}", suffix, buf, maxlen);
@@ -667,11 +437,8 @@ static int write_error_statistics(char *prefix,
 	return VDO_SUCCESS;
 }
 
-static int write_bio_stats(char *prefix,
-			   struct bio_stats *stats,
-			   char *suffix,
-			   char **buf,
-			   unsigned int *maxlen)
+static int write_bio_stats(char *prefix, struct bio_stats *stats, char *suffix,
+			   char **buf, unsigned int *maxlen)
 {
 	int result;
 
@@ -679,51 +446,27 @@ static int write_bio_stats(char *prefix,
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of REQ_OP_READ bios */
-	result = write_u64("read : ",
-			   stats->read,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("read : ", stats->read, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of REQ_OP_WRITE bios with data */
-	result = write_u64("write : ",
-			   stats->write,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("write : ", stats->write, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of bios tagged with REQ_PREFLUSH and containing no data */
-	result = write_u64("emptyFlush : ",
-			   stats->empty_flush,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("emptyFlush : ", stats->empty_flush, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of REQ_OP_DISCARD bios */
-	result = write_u64("discard : ",
-			   stats->discard,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("discard : ", stats->discard, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of bios tagged with REQ_PREFLUSH */
-	result = write_u64("flush : ",
-			   stats->flush,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("flush : ", stats->flush, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of bios tagged with REQ_FUA */
-	result = write_u64("fua : ",
-			   stats->fua,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("fua : ", stats->fua, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	result = write_string(NULL, "}", suffix, buf, maxlen);
@@ -732,11 +475,8 @@ static int write_bio_stats(char *prefix,
 	return VDO_SUCCESS;
 }
 
-static int write_memory_usage(char *prefix,
-			      struct memory_usage *stats,
-			      char *suffix,
-			      char **buf,
-			      unsigned int *maxlen)
+static int write_memory_usage(char *prefix, struct memory_usage *stats, char *suffix,
+			      char **buf, unsigned int *maxlen)
 {
 	int result;
 
@@ -744,18 +484,11 @@ static int write_memory_usage(char *prefix,
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Tracked bytes currently allocated. */
-	result = write_u64("bytesUsed : ",
-			   stats->bytes_used,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("bytesUsed : ", stats->bytes_used, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Maximum tracked bytes allocated. */
-	result = write_u64("peakBytesUsed : ",
-			   stats->peak_bytes_used,
-			   ", ",
-			   buf,
+	result = write_u64("peakBytesUsed : ", stats->peak_bytes_used, ", ", buf,
 			   maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
@@ -765,11 +498,8 @@ static int write_memory_usage(char *prefix,
 	return VDO_SUCCESS;
 }
 
-static int write_index_statistics(char *prefix,
-				  struct index_statistics *stats,
-				  char *suffix,
-				  char **buf,
-				  unsigned int *maxlen)
+static int write_index_statistics(char *prefix, struct index_statistics *stats,
+				  char *suffix, char **buf, unsigned int *maxlen)
 {
 	int result;
 
@@ -777,66 +507,39 @@ static int write_index_statistics(char *prefix,
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of records stored in the index */
-	result = write_u64("entriesIndexed : ",
-			   stats->entries_indexed,
-			   ", ",
-			   buf,
+	result = write_u64("entriesIndexed : ", stats->entries_indexed, ", ", buf,
 			   maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of post calls that found an existing entry */
-	result = write_u64("postsFound : ",
-			   stats->posts_found,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("postsFound : ", stats->posts_found, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of post calls that added a new entry */
-	result = write_u64("postsNotFound : ",
-			   stats->posts_not_found,
-			   ", ",
-			   buf,
+	result = write_u64("postsNotFound : ", stats->posts_not_found, ", ", buf,
 			   maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of query calls that found an existing entry */
-	result = write_u64("queriesFound : ",
-			   stats->queries_found,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("queriesFound : ", stats->queries_found, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of query calls that added a new entry */
-	result = write_u64("queriesNotFound : ",
-			   stats->queries_not_found,
-			   ", ",
-			   buf,
+	result = write_u64("queriesNotFound : ", stats->queries_not_found, ", ", buf,
 			   maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of update calls that found an existing entry */
-	result = write_u64("updatesFound : ",
-			   stats->updates_found,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("updatesFound : ", stats->updates_found, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of update calls that added a new entry */
-	result = write_u64("updatesNotFound : ",
-			   stats->updates_not_found,
-			   ", ",
-			   buf,
+	result = write_u64("updatesNotFound : ", stats->updates_not_found, ", ", buf,
 			   maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of entries discarded */
-	result = write_u64("entriesDiscarded : ",
-			   stats->entries_discarded,
-			   ", ",
-			   buf,
+	result = write_u64("entriesDiscarded : ", stats->entries_discarded, ", ", buf,
 			   maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
@@ -846,349 +549,205 @@ static int write_index_statistics(char *prefix,
 	return VDO_SUCCESS;
 }
 
-static int write_vdo_statistics(char *prefix,
-				struct vdo_statistics *stats,
-				char *suffix,
-				char **buf,
-				unsigned int *maxlen)
+static int write_vdo_statistics(char *prefix, struct vdo_statistics *stats, char *suffix,
+				char **buf, unsigned int *maxlen)
 {
 	int result;
 
 	result = write_string(prefix, "{ ", NULL, buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
-	result = write_u32("version : ",
-			   stats->version,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u32("version : ", stats->version, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of blocks used for data */
-	result = write_u64("dataBlocksUsed : ",
-			   stats->data_blocks_used,
-			   ", ",
-			   buf,
+	result = write_u64("dataBlocksUsed : ", stats->data_blocks_used, ", ", buf,
 			   maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of blocks used for VDO metadata */
-	result = write_u64("overheadBlocksUsed : ",
-			   stats->overhead_blocks_used,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("overheadBlocksUsed : ", stats->overhead_blocks_used, ", ",
+			   buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of logical blocks that are currently mapped to physical blocks */
-	result = write_u64("logicalBlocksUsed : ",
-			   stats->logical_blocks_used,
-			   ", ",
-			   buf,
+	result = write_u64("logicalBlocksUsed : ", stats->logical_blocks_used, ", ", buf,
 			   maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* number of physical blocks */
-	result = write_block_count_t("physicalBlocks : ",
-				     stats->physical_blocks,
-				     ", ",
-				     buf,
-				     maxlen);
+	result = write_block_count_t("physicalBlocks : ", stats->physical_blocks, ", ",
+				     buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* number of logical blocks */
-	result = write_block_count_t("logicalBlocks : ",
-				     stats->logical_blocks,
-				     ", ",
-				     buf,
-				     maxlen);
+	result = write_block_count_t("logicalBlocks : ", stats->logical_blocks, ", ",
+				     buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Size of the block map page cache, in bytes */
-	result = write_u64("blockMapCacheSize : ",
-			   stats->block_map_cache_size,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("blockMapCacheSize : ", stats->block_map_cache_size, ", ",
+			   buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* The physical block size */
-	result = write_u64("blockSize : ",
-			   stats->block_size,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("blockSize : ", stats->block_size, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of times the VDO has successfully recovered */
-	result = write_u64("completeRecoveries : ",
-			   stats->complete_recoveries,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("completeRecoveries : ", stats->complete_recoveries, ", ",
+			   buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of times the VDO has recovered from read-only mode */
-	result = write_u64("readOnlyRecoveries : ",
-			   stats->read_only_recoveries,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("readOnlyRecoveries : ", stats->read_only_recoveries, ", ",
+			   buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* String describing the operating mode of the VDO */
-	result = write_string("mode : ",
-			      stats->mode,
-			      ", ",
-			      buf,
-			      maxlen);
+	result = write_string("mode : ", stats->mode, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Whether the VDO is in recovery mode */
-	result = write_bool("inRecoveryMode : ",
-			    stats->in_recovery_mode,
-			    ", ",
-			    buf,
+	result = write_bool("inRecoveryMode : ", stats->in_recovery_mode, ", ", buf,
 			    maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* What percentage of recovery mode work has been completed */
-	result = write_u8("recoveryPercentage : ",
-			  stats->recovery_percentage,
-			  ", ",
-			  buf,
+	result = write_u8("recoveryPercentage : ", stats->recovery_percentage, ", ", buf,
 			  maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* The statistics for the compressed block packer */
-	result = write_packer_statistics("packer : ",
-					 &stats->packer,
-					 ", ",
-					 buf,
-					 maxlen);
+	result = write_packer_statistics("packer : ", &stats->packer, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Counters for events in the block allocator */
-	result = write_block_allocator_statistics("allocator : ",
-						  &stats->allocator,
-						  ", ",
-						  buf,
-						  maxlen);
+	result = write_block_allocator_statistics("allocator : ", &stats->allocator,
+						  ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Counters for events in the recovery journal */
-	result = write_recovery_journal_statistics("journal : ",
-						   &stats->journal,
-						   ", ",
-						   buf,
-						   maxlen);
+	result = write_recovery_journal_statistics("journal : ", &stats->journal, ", ",
+						   buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* The statistics for the slab journals */
-	result = write_slab_journal_statistics("slabJournal : ",
-					       &stats->slab_journal,
-					       ", ",
-					       buf,
-					       maxlen);
+	result = write_slab_journal_statistics("slabJournal : ", &stats->slab_journal,
+					       ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* The statistics for the slab summary */
-	result = write_slab_summary_statistics("slabSummary : ",
-					       &stats->slab_summary,
-					       ", ",
-					       buf,
-					       maxlen);
+	result = write_slab_summary_statistics("slabSummary : ", &stats->slab_summary,
+					       ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* The statistics for the reference counts */
-	result = write_ref_counts_statistics("refCounts : ",
-					     &stats->ref_counts,
-					     ", ",
-					     buf,
-					     maxlen);
+	result = write_ref_counts_statistics("refCounts : ", &stats->ref_counts, ", ",
+					     buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* The statistics for the block map */
-	result = write_block_map_statistics("blockMap : ",
-					    &stats->block_map,
-					    ", ",
-					    buf,
+	result = write_block_map_statistics("blockMap : ", &stats->block_map, ", ", buf,
 					    maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* The dedupe statistics from hash locks */
-	result = write_hash_lock_statistics("hashLock : ",
-					    &stats->hash_lock,
-					    ", ",
-					    buf,
+	result = write_hash_lock_statistics("hashLock : ", &stats->hash_lock, ", ", buf,
 					    maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Counts of error conditions */
-	result = write_error_statistics("errors : ",
-					&stats->errors,
-					", ",
-					buf,
-					maxlen);
+	result = write_error_statistics("errors : ", &stats->errors, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* The VDO instance */
-	result = write_u32("instance : ",
-			   stats->instance,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u32("instance : ", stats->instance, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Current number of active VIOs */
-	result = write_u32("currentVIOsInProgress : ",
-			   stats->current_vios_in_progress,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u32("currentVIOsInProgress : ", stats->current_vios_in_progress,
+			   ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Maximum number of active VIOs */
-	result = write_u32("maxVIOs : ",
-			   stats->max_vios,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u32("maxVIOs : ", stats->max_vios, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of times the UDS index was too slow in responding */
-	result = write_u64("dedupeAdviceTimeouts : ",
-			   stats->dedupe_advice_timeouts,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("dedupeAdviceTimeouts : ", stats->dedupe_advice_timeouts,
+			   ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Number of flush requests submitted to the storage device */
-	result = write_u64("flushOut : ",
-			   stats->flush_out,
-			   ", ",
-			   buf,
-			   maxlen);
+	result = write_u64("flushOut : ", stats->flush_out, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Logical block size */
-	result = write_u64("logicalBlockSize : ",
-			   stats->logical_block_size,
-			   ", ",
-			   buf,
+	result = write_u64("logicalBlockSize : ", stats->logical_block_size, ", ", buf,
 			   maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Bios submitted into VDO from above */
-	result = write_bio_stats("biosIn : ",
-				 &stats->bios_in,
-				 ", ",
-				 buf,
-				 maxlen);
+	result = write_bio_stats("biosIn : ", &stats->bios_in, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
-	result = write_bio_stats("biosInPartial : ",
-				 &stats->bios_in_partial,
-				 ", ",
-				 buf,
+	result = write_bio_stats("biosInPartial : ", &stats->bios_in_partial, ", ", buf,
 				 maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Bios submitted onward for user data */
-	result = write_bio_stats("biosOut : ",
-				 &stats->bios_out,
-				 ", ",
-				 buf,
-				 maxlen);
+	result = write_bio_stats("biosOut : ", &stats->bios_out, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Bios submitted onward for metadata */
-	result = write_bio_stats("biosMeta : ",
-				 &stats->bios_meta,
-				 ", ",
-				 buf,
+	result = write_bio_stats("biosMeta : ", &stats->bios_meta, ", ", buf, maxlen);
+	if (result != VDO_SUCCESS)
+		return result;
+	result = write_bio_stats("biosJournal : ", &stats->bios_journal, ", ", buf,
 				 maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
-	result = write_bio_stats("biosJournal : ",
-				 &stats->bios_journal,
-				 ", ",
-				 buf,
+	result = write_bio_stats("biosPageCache : ", &stats->bios_page_cache, ", ", buf,
 				 maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
-	result = write_bio_stats("biosPageCache : ",
-				 &stats->bios_page_cache,
-				 ", ",
-				 buf,
-				 maxlen);
+	result = write_bio_stats("biosOutCompleted : ", &stats->bios_out_completed, ", ",
+				 buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
-	result = write_bio_stats("biosOutCompleted : ",
-				 &stats->bios_out_completed,
-				 ", ",
-				 buf,
-				 maxlen);
-	if (result != VDO_SUCCESS)
-		return result;
-	result = write_bio_stats("biosMetaCompleted : ",
-				 &stats->bios_meta_completed,
-				 ", ",
-				 buf,
-				 maxlen);
+	result = write_bio_stats("biosMetaCompleted : ", &stats->bios_meta_completed,
+				 ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	result = write_bio_stats("biosJournalCompleted : ",
-				 &stats->bios_journal_completed,
-				 ", ",
-				 buf,
-				 maxlen);
+				 &stats->bios_journal_completed, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	result = write_bio_stats("biosPageCacheCompleted : ",
-				 &stats->bios_page_cache_completed,
-				 ", ",
-				 buf,
-				 maxlen);
+				 &stats->bios_page_cache_completed, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
-	result = write_bio_stats("biosAcknowledged : ",
-				 &stats->bios_acknowledged,
-				 ", ",
-				 buf,
-				 maxlen);
+	result = write_bio_stats("biosAcknowledged : ", &stats->bios_acknowledged, ", ",
+				 buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	result = write_bio_stats("biosAcknowledgedPartial : ",
-				 &stats->bios_acknowledged_partial,
-				 ", ",
-				 buf,
-				 maxlen);
+				 &stats->bios_acknowledged_partial, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Current number of bios in progress */
-	result = write_bio_stats("biosInProgress : ",
-				 &stats->bios_in_progress,
-				 ", ",
-				 buf,
-				 maxlen);
+	result = write_bio_stats("biosInProgress : ", &stats->bios_in_progress, ", ",
+				 buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* Memory usage stats. */
-	result = write_memory_usage("memoryUsage : ",
-				    &stats->memory_usage,
-				    ", ",
-				    buf,
+	result = write_memory_usage("memoryUsage : ", &stats->memory_usage, ", ", buf,
 				    maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	/* The statistics for the UDS index */
-	result = write_index_statistics("index : ",
-					&stats->index,
-					", ",
-					buf,
-					maxlen);
+	result = write_index_statistics("index : ", &stats->index, ", ", buf, maxlen);
 	if (result != VDO_SUCCESS)
 		return result;
 	result = write_string(NULL, "}", suffix, buf, maxlen);
@@ -1197,9 +756,7 @@ static int write_vdo_statistics(char *prefix,
 	return VDO_SUCCESS;
 }
 
-int vdo_write_stats(struct vdo *vdo,
-		    char *buf,
-		    unsigned int maxlen)
+int vdo_write_stats(struct vdo *vdo, char *buf, unsigned int maxlen)
 {
 	struct vdo_statistics *stats;
 	int result;

--- a/drivers/md/dm-vdo/pool-sysfs-stats.c
+++ b/drivers/md/dm-vdo/pool-sysfs-stats.c
@@ -18,8 +18,7 @@ struct pool_stats_attribute {
 	ssize_t (*print)(struct vdo_statistics *stats, char *buf);
 };
 
-static ssize_t pool_stats_attr_show(struct kobject *directory,
-				    struct attribute *attr,
+static ssize_t pool_stats_attr_show(struct kobject *directory, struct attribute *attr,
 				    char *buf)
 {
 	ssize_t size;
@@ -44,8 +43,7 @@ const struct sysfs_ops vdo_pool_stats_sysfs_ops = {
 };
 
 /* Number of blocks used for data */
-static ssize_t
-pool_stats_print_data_blocks_used(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_data_blocks_used(struct vdo_statistics *stats, char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->data_blocks_used);
 }
@@ -56,8 +54,8 @@ static struct pool_stats_attribute pool_stats_attr_data_blocks_used = {
 };
 
 /* Number of blocks used for VDO metadata */
-static ssize_t
-pool_stats_print_overhead_blocks_used(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_overhead_blocks_used(struct vdo_statistics *stats,
+						     char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->overhead_blocks_used);
 }
@@ -68,8 +66,8 @@ static struct pool_stats_attribute pool_stats_attr_overhead_blocks_used = {
 };
 
 /* Number of logical blocks that are currently mapped to physical blocks */
-static ssize_t
-pool_stats_print_logical_blocks_used(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_logical_blocks_used(struct vdo_statistics *stats,
+						    char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->logical_blocks_used);
 }
@@ -80,8 +78,7 @@ static struct pool_stats_attribute pool_stats_attr_logical_blocks_used = {
 };
 
 /* number of physical blocks */
-static ssize_t
-pool_stats_print_physical_blocks(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_physical_blocks(struct vdo_statistics *stats, char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->physical_blocks);
 }
@@ -92,8 +89,7 @@ static struct pool_stats_attribute pool_stats_attr_physical_blocks = {
 };
 
 /* number of logical blocks */
-static ssize_t
-pool_stats_print_logical_blocks(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_logical_blocks(struct vdo_statistics *stats, char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->logical_blocks);
 }
@@ -104,8 +100,8 @@ static struct pool_stats_attribute pool_stats_attr_logical_blocks = {
 };
 
 /* Size of the block map page cache, in bytes */
-static ssize_t
-pool_stats_print_block_map_cache_size(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_block_map_cache_size(struct vdo_statistics *stats,
+						     char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->block_map_cache_size);
 }
@@ -116,8 +112,7 @@ static struct pool_stats_attribute pool_stats_attr_block_map_cache_size = {
 };
 
 /* The physical block size */
-static ssize_t
-pool_stats_print_block_size(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_block_size(struct vdo_statistics *stats, char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->block_size);
 }
@@ -128,8 +123,8 @@ static struct pool_stats_attribute pool_stats_attr_block_size = {
 };
 
 /* Number of times the VDO has successfully recovered */
-static ssize_t
-pool_stats_print_complete_recoveries(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_complete_recoveries(struct vdo_statistics *stats,
+						    char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->complete_recoveries);
 }
@@ -140,8 +135,8 @@ static struct pool_stats_attribute pool_stats_attr_complete_recoveries = {
 };
 
 /* Number of times the VDO has recovered from read-only mode */
-static ssize_t
-pool_stats_print_read_only_recoveries(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_read_only_recoveries(struct vdo_statistics *stats,
+						     char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->read_only_recoveries);
 }
@@ -152,8 +147,7 @@ static struct pool_stats_attribute pool_stats_attr_read_only_recoveries = {
 };
 
 /* String describing the operating mode of the VDO */
-static ssize_t
-pool_stats_print_mode(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_mode(struct vdo_statistics *stats, char *buf)
 {
 	return sprintf(buf, "%s\n", stats->mode);
 }
@@ -164,8 +158,7 @@ static struct pool_stats_attribute pool_stats_attr_mode = {
 };
 
 /* Whether the VDO is in recovery mode */
-static ssize_t
-pool_stats_print_in_recovery_mode(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_in_recovery_mode(struct vdo_statistics *stats, char *buf)
 {
 	return sprintf(buf, "%d\n", stats->in_recovery_mode);
 }
@@ -176,8 +169,8 @@ static struct pool_stats_attribute pool_stats_attr_in_recovery_mode = {
 };
 
 /* What percentage of recovery mode work has been completed */
-static ssize_t
-pool_stats_print_recovery_percentage(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_recovery_percentage(struct vdo_statistics *stats,
+						    char *buf)
 {
 	return sprintf(buf, "%u\n", stats->recovery_percentage);
 }
@@ -188,8 +181,8 @@ static struct pool_stats_attribute pool_stats_attr_recovery_percentage = {
 };
 
 /* Number of compressed data items written since startup */
-static ssize_t
-pool_stats_print_packer_compressed_fragments_written(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_packer_compressed_fragments_written(struct vdo_statistics *stats,
+								    char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->packer.compressed_fragments_written);
 }
@@ -200,8 +193,8 @@ static struct pool_stats_attribute pool_stats_attr_packer_compressed_fragments_w
 };
 
 /* Number of blocks containing compressed items written since startup */
-static ssize_t
-pool_stats_print_packer_compressed_blocks_written(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_packer_compressed_blocks_written(struct vdo_statistics *stats,
+								 char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->packer.compressed_blocks_written);
 }
@@ -212,8 +205,8 @@ static struct pool_stats_attribute pool_stats_attr_packer_compressed_blocks_writ
 };
 
 /* Number of VIOs that are pending in the packer */
-static ssize_t
-pool_stats_print_packer_compressed_fragments_in_packer(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_packer_compressed_fragments_in_packer(struct vdo_statistics *stats,
+								      char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->packer.compressed_fragments_in_packer);
 }
@@ -224,8 +217,8 @@ static struct pool_stats_attribute pool_stats_attr_packer_compressed_fragments_i
 };
 
 /* The total number of slabs from which blocks may be allocated */
-static ssize_t
-pool_stats_print_allocator_slab_count(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_allocator_slab_count(struct vdo_statistics *stats,
+						     char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->allocator.slab_count);
 }
@@ -236,8 +229,8 @@ static struct pool_stats_attribute pool_stats_attr_allocator_slab_count = {
 };
 
 /* The total number of slabs from which blocks have ever been allocated */
-static ssize_t
-pool_stats_print_allocator_slabs_opened(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_allocator_slabs_opened(struct vdo_statistics *stats,
+						       char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->allocator.slabs_opened);
 }
@@ -248,8 +241,8 @@ static struct pool_stats_attribute pool_stats_attr_allocator_slabs_opened = {
 };
 
 /* The number of times since loading that a slab has been re-opened */
-static ssize_t
-pool_stats_print_allocator_slabs_reopened(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_allocator_slabs_reopened(struct vdo_statistics *stats,
+							 char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->allocator.slabs_reopened);
 }
@@ -260,8 +253,8 @@ static struct pool_stats_attribute pool_stats_attr_allocator_slabs_reopened = {
 };
 
 /* Number of times the on-disk journal was full */
-static ssize_t
-pool_stats_print_journal_disk_full(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_journal_disk_full(struct vdo_statistics *stats,
+						  char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->journal.disk_full);
 }
@@ -272,8 +265,8 @@ static struct pool_stats_attribute pool_stats_attr_journal_disk_full = {
 };
 
 /* Number of times the recovery journal requested slab journal commits. */
-static ssize_t
-pool_stats_print_journal_slab_journal_commits_requested(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_journal_slab_journal_commits_requested(struct vdo_statistics *stats,
+								       char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->journal.slab_journal_commits_requested);
 }
@@ -284,8 +277,8 @@ static struct pool_stats_attribute pool_stats_attr_journal_slab_journal_commits_
 };
 
 /* The total number of items on which processing has started */
-static ssize_t
-pool_stats_print_journal_entries_started(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_journal_entries_started(struct vdo_statistics *stats,
+							char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->journal.entries.started);
 }
@@ -296,8 +289,8 @@ static struct pool_stats_attribute pool_stats_attr_journal_entries_started = {
 };
 
 /* The total number of items for which a write operation has been issued */
-static ssize_t
-pool_stats_print_journal_entries_written(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_journal_entries_written(struct vdo_statistics *stats,
+							char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->journal.entries.written);
 }
@@ -308,8 +301,8 @@ static struct pool_stats_attribute pool_stats_attr_journal_entries_written = {
 };
 
 /* The total number of items for which a write operation has completed */
-static ssize_t
-pool_stats_print_journal_entries_committed(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_journal_entries_committed(struct vdo_statistics *stats,
+							  char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->journal.entries.committed);
 }
@@ -320,8 +313,8 @@ static struct pool_stats_attribute pool_stats_attr_journal_entries_committed = {
 };
 
 /* The total number of items on which processing has started */
-static ssize_t
-pool_stats_print_journal_blocks_started(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_journal_blocks_started(struct vdo_statistics *stats,
+						       char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->journal.blocks.started);
 }
@@ -332,8 +325,8 @@ static struct pool_stats_attribute pool_stats_attr_journal_blocks_started = {
 };
 
 /* The total number of items for which a write operation has been issued */
-static ssize_t
-pool_stats_print_journal_blocks_written(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_journal_blocks_written(struct vdo_statistics *stats,
+						       char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->journal.blocks.written);
 }
@@ -344,8 +337,8 @@ static struct pool_stats_attribute pool_stats_attr_journal_blocks_written = {
 };
 
 /* The total number of items for which a write operation has completed */
-static ssize_t
-pool_stats_print_journal_blocks_committed(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_journal_blocks_committed(struct vdo_statistics *stats,
+							 char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->journal.blocks.committed);
 }
@@ -356,8 +349,8 @@ static struct pool_stats_attribute pool_stats_attr_journal_blocks_committed = {
 };
 
 /* Number of times the on-disk journal was full */
-static ssize_t
-pool_stats_print_slab_journal_disk_full_count(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_slab_journal_disk_full_count(struct vdo_statistics *stats,
+							     char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->slab_journal.disk_full_count);
 }
@@ -368,8 +361,8 @@ static struct pool_stats_attribute pool_stats_attr_slab_journal_disk_full_count 
 };
 
 /* Number of times an entry was added over the flush threshold */
-static ssize_t
-pool_stats_print_slab_journal_flush_count(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_slab_journal_flush_count(struct vdo_statistics *stats,
+							 char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->slab_journal.flush_count);
 }
@@ -380,8 +373,8 @@ static struct pool_stats_attribute pool_stats_attr_slab_journal_flush_count = {
 };
 
 /* Number of times an entry was added over the block threshold */
-static ssize_t
-pool_stats_print_slab_journal_blocked_count(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_slab_journal_blocked_count(struct vdo_statistics *stats,
+							   char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->slab_journal.blocked_count);
 }
@@ -392,8 +385,8 @@ static struct pool_stats_attribute pool_stats_attr_slab_journal_blocked_count = 
 };
 
 /* Number of times a tail block was written */
-static ssize_t
-pool_stats_print_slab_journal_blocks_written(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_slab_journal_blocks_written(struct vdo_statistics *stats,
+							    char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->slab_journal.blocks_written);
 }
@@ -404,8 +397,8 @@ static struct pool_stats_attribute pool_stats_attr_slab_journal_blocks_written =
 };
 
 /* Number of times we had to wait for the tail to write */
-static ssize_t
-pool_stats_print_slab_journal_tail_busy_count(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_slab_journal_tail_busy_count(struct vdo_statistics *stats,
+							     char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->slab_journal.tail_busy_count);
 }
@@ -416,8 +409,8 @@ static struct pool_stats_attribute pool_stats_attr_slab_journal_tail_busy_count 
 };
 
 /* Number of blocks written */
-static ssize_t
-pool_stats_print_slab_summary_blocks_written(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_slab_summary_blocks_written(struct vdo_statistics *stats,
+							    char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->slab_summary.blocks_written);
 }
@@ -428,8 +421,8 @@ static struct pool_stats_attribute pool_stats_attr_slab_summary_blocks_written =
 };
 
 /* Number of reference blocks written */
-static ssize_t
-pool_stats_print_ref_counts_blocks_written(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_ref_counts_blocks_written(struct vdo_statistics *stats,
+							  char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->ref_counts.blocks_written);
 }
@@ -440,8 +433,8 @@ static struct pool_stats_attribute pool_stats_attr_ref_counts_blocks_written = {
 };
 
 /* number of dirty (resident) pages */
-static ssize_t
-pool_stats_print_block_map_dirty_pages(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_block_map_dirty_pages(struct vdo_statistics *stats,
+						      char *buf)
 {
 	return sprintf(buf, "%u\n", stats->block_map.dirty_pages);
 }
@@ -452,8 +445,8 @@ static struct pool_stats_attribute pool_stats_attr_block_map_dirty_pages = {
 };
 
 /* number of clean (resident) pages */
-static ssize_t
-pool_stats_print_block_map_clean_pages(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_block_map_clean_pages(struct vdo_statistics *stats,
+						      char *buf)
 {
 	return sprintf(buf, "%u\n", stats->block_map.clean_pages);
 }
@@ -464,8 +457,8 @@ static struct pool_stats_attribute pool_stats_attr_block_map_clean_pages = {
 };
 
 /* number of free pages */
-static ssize_t
-pool_stats_print_block_map_free_pages(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_block_map_free_pages(struct vdo_statistics *stats,
+						     char *buf)
 {
 	return sprintf(buf, "%u\n", stats->block_map.free_pages);
 }
@@ -476,8 +469,8 @@ static struct pool_stats_attribute pool_stats_attr_block_map_free_pages = {
 };
 
 /* number of pages in failed state */
-static ssize_t
-pool_stats_print_block_map_failed_pages(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_block_map_failed_pages(struct vdo_statistics *stats,
+						       char *buf)
 {
 	return sprintf(buf, "%u\n", stats->block_map.failed_pages);
 }
@@ -488,8 +481,8 @@ static struct pool_stats_attribute pool_stats_attr_block_map_failed_pages = {
 };
 
 /* number of pages incoming */
-static ssize_t
-pool_stats_print_block_map_incoming_pages(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_block_map_incoming_pages(struct vdo_statistics *stats,
+							 char *buf)
 {
 	return sprintf(buf, "%u\n", stats->block_map.incoming_pages);
 }
@@ -500,8 +493,8 @@ static struct pool_stats_attribute pool_stats_attr_block_map_incoming_pages = {
 };
 
 /* number of pages outgoing */
-static ssize_t
-pool_stats_print_block_map_outgoing_pages(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_block_map_outgoing_pages(struct vdo_statistics *stats,
+							 char *buf)
 {
 	return sprintf(buf, "%u\n", stats->block_map.outgoing_pages);
 }
@@ -512,8 +505,8 @@ static struct pool_stats_attribute pool_stats_attr_block_map_outgoing_pages = {
 };
 
 /* how many times free page not avail */
-static ssize_t
-pool_stats_print_block_map_cache_pressure(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_block_map_cache_pressure(struct vdo_statistics *stats,
+							 char *buf)
 {
 	return sprintf(buf, "%u\n", stats->block_map.cache_pressure);
 }
@@ -524,8 +517,8 @@ static struct pool_stats_attribute pool_stats_attr_block_map_cache_pressure = {
 };
 
 /* number of get_vdo_page() calls for read */
-static ssize_t
-pool_stats_print_block_map_read_count(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_block_map_read_count(struct vdo_statistics *stats,
+						     char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->block_map.read_count);
 }
@@ -536,8 +529,8 @@ static struct pool_stats_attribute pool_stats_attr_block_map_read_count = {
 };
 
 /* number of get_vdo_page() calls for write */
-static ssize_t
-pool_stats_print_block_map_write_count(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_block_map_write_count(struct vdo_statistics *stats,
+						      char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->block_map.write_count);
 }
@@ -548,8 +541,8 @@ static struct pool_stats_attribute pool_stats_attr_block_map_write_count = {
 };
 
 /* number of times pages failed to read */
-static ssize_t
-pool_stats_print_block_map_failed_reads(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_block_map_failed_reads(struct vdo_statistics *stats,
+						       char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->block_map.failed_reads);
 }
@@ -560,8 +553,8 @@ static struct pool_stats_attribute pool_stats_attr_block_map_failed_reads = {
 };
 
 /* number of times pages failed to write */
-static ssize_t
-pool_stats_print_block_map_failed_writes(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_block_map_failed_writes(struct vdo_statistics *stats,
+							char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->block_map.failed_writes);
 }
@@ -572,8 +565,8 @@ static struct pool_stats_attribute pool_stats_attr_block_map_failed_writes = {
 };
 
 /* number of gets that are reclaimed */
-static ssize_t
-pool_stats_print_block_map_reclaimed(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_block_map_reclaimed(struct vdo_statistics *stats,
+						    char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->block_map.reclaimed);
 }
@@ -584,8 +577,8 @@ static struct pool_stats_attribute pool_stats_attr_block_map_reclaimed = {
 };
 
 /* number of gets for outgoing pages */
-static ssize_t
-pool_stats_print_block_map_read_outgoing(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_block_map_read_outgoing(struct vdo_statistics *stats,
+							char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->block_map.read_outgoing);
 }
@@ -596,8 +589,8 @@ static struct pool_stats_attribute pool_stats_attr_block_map_read_outgoing = {
 };
 
 /* number of gets that were already there */
-static ssize_t
-pool_stats_print_block_map_found_in_cache(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_block_map_found_in_cache(struct vdo_statistics *stats,
+							 char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->block_map.found_in_cache);
 }
@@ -608,8 +601,8 @@ static struct pool_stats_attribute pool_stats_attr_block_map_found_in_cache = {
 };
 
 /* number of gets requiring discard */
-static ssize_t
-pool_stats_print_block_map_discard_required(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_block_map_discard_required(struct vdo_statistics *stats,
+							   char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->block_map.discard_required);
 }
@@ -620,8 +613,8 @@ static struct pool_stats_attribute pool_stats_attr_block_map_discard_required = 
 };
 
 /* number of gets enqueued for their page */
-static ssize_t
-pool_stats_print_block_map_wait_for_page(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_block_map_wait_for_page(struct vdo_statistics *stats,
+							char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->block_map.wait_for_page);
 }
@@ -632,8 +625,8 @@ static struct pool_stats_attribute pool_stats_attr_block_map_wait_for_page = {
 };
 
 /* number of gets that have to fetch */
-static ssize_t
-pool_stats_print_block_map_fetch_required(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_block_map_fetch_required(struct vdo_statistics *stats,
+							 char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->block_map.fetch_required);
 }
@@ -644,8 +637,8 @@ static struct pool_stats_attribute pool_stats_attr_block_map_fetch_required = {
 };
 
 /* number of page fetches */
-static ssize_t
-pool_stats_print_block_map_pages_loaded(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_block_map_pages_loaded(struct vdo_statistics *stats,
+						       char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->block_map.pages_loaded);
 }
@@ -656,8 +649,8 @@ static struct pool_stats_attribute pool_stats_attr_block_map_pages_loaded = {
 };
 
 /* number of page saves */
-static ssize_t
-pool_stats_print_block_map_pages_saved(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_block_map_pages_saved(struct vdo_statistics *stats,
+						      char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->block_map.pages_saved);
 }
@@ -668,8 +661,8 @@ static struct pool_stats_attribute pool_stats_attr_block_map_pages_saved = {
 };
 
 /* the number of flushes issued */
-static ssize_t
-pool_stats_print_block_map_flush_count(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_block_map_flush_count(struct vdo_statistics *stats,
+						      char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->block_map.flush_count);
 }
@@ -680,8 +673,8 @@ static struct pool_stats_attribute pool_stats_attr_block_map_flush_count = {
 };
 
 /* Number of times the UDS advice proved correct */
-static ssize_t
-pool_stats_print_hash_lock_dedupe_advice_valid(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_hash_lock_dedupe_advice_valid(struct vdo_statistics *stats,
+							      char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->hash_lock.dedupe_advice_valid);
 }
@@ -692,8 +685,8 @@ static struct pool_stats_attribute pool_stats_attr_hash_lock_dedupe_advice_valid
 };
 
 /* Number of times the UDS advice proved incorrect */
-static ssize_t
-pool_stats_print_hash_lock_dedupe_advice_stale(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_hash_lock_dedupe_advice_stale(struct vdo_statistics *stats,
+							      char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->hash_lock.dedupe_advice_stale);
 }
@@ -704,8 +697,8 @@ static struct pool_stats_attribute pool_stats_attr_hash_lock_dedupe_advice_stale
 };
 
 /* Number of writes with the same data as another in-flight write */
-static ssize_t
-pool_stats_print_hash_lock_concurrent_data_matches(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_hash_lock_concurrent_data_matches(struct vdo_statistics *stats,
+								  char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->hash_lock.concurrent_data_matches);
 }
@@ -716,8 +709,8 @@ static struct pool_stats_attribute pool_stats_attr_hash_lock_concurrent_data_mat
 };
 
 /* Number of writes whose hash collided with an in-flight write */
-static ssize_t
-pool_stats_print_hash_lock_concurrent_hash_collisions(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_hash_lock_concurrent_hash_collisions(struct vdo_statistics *stats,
+								     char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->hash_lock.concurrent_hash_collisions);
 }
@@ -728,8 +721,8 @@ static struct pool_stats_attribute pool_stats_attr_hash_lock_concurrent_hash_col
 };
 
 /* Current number of dedupe queries that are in flight */
-static ssize_t
-pool_stats_print_hash_lock_curr_dedupe_queries(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_hash_lock_curr_dedupe_queries(struct vdo_statistics *stats,
+							      char *buf)
 {
 	return sprintf(buf, "%u\n", stats->hash_lock.curr_dedupe_queries);
 }
@@ -740,8 +733,8 @@ static struct pool_stats_attribute pool_stats_attr_hash_lock_curr_dedupe_queries
 };
 
 /* number of times VDO got an invalid dedupe advice PBN from UDS */
-static ssize_t
-pool_stats_print_errors_invalid_advice_pbn_count(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_errors_invalid_advice_pbn_count(struct vdo_statistics *stats,
+								char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->errors.invalid_advice_pbn_count);
 }
@@ -752,8 +745,8 @@ static struct pool_stats_attribute pool_stats_attr_errors_invalid_advice_pbn_cou
 };
 
 /* number of times a VIO completed with a VDO_NO_SPACE error */
-static ssize_t
-pool_stats_print_errors_no_space_error_count(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_errors_no_space_error_count(struct vdo_statistics *stats,
+							    char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->errors.no_space_error_count);
 }
@@ -764,8 +757,8 @@ static struct pool_stats_attribute pool_stats_attr_errors_no_space_error_count =
 };
 
 /* number of times a VIO completed with a VDO_READ_ONLY error */
-static ssize_t
-pool_stats_print_errors_read_only_error_count(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_errors_read_only_error_count(struct vdo_statistics *stats,
+							     char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->errors.read_only_error_count);
 }
@@ -776,8 +769,7 @@ static struct pool_stats_attribute pool_stats_attr_errors_read_only_error_count 
 };
 
 /* The VDO instance */
-static ssize_t
-pool_stats_print_instance(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_instance(struct vdo_statistics *stats, char *buf)
 {
 	return sprintf(buf, "%u\n", stats->instance);
 }
@@ -788,8 +780,8 @@ static struct pool_stats_attribute pool_stats_attr_instance = {
 };
 
 /* Current number of active VIOs */
-static ssize_t
-pool_stats_print_current_vios_in_progress(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_current_vios_in_progress(struct vdo_statistics *stats,
+							 char *buf)
 {
 	return sprintf(buf, "%u\n", stats->current_vios_in_progress);
 }
@@ -800,8 +792,7 @@ static struct pool_stats_attribute pool_stats_attr_current_vios_in_progress = {
 };
 
 /* Maximum number of active VIOs */
-static ssize_t
-pool_stats_print_max_vios(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_max_vios(struct vdo_statistics *stats, char *buf)
 {
 	return sprintf(buf, "%u\n", stats->max_vios);
 }
@@ -812,8 +803,8 @@ static struct pool_stats_attribute pool_stats_attr_max_vios = {
 };
 
 /* Number of times the UDS index was too slow in responding */
-static ssize_t
-pool_stats_print_dedupe_advice_timeouts(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_dedupe_advice_timeouts(struct vdo_statistics *stats,
+						       char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->dedupe_advice_timeouts);
 }
@@ -824,8 +815,7 @@ static struct pool_stats_attribute pool_stats_attr_dedupe_advice_timeouts = {
 };
 
 /* Number of flush requests submitted to the storage device */
-static ssize_t
-pool_stats_print_flush_out(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_flush_out(struct vdo_statistics *stats, char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->flush_out);
 }
@@ -836,8 +826,8 @@ static struct pool_stats_attribute pool_stats_attr_flush_out = {
 };
 
 /* Logical block size */
-static ssize_t
-pool_stats_print_logical_block_size(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_logical_block_size(struct vdo_statistics *stats,
+						   char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->logical_block_size);
 }
@@ -848,8 +838,7 @@ static struct pool_stats_attribute pool_stats_attr_logical_block_size = {
 };
 
 /* Number of REQ_OP_READ bios */
-static ssize_t
-pool_stats_print_bios_in_read(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_in_read(struct vdo_statistics *stats, char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_in.read);
 }
@@ -860,8 +849,7 @@ static struct pool_stats_attribute pool_stats_attr_bios_in_read = {
 };
 
 /* Number of REQ_OP_WRITE bios with data */
-static ssize_t
-pool_stats_print_bios_in_write(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_in_write(struct vdo_statistics *stats, char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_in.write);
 }
@@ -872,8 +860,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_in_write = {
 };
 
 /* Number of bios tagged with REQ_PREFLUSH and containing no data */
-static ssize_t
-pool_stats_print_bios_in_empty_flush(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_in_empty_flush(struct vdo_statistics *stats,
+						    char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_in.empty_flush);
 }
@@ -884,8 +872,7 @@ static struct pool_stats_attribute pool_stats_attr_bios_in_empty_flush = {
 };
 
 /* Number of REQ_OP_DISCARD bios */
-static ssize_t
-pool_stats_print_bios_in_discard(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_in_discard(struct vdo_statistics *stats, char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_in.discard);
 }
@@ -896,8 +883,7 @@ static struct pool_stats_attribute pool_stats_attr_bios_in_discard = {
 };
 
 /* Number of bios tagged with REQ_PREFLUSH */
-static ssize_t
-pool_stats_print_bios_in_flush(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_in_flush(struct vdo_statistics *stats, char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_in.flush);
 }
@@ -908,8 +894,7 @@ static struct pool_stats_attribute pool_stats_attr_bios_in_flush = {
 };
 
 /* Number of bios tagged with REQ_FUA */
-static ssize_t
-pool_stats_print_bios_in_fua(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_in_fua(struct vdo_statistics *stats, char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_in.fua);
 }
@@ -920,8 +905,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_in_fua = {
 };
 
 /* Number of REQ_OP_READ bios */
-static ssize_t
-pool_stats_print_bios_in_partial_read(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_in_partial_read(struct vdo_statistics *stats,
+						     char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_in_partial.read);
 }
@@ -932,8 +917,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_in_partial_read = {
 };
 
 /* Number of REQ_OP_WRITE bios with data */
-static ssize_t
-pool_stats_print_bios_in_partial_write(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_in_partial_write(struct vdo_statistics *stats,
+						      char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_in_partial.write);
 }
@@ -944,8 +929,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_in_partial_write = {
 };
 
 /* Number of bios tagged with REQ_PREFLUSH and containing no data */
-static ssize_t
-pool_stats_print_bios_in_partial_empty_flush(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_in_partial_empty_flush(struct vdo_statistics *stats,
+							    char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_in_partial.empty_flush);
 }
@@ -956,8 +941,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_in_partial_empty_flush =
 };
 
 /* Number of REQ_OP_DISCARD bios */
-static ssize_t
-pool_stats_print_bios_in_partial_discard(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_in_partial_discard(struct vdo_statistics *stats,
+							char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_in_partial.discard);
 }
@@ -968,8 +953,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_in_partial_discard = {
 };
 
 /* Number of bios tagged with REQ_PREFLUSH */
-static ssize_t
-pool_stats_print_bios_in_partial_flush(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_in_partial_flush(struct vdo_statistics *stats,
+						      char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_in_partial.flush);
 }
@@ -980,8 +965,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_in_partial_flush = {
 };
 
 /* Number of bios tagged with REQ_FUA */
-static ssize_t
-pool_stats_print_bios_in_partial_fua(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_in_partial_fua(struct vdo_statistics *stats,
+						    char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_in_partial.fua);
 }
@@ -992,8 +977,7 @@ static struct pool_stats_attribute pool_stats_attr_bios_in_partial_fua = {
 };
 
 /* Number of REQ_OP_READ bios */
-static ssize_t
-pool_stats_print_bios_out_read(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_out_read(struct vdo_statistics *stats, char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_out.read);
 }
@@ -1004,8 +988,7 @@ static struct pool_stats_attribute pool_stats_attr_bios_out_read = {
 };
 
 /* Number of REQ_OP_WRITE bios with data */
-static ssize_t
-pool_stats_print_bios_out_write(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_out_write(struct vdo_statistics *stats, char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_out.write);
 }
@@ -1016,8 +999,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_out_write = {
 };
 
 /* Number of bios tagged with REQ_PREFLUSH and containing no data */
-static ssize_t
-pool_stats_print_bios_out_empty_flush(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_out_empty_flush(struct vdo_statistics *stats,
+						     char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_out.empty_flush);
 }
@@ -1028,8 +1011,7 @@ static struct pool_stats_attribute pool_stats_attr_bios_out_empty_flush = {
 };
 
 /* Number of REQ_OP_DISCARD bios */
-static ssize_t
-pool_stats_print_bios_out_discard(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_out_discard(struct vdo_statistics *stats, char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_out.discard);
 }
@@ -1040,8 +1022,7 @@ static struct pool_stats_attribute pool_stats_attr_bios_out_discard = {
 };
 
 /* Number of bios tagged with REQ_PREFLUSH */
-static ssize_t
-pool_stats_print_bios_out_flush(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_out_flush(struct vdo_statistics *stats, char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_out.flush);
 }
@@ -1052,8 +1033,7 @@ static struct pool_stats_attribute pool_stats_attr_bios_out_flush = {
 };
 
 /* Number of bios tagged with REQ_FUA */
-static ssize_t
-pool_stats_print_bios_out_fua(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_out_fua(struct vdo_statistics *stats, char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_out.fua);
 }
@@ -1064,8 +1044,7 @@ static struct pool_stats_attribute pool_stats_attr_bios_out_fua = {
 };
 
 /* Number of REQ_OP_READ bios */
-static ssize_t
-pool_stats_print_bios_meta_read(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_meta_read(struct vdo_statistics *stats, char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_meta.read);
 }
@@ -1076,8 +1055,7 @@ static struct pool_stats_attribute pool_stats_attr_bios_meta_read = {
 };
 
 /* Number of REQ_OP_WRITE bios with data */
-static ssize_t
-pool_stats_print_bios_meta_write(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_meta_write(struct vdo_statistics *stats, char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_meta.write);
 }
@@ -1088,8 +1066,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_meta_write = {
 };
 
 /* Number of bios tagged with REQ_PREFLUSH and containing no data */
-static ssize_t
-pool_stats_print_bios_meta_empty_flush(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_meta_empty_flush(struct vdo_statistics *stats,
+						      char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_meta.empty_flush);
 }
@@ -1100,8 +1078,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_meta_empty_flush = {
 };
 
 /* Number of REQ_OP_DISCARD bios */
-static ssize_t
-pool_stats_print_bios_meta_discard(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_meta_discard(struct vdo_statistics *stats,
+						  char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_meta.discard);
 }
@@ -1112,8 +1090,7 @@ static struct pool_stats_attribute pool_stats_attr_bios_meta_discard = {
 };
 
 /* Number of bios tagged with REQ_PREFLUSH */
-static ssize_t
-pool_stats_print_bios_meta_flush(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_meta_flush(struct vdo_statistics *stats, char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_meta.flush);
 }
@@ -1124,8 +1101,7 @@ static struct pool_stats_attribute pool_stats_attr_bios_meta_flush = {
 };
 
 /* Number of bios tagged with REQ_FUA */
-static ssize_t
-pool_stats_print_bios_meta_fua(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_meta_fua(struct vdo_statistics *stats, char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_meta.fua);
 }
@@ -1136,8 +1112,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_meta_fua = {
 };
 
 /* Number of REQ_OP_READ bios */
-static ssize_t
-pool_stats_print_bios_journal_read(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_journal_read(struct vdo_statistics *stats,
+						  char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_journal.read);
 }
@@ -1148,8 +1124,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_journal_read = {
 };
 
 /* Number of REQ_OP_WRITE bios with data */
-static ssize_t
-pool_stats_print_bios_journal_write(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_journal_write(struct vdo_statistics *stats,
+						   char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_journal.write);
 }
@@ -1160,8 +1136,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_journal_write = {
 };
 
 /* Number of bios tagged with REQ_PREFLUSH and containing no data */
-static ssize_t
-pool_stats_print_bios_journal_empty_flush(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_journal_empty_flush(struct vdo_statistics *stats,
+							 char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_journal.empty_flush);
 }
@@ -1172,8 +1148,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_journal_empty_flush = {
 };
 
 /* Number of REQ_OP_DISCARD bios */
-static ssize_t
-pool_stats_print_bios_journal_discard(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_journal_discard(struct vdo_statistics *stats,
+						     char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_journal.discard);
 }
@@ -1184,8 +1160,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_journal_discard = {
 };
 
 /* Number of bios tagged with REQ_PREFLUSH */
-static ssize_t
-pool_stats_print_bios_journal_flush(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_journal_flush(struct vdo_statistics *stats,
+						   char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_journal.flush);
 }
@@ -1196,8 +1172,7 @@ static struct pool_stats_attribute pool_stats_attr_bios_journal_flush = {
 };
 
 /* Number of bios tagged with REQ_FUA */
-static ssize_t
-pool_stats_print_bios_journal_fua(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_journal_fua(struct vdo_statistics *stats, char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_journal.fua);
 }
@@ -1208,8 +1183,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_journal_fua = {
 };
 
 /* Number of REQ_OP_READ bios */
-static ssize_t
-pool_stats_print_bios_page_cache_read(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_page_cache_read(struct vdo_statistics *stats,
+						     char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_page_cache.read);
 }
@@ -1220,8 +1195,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_page_cache_read = {
 };
 
 /* Number of REQ_OP_WRITE bios with data */
-static ssize_t
-pool_stats_print_bios_page_cache_write(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_page_cache_write(struct vdo_statistics *stats,
+						      char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_page_cache.write);
 }
@@ -1232,8 +1207,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_page_cache_write = {
 };
 
 /* Number of bios tagged with REQ_PREFLUSH and containing no data */
-static ssize_t
-pool_stats_print_bios_page_cache_empty_flush(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_page_cache_empty_flush(struct vdo_statistics *stats,
+							    char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_page_cache.empty_flush);
 }
@@ -1244,8 +1219,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_page_cache_empty_flush =
 };
 
 /* Number of REQ_OP_DISCARD bios */
-static ssize_t
-pool_stats_print_bios_page_cache_discard(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_page_cache_discard(struct vdo_statistics *stats,
+							char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_page_cache.discard);
 }
@@ -1256,8 +1231,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_page_cache_discard = {
 };
 
 /* Number of bios tagged with REQ_PREFLUSH */
-static ssize_t
-pool_stats_print_bios_page_cache_flush(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_page_cache_flush(struct vdo_statistics *stats,
+						      char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_page_cache.flush);
 }
@@ -1268,8 +1243,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_page_cache_flush = {
 };
 
 /* Number of bios tagged with REQ_FUA */
-static ssize_t
-pool_stats_print_bios_page_cache_fua(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_page_cache_fua(struct vdo_statistics *stats,
+						    char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_page_cache.fua);
 }
@@ -1280,8 +1255,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_page_cache_fua = {
 };
 
 /* Number of REQ_OP_READ bios */
-static ssize_t
-pool_stats_print_bios_out_completed_read(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_out_completed_read(struct vdo_statistics *stats,
+							char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_out_completed.read);
 }
@@ -1292,8 +1267,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_out_completed_read = {
 };
 
 /* Number of REQ_OP_WRITE bios with data */
-static ssize_t
-pool_stats_print_bios_out_completed_write(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_out_completed_write(struct vdo_statistics *stats,
+							 char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_out_completed.write);
 }
@@ -1304,8 +1279,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_out_completed_write = {
 };
 
 /* Number of bios tagged with REQ_PREFLUSH and containing no data */
-static ssize_t
-pool_stats_print_bios_out_completed_empty_flush(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_out_completed_empty_flush(struct vdo_statistics *stats,
+							       char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_out_completed.empty_flush);
 }
@@ -1316,8 +1291,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_out_completed_empty_flus
 };
 
 /* Number of REQ_OP_DISCARD bios */
-static ssize_t
-pool_stats_print_bios_out_completed_discard(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_out_completed_discard(struct vdo_statistics *stats,
+							   char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_out_completed.discard);
 }
@@ -1328,8 +1303,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_out_completed_discard = 
 };
 
 /* Number of bios tagged with REQ_PREFLUSH */
-static ssize_t
-pool_stats_print_bios_out_completed_flush(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_out_completed_flush(struct vdo_statistics *stats,
+							 char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_out_completed.flush);
 }
@@ -1340,8 +1315,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_out_completed_flush = {
 };
 
 /* Number of bios tagged with REQ_FUA */
-static ssize_t
-pool_stats_print_bios_out_completed_fua(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_out_completed_fua(struct vdo_statistics *stats,
+						       char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_out_completed.fua);
 }
@@ -1352,8 +1327,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_out_completed_fua = {
 };
 
 /* Number of REQ_OP_READ bios */
-static ssize_t
-pool_stats_print_bios_meta_completed_read(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_meta_completed_read(struct vdo_statistics *stats,
+							 char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_meta_completed.read);
 }
@@ -1364,8 +1339,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_meta_completed_read = {
 };
 
 /* Number of REQ_OP_WRITE bios with data */
-static ssize_t
-pool_stats_print_bios_meta_completed_write(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_meta_completed_write(struct vdo_statistics *stats,
+							  char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_meta_completed.write);
 }
@@ -1376,8 +1351,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_meta_completed_write = {
 };
 
 /* Number of bios tagged with REQ_PREFLUSH and containing no data */
-static ssize_t
-pool_stats_print_bios_meta_completed_empty_flush(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_meta_completed_empty_flush(struct vdo_statistics *stats,
+								char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_meta_completed.empty_flush);
 }
@@ -1388,8 +1363,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_meta_completed_empty_flu
 };
 
 /* Number of REQ_OP_DISCARD bios */
-static ssize_t
-pool_stats_print_bios_meta_completed_discard(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_meta_completed_discard(struct vdo_statistics *stats,
+							    char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_meta_completed.discard);
 }
@@ -1400,8 +1375,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_meta_completed_discard =
 };
 
 /* Number of bios tagged with REQ_PREFLUSH */
-static ssize_t
-pool_stats_print_bios_meta_completed_flush(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_meta_completed_flush(struct vdo_statistics *stats,
+							  char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_meta_completed.flush);
 }
@@ -1412,8 +1387,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_meta_completed_flush = {
 };
 
 /* Number of bios tagged with REQ_FUA */
-static ssize_t
-pool_stats_print_bios_meta_completed_fua(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_meta_completed_fua(struct vdo_statistics *stats,
+							char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_meta_completed.fua);
 }
@@ -1424,8 +1399,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_meta_completed_fua = {
 };
 
 /* Number of REQ_OP_READ bios */
-static ssize_t
-pool_stats_print_bios_journal_completed_read(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_journal_completed_read(struct vdo_statistics *stats,
+							    char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_journal_completed.read);
 }
@@ -1436,8 +1411,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_journal_completed_read =
 };
 
 /* Number of REQ_OP_WRITE bios with data */
-static ssize_t
-pool_stats_print_bios_journal_completed_write(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_journal_completed_write(struct vdo_statistics *stats,
+							     char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_journal_completed.write);
 }
@@ -1448,8 +1423,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_journal_completed_write 
 };
 
 /* Number of bios tagged with REQ_PREFLUSH and containing no data */
-static ssize_t
-pool_stats_print_bios_journal_completed_empty_flush(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_journal_completed_empty_flush(struct vdo_statistics *stats,
+								   char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_journal_completed.empty_flush);
 }
@@ -1460,8 +1435,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_journal_completed_empty_
 };
 
 /* Number of REQ_OP_DISCARD bios */
-static ssize_t
-pool_stats_print_bios_journal_completed_discard(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_journal_completed_discard(struct vdo_statistics *stats,
+							       char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_journal_completed.discard);
 }
@@ -1472,8 +1447,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_journal_completed_discar
 };
 
 /* Number of bios tagged with REQ_PREFLUSH */
-static ssize_t
-pool_stats_print_bios_journal_completed_flush(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_journal_completed_flush(struct vdo_statistics *stats,
+							     char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_journal_completed.flush);
 }
@@ -1484,8 +1459,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_journal_completed_flush 
 };
 
 /* Number of bios tagged with REQ_FUA */
-static ssize_t
-pool_stats_print_bios_journal_completed_fua(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_journal_completed_fua(struct vdo_statistics *stats,
+							   char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_journal_completed.fua);
 }
@@ -1496,8 +1471,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_journal_completed_fua = 
 };
 
 /* Number of REQ_OP_READ bios */
-static ssize_t
-pool_stats_print_bios_page_cache_completed_read(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_page_cache_completed_read(struct vdo_statistics *stats,
+							       char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_page_cache_completed.read);
 }
@@ -1508,8 +1483,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_page_cache_completed_rea
 };
 
 /* Number of REQ_OP_WRITE bios with data */
-static ssize_t
-pool_stats_print_bios_page_cache_completed_write(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_page_cache_completed_write(struct vdo_statistics *stats,
+								char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_page_cache_completed.write);
 }
@@ -1520,8 +1495,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_page_cache_completed_wri
 };
 
 /* Number of bios tagged with REQ_PREFLUSH and containing no data */
-static ssize_t
-pool_stats_print_bios_page_cache_completed_empty_flush(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_page_cache_completed_empty_flush(struct vdo_statistics *stats,
+								      char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_page_cache_completed.empty_flush);
 }
@@ -1532,8 +1507,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_page_cache_completed_emp
 };
 
 /* Number of REQ_OP_DISCARD bios */
-static ssize_t
-pool_stats_print_bios_page_cache_completed_discard(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_page_cache_completed_discard(struct vdo_statistics *stats,
+								  char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_page_cache_completed.discard);
 }
@@ -1544,8 +1519,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_page_cache_completed_dis
 };
 
 /* Number of bios tagged with REQ_PREFLUSH */
-static ssize_t
-pool_stats_print_bios_page_cache_completed_flush(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_page_cache_completed_flush(struct vdo_statistics *stats,
+								char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_page_cache_completed.flush);
 }
@@ -1556,8 +1531,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_page_cache_completed_flu
 };
 
 /* Number of bios tagged with REQ_FUA */
-static ssize_t
-pool_stats_print_bios_page_cache_completed_fua(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_page_cache_completed_fua(struct vdo_statistics *stats,
+							      char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_page_cache_completed.fua);
 }
@@ -1568,8 +1543,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_page_cache_completed_fua
 };
 
 /* Number of REQ_OP_READ bios */
-static ssize_t
-pool_stats_print_bios_acknowledged_read(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_acknowledged_read(struct vdo_statistics *stats,
+						       char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_acknowledged.read);
 }
@@ -1580,8 +1555,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_acknowledged_read = {
 };
 
 /* Number of REQ_OP_WRITE bios with data */
-static ssize_t
-pool_stats_print_bios_acknowledged_write(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_acknowledged_write(struct vdo_statistics *stats,
+							char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_acknowledged.write);
 }
@@ -1592,8 +1567,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_acknowledged_write = {
 };
 
 /* Number of bios tagged with REQ_PREFLUSH and containing no data */
-static ssize_t
-pool_stats_print_bios_acknowledged_empty_flush(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_acknowledged_empty_flush(struct vdo_statistics *stats,
+							      char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_acknowledged.empty_flush);
 }
@@ -1604,8 +1579,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_acknowledged_empty_flush
 };
 
 /* Number of REQ_OP_DISCARD bios */
-static ssize_t
-pool_stats_print_bios_acknowledged_discard(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_acknowledged_discard(struct vdo_statistics *stats,
+							  char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_acknowledged.discard);
 }
@@ -1616,8 +1591,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_acknowledged_discard = {
 };
 
 /* Number of bios tagged with REQ_PREFLUSH */
-static ssize_t
-pool_stats_print_bios_acknowledged_flush(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_acknowledged_flush(struct vdo_statistics *stats,
+							char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_acknowledged.flush);
 }
@@ -1628,8 +1603,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_acknowledged_flush = {
 };
 
 /* Number of bios tagged with REQ_FUA */
-static ssize_t
-pool_stats_print_bios_acknowledged_fua(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_acknowledged_fua(struct vdo_statistics *stats,
+						      char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_acknowledged.fua);
 }
@@ -1640,8 +1615,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_acknowledged_fua = {
 };
 
 /* Number of REQ_OP_READ bios */
-static ssize_t
-pool_stats_print_bios_acknowledged_partial_read(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_acknowledged_partial_read(struct vdo_statistics *stats,
+							       char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_acknowledged_partial.read);
 }
@@ -1652,8 +1627,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_acknowledged_partial_rea
 };
 
 /* Number of REQ_OP_WRITE bios with data */
-static ssize_t
-pool_stats_print_bios_acknowledged_partial_write(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_acknowledged_partial_write(struct vdo_statistics *stats,
+								char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_acknowledged_partial.write);
 }
@@ -1664,8 +1639,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_acknowledged_partial_wri
 };
 
 /* Number of bios tagged with REQ_PREFLUSH and containing no data */
-static ssize_t
-pool_stats_print_bios_acknowledged_partial_empty_flush(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_acknowledged_partial_empty_flush(struct vdo_statistics *stats,
+								      char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_acknowledged_partial.empty_flush);
 }
@@ -1676,8 +1651,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_acknowledged_partial_emp
 };
 
 /* Number of REQ_OP_DISCARD bios */
-static ssize_t
-pool_stats_print_bios_acknowledged_partial_discard(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_acknowledged_partial_discard(struct vdo_statistics *stats,
+								  char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_acknowledged_partial.discard);
 }
@@ -1688,8 +1663,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_acknowledged_partial_dis
 };
 
 /* Number of bios tagged with REQ_PREFLUSH */
-static ssize_t
-pool_stats_print_bios_acknowledged_partial_flush(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_acknowledged_partial_flush(struct vdo_statistics *stats,
+								char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_acknowledged_partial.flush);
 }
@@ -1700,8 +1675,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_acknowledged_partial_flu
 };
 
 /* Number of bios tagged with REQ_FUA */
-static ssize_t
-pool_stats_print_bios_acknowledged_partial_fua(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_acknowledged_partial_fua(struct vdo_statistics *stats,
+							      char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_acknowledged_partial.fua);
 }
@@ -1712,8 +1687,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_acknowledged_partial_fua
 };
 
 /* Number of REQ_OP_READ bios */
-static ssize_t
-pool_stats_print_bios_in_progress_read(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_in_progress_read(struct vdo_statistics *stats,
+						      char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_in_progress.read);
 }
@@ -1724,8 +1699,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_in_progress_read = {
 };
 
 /* Number of REQ_OP_WRITE bios with data */
-static ssize_t
-pool_stats_print_bios_in_progress_write(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_in_progress_write(struct vdo_statistics *stats,
+						       char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_in_progress.write);
 }
@@ -1736,8 +1711,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_in_progress_write = {
 };
 
 /* Number of bios tagged with REQ_PREFLUSH and containing no data */
-static ssize_t
-pool_stats_print_bios_in_progress_empty_flush(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_in_progress_empty_flush(struct vdo_statistics *stats,
+							     char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_in_progress.empty_flush);
 }
@@ -1748,8 +1723,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_in_progress_empty_flush 
 };
 
 /* Number of REQ_OP_DISCARD bios */
-static ssize_t
-pool_stats_print_bios_in_progress_discard(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_in_progress_discard(struct vdo_statistics *stats,
+							 char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_in_progress.discard);
 }
@@ -1760,8 +1735,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_in_progress_discard = {
 };
 
 /* Number of bios tagged with REQ_PREFLUSH */
-static ssize_t
-pool_stats_print_bios_in_progress_flush(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_in_progress_flush(struct vdo_statistics *stats,
+						       char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_in_progress.flush);
 }
@@ -1772,8 +1747,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_in_progress_flush = {
 };
 
 /* Number of bios tagged with REQ_FUA */
-static ssize_t
-pool_stats_print_bios_in_progress_fua(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_bios_in_progress_fua(struct vdo_statistics *stats,
+						     char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->bios_in_progress.fua);
 }
@@ -1784,8 +1759,8 @@ static struct pool_stats_attribute pool_stats_attr_bios_in_progress_fua = {
 };
 
 /* Tracked bytes currently allocated. */
-static ssize_t
-pool_stats_print_memory_usage_bytes_used(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_memory_usage_bytes_used(struct vdo_statistics *stats,
+							char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->memory_usage.bytes_used);
 }
@@ -1796,8 +1771,8 @@ static struct pool_stats_attribute pool_stats_attr_memory_usage_bytes_used = {
 };
 
 /* Maximum tracked bytes allocated. */
-static ssize_t
-pool_stats_print_memory_usage_peak_bytes_used(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_memory_usage_peak_bytes_used(struct vdo_statistics *stats,
+							     char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->memory_usage.peak_bytes_used);
 }
@@ -1808,8 +1783,8 @@ static struct pool_stats_attribute pool_stats_attr_memory_usage_peak_bytes_used 
 };
 
 /* Number of records stored in the index */
-static ssize_t
-pool_stats_print_index_entries_indexed(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_index_entries_indexed(struct vdo_statistics *stats,
+						      char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->index.entries_indexed);
 }
@@ -1820,8 +1795,8 @@ static struct pool_stats_attribute pool_stats_attr_index_entries_indexed = {
 };
 
 /* Number of post calls that found an existing entry */
-static ssize_t
-pool_stats_print_index_posts_found(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_index_posts_found(struct vdo_statistics *stats,
+						  char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->index.posts_found);
 }
@@ -1832,8 +1807,8 @@ static struct pool_stats_attribute pool_stats_attr_index_posts_found = {
 };
 
 /* Number of post calls that added a new entry */
-static ssize_t
-pool_stats_print_index_posts_not_found(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_index_posts_not_found(struct vdo_statistics *stats,
+						      char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->index.posts_not_found);
 }
@@ -1844,8 +1819,8 @@ static struct pool_stats_attribute pool_stats_attr_index_posts_not_found = {
 };
 
 /* Number of query calls that found an existing entry */
-static ssize_t
-pool_stats_print_index_queries_found(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_index_queries_found(struct vdo_statistics *stats,
+						    char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->index.queries_found);
 }
@@ -1856,8 +1831,8 @@ static struct pool_stats_attribute pool_stats_attr_index_queries_found = {
 };
 
 /* Number of query calls that added a new entry */
-static ssize_t
-pool_stats_print_index_queries_not_found(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_index_queries_not_found(struct vdo_statistics *stats,
+							char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->index.queries_not_found);
 }
@@ -1868,8 +1843,8 @@ static struct pool_stats_attribute pool_stats_attr_index_queries_not_found = {
 };
 
 /* Number of update calls that found an existing entry */
-static ssize_t
-pool_stats_print_index_updates_found(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_index_updates_found(struct vdo_statistics *stats,
+						    char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->index.updates_found);
 }
@@ -1880,8 +1855,8 @@ static struct pool_stats_attribute pool_stats_attr_index_updates_found = {
 };
 
 /* Number of update calls that added a new entry */
-static ssize_t
-pool_stats_print_index_updates_not_found(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_index_updates_not_found(struct vdo_statistics *stats,
+							char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->index.updates_not_found);
 }
@@ -1892,8 +1867,8 @@ static struct pool_stats_attribute pool_stats_attr_index_updates_not_found = {
 };
 
 /* Number of entries discarded */
-static ssize_t
-pool_stats_print_index_entries_discarded(struct vdo_statistics *stats, char *buf)
+static ssize_t pool_stats_print_index_entries_discarded(struct vdo_statistics *stats,
+							char *buf)
 {
 	return sprintf(buf, "%llu\n", stats->index.entries_discarded);
 }


### PR DESCRIPTION
Upstream changes in vdo-devel/81.

Of these, only the message stats reflowing will go upstream.
pool-sysfs-stats is going to be removed shortly, so there's no point in creating churn by pushing the reflow. However, we still want to keep our repository in sync so that future overlay patches don't flag the difference.