### PR TITLE
[VDO-5693] Include <asm/current.h> for loongarch

### DIFF
--- a/drivers/md/dm-vdo/logger.c
+++ b/drivers/md/dm-vdo/logger.c
@@ -5,6 +5,7 @@
 
 #include "logger.h"
 
+#include <asm/current.h>
 #include <linux/delay.h>
 #include <linux/hardirq.h>
 #include <linux/module.h>

--- a/drivers/md/dm-vdo/thread-registry.c
+++ b/drivers/md/dm-vdo/thread-registry.c
@@ -5,6 +5,7 @@
 
 #include "thread-registry.h"
 
+#include <asm/current.h>
 #include <linux/rculist.h>
 
 #include "permassert.h"

--- a/drivers/md/dm-vdo/thread-utils.c
+++ b/drivers/md/dm-vdo/thread-utils.c
@@ -5,6 +5,7 @@
 
 #include "thread-utils.h"
 
+#include <asm/current.h>
 #include <linux/delay.h>
 #include <linux/kthread.h>
 #include <linux/mutex.h>


### PR DESCRIPTION
Upstream commits from vdo-devel/94.
Reported when building on loongarch, which we can't really test.