### PR TITLE
[RHELMISC-32989] add deviceless message support for capacity queries

### DIFF
--- a/drivers/md/dm-ioctl.c
+++ b/drivers/md/dm-ioctl.c
@@ -1754,6 +1754,30 @@ static int message_for_md(struct mapped_device *md, unsigned int argc, char **ar
 	return -EINVAL;
 }
 
+static int message_for_module(const char *target_name, unsigned int argc, char **argv,
+			      char *result, unsigned int maxlen)
+{
+	struct target_type *tt;
+	int r;
+
+	tt = dm_get_target_type(target_name);
+	if (!tt) {
+		DMERR("unknown target name %s", target_name);
+		return -EINVAL;
+	}
+
+	if (!tt->deviceless_message) {
+		DMERR("target %s doesn't support deviceless messages", target_name);
+		r = -EINVAL;
+	} else {
+		r = tt->deviceless_message(argc, argv, result, maxlen);
+	}
+
+	dm_put_target_type(tt);
+
+	return r;
+}
+
 /*
  * Pass a message to the target that's at the supplied device offset.
  */
@@ -1768,10 +1792,6 @@ static int target_message(struct file *filp, struct dm_ioctl *param, size_t para
 	size_t maxlen;
 	char *result = get_result_buffer(param, param_size, &maxlen);
 	int srcu_idx;
-
-	md = find_device(param);
-	if (!md)
-		return -ENXIO;
 
 	if (tmsg < (struct dm_target_msg *) param->data ||
 	    invalid_str(tmsg->message, (void *) param + param_size)) {
@@ -1792,9 +1812,25 @@ static int target_message(struct file *filp, struct dm_ioctl *param, size_t para
 		goto out_argv;
 	}
 
+	if (!strcmp(param->name, ".")) {
+		if (argc == 1) {
+			DMERR("Empty message received.");
+			r = -EINVAL;
+			goto out_argv;
+		}
+		r = message_for_module(argv[0], argc - 1, argv + 1, result, maxlen);
+		goto out_deviceless;
+	}
+
+	md = find_device(param);
+	if (!md) {
+		r = -ENXIO;
+		goto out_argv;
+	}
+
 	r = message_for_md(md, argc, argv, result, maxlen);
 	if (r <= 1)
-		goto out_argv;
+		goto out_md;
 
 	table = dm_get_live_table(md, &srcu_idx);
 	if (!table)
@@ -1816,14 +1852,13 @@ static int target_message(struct file *filp, struct dm_ioctl *param, size_t para
 		r = -EINVAL;
 	}
 
- out_table:
+out_table:
 	dm_put_live_table(md, srcu_idx);
- out_argv:
-	kfree(argv);
- out:
+out_md:
 	if (r >= 0)
 		__dev_status(md, param);
-
+	dm_put(md);
+out_deviceless:
 	if (r == 1) {
 		param->flags |= DM_DATA_OUT_FLAG;
 		if (dm_message_test_buffer_overflow(result, maxlen))
@@ -1832,8 +1867,9 @@ static int target_message(struct file *filp, struct dm_ioctl *param, size_t para
 			param->data_size = param->data_start + strlen(result) + 1;
 		r = 0;
 	}
-
-	dm_put(md);
+out_argv:
+	kfree(argv);
+out:
 	return r;
 }
 

--- a/drivers/md/dm-vdo/dm-vdo-target.c
+++ b/drivers/md/dm-vdo/dm-vdo-target.c
@@ -13,6 +13,7 @@
 #include <linux/module.h>
 #include <linux/mutex.h>
 #include <linux/spinlock.h>
+#include <linux/uuid.h>
 
 #include "admin-state.h"
 #include "block-map.h"
@@ -1211,6 +1212,199 @@ static int vdo_message(struct dm_target *ti, unsigned int argc, char **argv,
 	vdo_unregister_thread_device_id();
 	vdo_unregister_allocating_thread();
 	return result;
+}
+
+/**
+ * parse_capacity_args() - Parse the arguments for a capacity message.
+ * @argc: The number of arguments.
+ * @argv: The arguments (logical_blocks, physical_blocks, slab_blocks, index_memory, index_sparse).
+ * @vdo_config: The vdo config to populate.
+ * @index_config: The index config to populate.
+ *
+ * Return: VDO_SUCCESS or an error code.
+ */
+static int parse_capacity_args(unsigned int argc, char **argv,
+			       struct vdo_config *vdo_config,
+			       struct index_config *index_config)
+{
+	int result;
+	u64 logical_blocks, physical_blocks;
+	block_count_t slab_blocks;
+	uds_memory_config_size_t index_memory;
+	bool index_sparse;
+
+	if (argc != 5) {
+		vdo_log_error("capacity message requires 5 arguments");
+		return VDO_BAD_CONFIGURATION;
+	}
+
+	if (kstrtoull(argv[0], 10, &logical_blocks) ||
+	    kstrtoull(argv[1], 10, &physical_blocks)) {
+		vdo_log_error("invalid logical or physical block count");
+		return VDO_BAD_CONFIGURATION;
+	}
+
+	if (logical_blocks > MAXIMUM_VDO_LOGICAL_BLOCKS) {
+		vdo_log_error("logical block count exceeds the maximum");
+		return VDO_OUT_OF_RANGE;
+	}
+
+	if (physical_blocks > MAXIMUM_VDO_PHYSICAL_BLOCKS) {
+		vdo_log_error("physical block count exceeds the maximum");
+		return VDO_OUT_OF_RANGE;
+	}
+
+	result = parse_slab_size(argv[2], &slab_blocks);
+	if (result != VDO_SUCCESS) {
+		vdo_log_error("invalid slab size");
+		return result;
+	}
+
+	result = parse_memory(argv[3], &index_memory);
+	if (result != VDO_SUCCESS) {
+		vdo_log_error("invalid index memory size");
+		return result;
+	}
+
+	result = parse_bool(argv[4], "on", "off", &index_sparse);
+	if (result != VDO_SUCCESS) {
+		vdo_log_error("invalid index sparse value, expected 'on' or 'off'");
+		return result;
+	}
+
+	*vdo_config = (struct vdo_config) {
+		.logical_blocks        = logical_blocks,
+		.physical_blocks       = physical_blocks,
+		.slab_size             = slab_blocks,
+		.slab_journal_blocks   = DEFAULT_VDO_SLAB_JOURNAL_SIZE,
+		.recovery_journal_size = DEFAULT_VDO_RECOVERY_JOURNAL_SIZE,
+	};
+
+	*index_config = (struct index_config) {
+		.mem = index_memory,
+		.sparse = index_sparse,
+	};
+
+	return VDO_SUCCESS;
+}
+
+static int process_capacity_message(unsigned int argc, char **argv,
+				    char *result_buffer, unsigned int maxlen)
+{
+	int result;
+	struct vdo_config vdo_config;
+	struct index_config index_config;
+	struct volume_geometry *geometry;
+	struct vdo_component_states *states;
+	struct slab_config *slab_config;
+	slab_count_t slab_count;
+	block_count_t data_blocks;
+	block_count_t max_data_blocks;
+	block_count_t writable_blocks;
+	block_count_t max_writable_blocks;
+	uuid_t uuid = {};
+
+	result = parse_capacity_args(argc, argv, &vdo_config, &index_config);
+	if (result != VDO_SUCCESS)
+		return result;
+
+	result = vdo_allocate(1, __func__, &geometry);
+	if (result != VDO_SUCCESS) {
+		vdo_log_error("cannot allocate memory for capacity calculation");
+		return result;
+	}
+
+	result = vdo_initialize_volume_geometry(0, &uuid, &index_config, geometry);
+	if (result != VDO_SUCCESS) {
+		vdo_log_error("cannot initialize geometry for capacity calculation");
+		vdo_free(geometry);
+		return result;
+	}
+
+	result = vdo_allocate(1, __func__, &states);
+	if (result != VDO_SUCCESS) {
+		vdo_log_error("cannot allocate memory for capacity calculation");
+		vdo_free(geometry);
+		return result;
+	}
+
+	result = vdo_initialize_component_states(&vdo_config, geometry,
+						 geometry->nonce, states);
+	if (result == VDO_NO_SPACE) {
+		block_count_t necessary_size = 1 +
+			vdo_get_data_region_start(*geometry) +
+			DEFAULT_VDO_BLOCK_MAP_TREE_ROOT_COUNT +
+			DEFAULT_VDO_RECOVERY_JOURNAL_SIZE +
+			VDO_SLAB_SUMMARY_BLOCKS +
+			vdo_config.slab_size;
+
+		vdo_log_error("Not enough space, minimum %llu blocks required",
+			      (unsigned long long)necessary_size);
+		vdo_free(states);
+		vdo_free(geometry);
+		return result;
+	}
+
+	if (result == VDO_TOO_MANY_SLABS) {
+		vdo_log_error("Reduce the device size or increase the slab size");
+		vdo_free(states);
+		vdo_free(geometry);
+		return result;
+	}
+
+	if (result != VDO_SUCCESS) {
+		vdo_log_error("invalid configuration for capacity calculation");
+		vdo_free(states);
+		vdo_free(geometry);
+		return result;
+	}
+
+	slab_config = &states->slab_depot.slab_config;
+	slab_count = vdo_compute_slab_count(states->slab_depot.first_block,
+					    states->slab_depot.last_block,
+					    ilog2(vdo_config.slab_size));
+
+	data_blocks = (block_count_t)slab_count * slab_config->data_blocks;
+	max_data_blocks = (block_count_t)MAX_VDO_SLABS * slab_config->data_blocks;
+
+	writable_blocks = vdo_compute_writable_blocks(vdo_config.logical_blocks,
+						      data_blocks);
+	max_writable_blocks = vdo_compute_writable_blocks(vdo_config.logical_blocks,
+							  max_data_blocks);
+
+	snprintf(result_buffer, maxlen,
+		 "{ version : 1, "
+		 "slab_count : %u, max_slab_count : %u "
+		 "writable_blocks : %llu, max_writable_blocks : %llu }",
+		 slab_count, MAX_VDO_SLABS,
+		 (unsigned long long)writable_blocks,
+		 (unsigned long long)max_writable_blocks);
+	vdo_uninitialize_layout(&states->layout);
+	vdo_free(states);
+	vdo_free(geometry);
+	return VDO_SUCCESS;
+}
+
+static int vdo_deviceless_message(unsigned int argc, char **argv,
+				  char *result_buffer, unsigned int maxlen)
+{
+	int result;
+
+	if (argc == 0) {
+		vdo_log_error("unspecified deviceless message");
+		return -EINVAL;
+	}
+
+	if (strcasecmp(argv[0], "capacity") != 0) {
+		vdo_log_error("unknown deviceless message '%s'", argv[0]);
+		return -EINVAL;
+	}
+
+	result = process_capacity_message(argc - 1, argv + 1, result_buffer, maxlen);
+	if (result != VDO_SUCCESS)
+		return -EINVAL;
+
+	return 1;
 }
 
 static void configure_target_capabilities(struct dm_target *ti)
@@ -2983,7 +3177,7 @@ static void vdo_resume(struct dm_target *ti)
 static struct target_type vdo_target_bio = {
 	.features = DM_TARGET_SINGLETON,
 	.name = "vdo",
-	.version = { 9, 2, 0 },
+	.version = { 9, 3, 0 },
 	.module = THIS_MODULE,
 	.ctr = vdo_ctr,
 	.dtr = vdo_dtr,
@@ -2991,6 +3185,7 @@ static struct target_type vdo_target_bio = {
 	.iterate_devices = vdo_iterate_devices,
 	.map = vdo_map_bio,
 	.message = vdo_message,
+	.deviceless_message = vdo_deviceless_message,
 	.status = vdo_status,
 	.presuspend = vdo_presuspend,
 	.postsuspend = vdo_postsuspend,

--- a/drivers/md/dm-vdo/encodings.c
+++ b/drivers/md/dm-vdo/encodings.c
@@ -516,6 +516,45 @@ block_count_t vdo_compute_new_forest_pages(root_count_t root_count,
 }
 
 /**
+ * vdo_compute_writable_blocks() - Compute writable blocks for a VDO volume.
+ * @logical_blocks: The number of logical blocks to address.
+ * @data_blocks: The number of physical blocks available.
+ *
+ * Computes the number of data blocks we can actually write to after accounting for
+ * block map overhead needed to address the specified number of logical blocks. If
+ * logical_blocks is 0, use data_blocks as the logical space.
+ *
+ * Return: The number of writable blocks.
+ */
+block_count_t vdo_compute_writable_blocks(block_count_t logical_blocks,
+					  block_count_t data_blocks)
+{
+	block_count_t approximate_non_leaves;
+	page_count_t approximate_leaves;
+	struct boundary new_sizes;
+
+	if (logical_blocks == 0)
+		logical_blocks = data_blocks;
+
+	approximate_non_leaves =
+		vdo_compute_new_forest_pages(DEFAULT_VDO_BLOCK_MAP_TREE_ROOT_COUNT,
+					     NULL, logical_blocks, &new_sizes);
+
+	/*
+	 * Exclude the tree roots since those aren't allocated from slabs,
+	 * and also exclude the super-roots, which only exist in memory.
+	 */
+	approximate_non_leaves -=
+		DEFAULT_VDO_BLOCK_MAP_TREE_ROOT_COUNT *
+		(new_sizes.levels[VDO_BLOCK_MAP_TREE_HEIGHT - 2] +
+		 new_sizes.levels[VDO_BLOCK_MAP_TREE_HEIGHT - 1]);
+
+	approximate_leaves = vdo_compute_block_map_page_count(logical_blocks);
+
+	return data_blocks - (approximate_non_leaves + approximate_leaves);
+}
+
+/**
  * encode_recovery_journal_state_7_0() - Encode the state of a recovery journal.
  * @buffer: A buffer to store the encoding.
  * @offset: The offset in the buffer at which to encode.

--- a/drivers/md/dm-vdo/encodings.h
+++ b/drivers/md/dm-vdo/encodings.h
@@ -881,6 +881,9 @@ block_count_t __must_check vdo_compute_new_forest_pages(root_count_t root_count,
 							block_count_t entries,
 							struct boundary *new_sizes);
 
+block_count_t vdo_compute_writable_blocks(block_count_t logical_blocks,
+					  block_count_t data_blocks);
+
 /**
  * vdo_pack_recovery_journal_entry() - Return the packed, on-disk representation of a recovery
  *                                     journal entry.

--- a/include/linux/device-mapper.h
+++ b/include/linux/device-mapper.h
@@ -93,6 +93,9 @@ typedef void (*dm_status_fn) (struct dm_target *ti, status_type_t status_type,
 typedef int (*dm_message_fn) (struct dm_target *ti, unsigned int argc, char **argv,
 			      char *result, unsigned int maxlen);
 
+typedef int (*dm_deviceless_message_fn) (unsigned int argc, char **argv,
+			      char *result, unsigned int maxlen);
+
 /*
  * Called with *forward == true. If it remains true, the ioctl should be
  * forwarded to bdev. If it is reset to false, the target already fully handled
@@ -214,6 +217,7 @@ struct target_type {
 	dm_resume_fn resume;
 	dm_status_fn status;
 	dm_message_fn message;
+	dm_deviceless_message_fn deviceless_message;
 	dm_prepare_ioctl_fn prepare_ioctl;
 	dm_report_zones_fn report_zones;
 	dm_busy_fn busy;


### PR DESCRIPTION
Add a deviceless message handler to the VDO target that allows querying VDO capacity information without an active device instance. The "capacity" message accepts logical blocks, physical blocks, slab size, index memory, and index sparse parameters, simulates VDO initialization, and returns a structured response with logical blocks, data blocks, max data blocks, slab count, and max slab count.

Also adds vdo_compute_logical_blocks() to correctly compute the default logical size by subtracting block map forest overhead from available data blocks.

Bumps VDO target version to 9.3.0.