### PR TITLE
[RHELMISC-34381] Remove secret inheritance from workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,3 @@ jobs:
         REPO=${{ github.repository }}
         REPO=${REPO//\//-}
         cp -a vdo-devel/logs /permabit/user/bunsen/artifacts/logs.`date +'%Y%m%d%H%M'`.$REPO.${{ github.event.pull_request.number }}
-    secrets: inherit


### PR DESCRIPTION
According to github docs, reusable workflows have automatic permissions to github.token and secrets.GITHUB_TOKEN. Remove direct inheritance to harden the workflow code.