### PR TITLE
[VDO-6041][VDO-6034] Fix saved region and zone count validation

### DIFF
--- a/drivers/md/dm-vdo/indexer/index-layout.c
+++ b/drivers/md/dm-vdo/indexer/index-layout.c
@@ -1444,11 +1444,11 @@ static int __must_check reconstruct_index_save(struct index_save_layout *isl,
 	u64 next_block = isl->index_save.start_block;
 	u64 last_block = next_block + isl->index_save.block_count;
 
-	isl->zone_count = table->header.region_count - 3;
-	if (isl->zone_count > MAX_ZONES)
+	if (table->header.region_count < 4)
 		return vdo_log_error_strerror(UDS_CORRUPT_DATA,
-					      "invalid zone count");
+					      "invalid region count");
 
+	isl->zone_count = table->header.region_count - 3;
 	last_region = &table->regions[table->header.region_count - 1];
 	if (last_region->kind == RL_KIND_EMPTY) {
 		isl->free_space = *last_region;
@@ -1461,6 +1461,10 @@ static int __must_check reconstruct_index_save(struct index_save_layout *isl,
 			.instance = RL_SOLE_INSTANCE,
 		};
 	}
+
+	if (isl->zone_count > MAX_ZONES)
+		return vdo_log_error_strerror(UDS_CORRUPT_DATA,
+					      "invalid zone count");
 
 	isl->header = table->regions[0];
 	result = verify_region(&isl->header, next_block++, RL_KIND_HEADER,


### PR DESCRIPTION
Defer zone_count check until the zone_count has been completely computed. (It can depend on the existence of an empty region in the table.) Also validate the region_count to catch cases where too few regions are defined.

As mentioned in vdo-devel, I intend to squash this patch into the first patch in PR #92 and send the combination upstream as v2 of that series.