### PR TITLE
ci: move vdo-devel clone from build to test stage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,10 @@ jobs:
       logfile: logs-${{ github.event.repository.owner.login }}-${{ github.event.repository.name }}-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
       run-public-build: false
       run-public-tests: false
-      run-private-build: true
+      run-private-build: false
       run-private-tests: true
-      private-build-action: |
-        git clone https://github.com/${{ github.event.repository.owner.login }}/vdo-devel.git
       private-tests-action: |
+        git clone https://github.com/${{ github.event.repository.owner.login }}/vdo-devel.git
         cd vdo-devel/src
         make DMLINUX_SOURCE_DIR=${{ github.workspace }} dmlinux-jenkins
       private-tests-action-failure: |


### PR DESCRIPTION
Build and test stages run on different runners, so artifacts from build stage are not available in test stage. Move the git clone of vdo-devel into the test stage where it's actually used, and disable the build stage since it's no longer needed.