### PR TITLE
ci: fix workspace directory evaluation in test stage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,10 @@ jobs:
         make defconfig
         yes "" | make drivers/md/
       private-tests-action: |
+        WORKSPACE=$(pwd)
         git clone https://github.com/${{ github.event.repository.owner.login }}/vdo-devel.git
         cd vdo-devel/src
-        make DMLINUX_SOURCE_DIR=${{ github.workspace }} dmlinux-jenkins
+        make DMLINUX_SOURCE_DIR=$WORKSPACE dmlinux-jenkins
       private-tests-action-failure: |
         REPO=${{ github.repository }}
         REPO=${REPO//\//-}


### PR DESCRIPTION
Replace ${{ github.workspace }} with $(pwd) in private-tests-action. The github.workspace context variable is evaluated when calling the reusable workflow and is empty at that point. Using $(pwd) ensures the current directory is captured when the script actually executes.