### PR TITLE
ci: add DM subsystem build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,11 @@ jobs:
       logfile: logs-${{ github.event.repository.owner.login }}-${{ github.event.repository.name }}-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
       run-public-build: false
       run-public-tests: false
-      run-private-build: false
+      run-private-build: true
       run-private-tests: true
+      private-build-action: |
+        cd ${{ github.workspace }}
+        make drivers/md/
       private-tests-action: |
         git clone https://github.com/${{ github.event.repository.owner.login }}/vdo-devel.git
         cd vdo-devel/src


### PR DESCRIPTION
Add a private build action that compiles the drivers/md/ directory to verify that DM core and dm-vdo changes compile correctly against dm-linux headers.

This provides a fast compilation check that catches build errors early, particularly for PRs that modify DM core files.

The build step runs before the vdo-devel test stage and does not affect the existing SRPM-based test workflow.