### PR TITLE
ci: fix workflow inputs for reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,11 @@ jobs:
   Run-Common-CI:
     uses: dm-vdo/vdo-org-actions/.github/workflows/ci.yaml@main
     with:
-      run-public: false
-      run-private: true
+      logfile: logs-${{ github.event.repository.owner.login }}-${{ github.event.repository.name }}-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+      run-public-build: false
+      run-public-tests: false
+      run-private-build: true
+      run-private-tests: true
       private-build-action: |
         git clone https://github.com/${{ github.event.repository.owner.login }}/vdo-devel.git
       private-tests-action: |


### PR DESCRIPTION
The reusable workflow now requires separate run-public-build and run-public-tests boolean inputs instead of a single run-public input. Update to provide both required inputs set to false.