### PR TITLE
[VDO-5720] dm vdo: use kernel byteswapping routines instead of GCC ones

### DIFF
--- a/drivers/md/dm-vdo/murmurhash3.c
+++ b/drivers/md/dm-vdo/murmurhash3.c
@@ -8,6 +8,8 @@
 
 #include "murmurhash3.h"
 
+#include <asm/byteorder.h>
+
 static inline u64 rotl64(u64 x, s8 r)
 {
 	return (x << r) | (x >> (64 - r));
@@ -16,24 +18,12 @@ static inline u64 rotl64(u64 x, s8 r)
 #define ROTL64(x, y) rotl64(x, y)
 static __always_inline u64 getblock64(const u64 *p, int i)
 {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-	return p[i];
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-	return __builtin_bswap64(p[i]);
-#else
-#error "can't figure out byte order"
-#endif
+	return le64_to_cpup(&p[i]);
 }
 
 static __always_inline void putblock64(u64 *p, int i, u64 value)
 {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-	p[i] = value;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-	p[i] = __builtin_bswap64(value);
-#else
-#error "can't figure out byte order"
-#endif
+	p[i] = cpu_to_le64(value);
 }
 
 /* Finalization mix - force all bits of a hash block to avalanche */


### PR DESCRIPTION
This fixes a sparc64 build problem.

Reported-by: Guenter Roeck <linux@roeck-us.net>