### PR TITLE
[VDO-5802] dm vdo: remove bad check of bi_next field

### DIFF
--- a/drivers/md/dm-vdo/io-submitter.c
+++ b/drivers/md/dm-vdo/io-submitter.c
@@ -346,7 +346,6 @@ void __submit_metadata_vio(struct vio *vio, physical_block_number_t physical,
 
 
 	VDO_ASSERT_LOG_ONLY(!code->quiescent, "I/O not allowed in state %s", code->name);
-	VDO_ASSERT_LOG_ONLY(vio->bio->bi_next == NULL, "metadata bio has no next bio");
 
 	vdo_reset_completion(completion);
 	completion->error_handler = error_handler;


### PR DESCRIPTION
This check was intended to make sure dm-vdo does not chain metadata bios together. Howver, vdo has no control over underlying storage layers, so the assertion is not always true. Remove the check to prevent spurious warning messages due to the behavior of other storage layers.

Changes from vdo-devel/183.