### PR TITLE
ci: add kernel configuration before DM build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,9 @@ jobs:
       run-public-tests: false
       run-private-build: true
       run-private-tests: true
-      private-build-action: make drivers/md/
+      private-build-action: |
+        make defconfig
+        yes "" | make drivers/md/
       private-tests-action: |
         git clone https://github.com/${{ github.event.repository.owner.login }}/vdo-devel.git
         cd vdo-devel/src


### PR DESCRIPTION
Add kernel configuration steps before building drivers/md/:

Without these config steps, make drivers/md/ fails because the kernel tree lacks a .config file.